### PR TITLE
Fix wrapping env vars

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,3 @@ module(
     version = "0.0.1",
     compatibility_level = 1,
 )
-
-bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
-

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ This script loads the ORFS environment, sets the 'BAZEL_ORFS` environment variab
 
 ### openroad.bzl
 
-This file contains simple helper functions written in starlark as well as macro `build_openroad()`. The implementation of this macro spawns multiple `run_binary()` rules which are responsible for running ORFS `make` targets during bazel build stage. Each `run_binary()` does the same
+This file contains simple helper functions written in starlark as well as macro `build_openroad()`. The implementation of this macro spawns multiple `genrule` native rules which are responsible for running ORFS `make` targets during bazel build stage. Each `genrule()` does the same
 thing: it sets env vars and runs one of make targets defined in *.mk files which then run make target from ORFS flow Makefile.
 
-There are 4 kinds of run_binary() spawned in this macro:
+There are 4 kinds of genrules spawned in this macro:
 
 * Stage targets (named: `target_name + “_” + stage`)
 * Local Runner targets (named: `target_name + “_” + stage + “_local_runner”`)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,14 +1,1 @@
 workspace(name = "bazel-orfs")
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
-    strip_prefix = "bazel-lib-1.32.1",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
-)
-
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
-
-aspect_bazel_lib_dependencies()

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -31,7 +31,18 @@ def filter(iterable, func):
     return result
 
 def wrap_args(args):
-    return map(lambda arg: '"' + arg + '"' if (' ' in arg or '\\$$' in arg or '=(' in arg) else arg, args)
+    wrapped_args = []
+
+    for arg in args:
+        splt = arg.split("=", 1)
+        if (len(splt) == 2):
+            if (" " in splt[1] and "DESIGN_CONFIG" != splt[0]):
+                wrapped_args.append(splt[0] + "='" + splt[1] + "'")
+            else:
+                wrapped_args.append(arg)
+        else:
+            wrapped_args.append(arg)
+    return wrapped_args
 
 def build_openroad(
     name,

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -228,7 +228,7 @@ def build_openroad(
 	    ] +
 	    stage_sources[stage] +
             [("//:" + target_name + "_" + previous_stage)] if stage not in ('clock_period', 'synth_sdc', 'synth') else [],
-	    cmd = "echo `cat $(location " + str(Label("//:local_runner.template.sh")) + ")` " + " ".join(stage_args.get(stage, [])) + " \\\"$$\\@\\\" > $@",
+	    cmd = "echo `cat $(location " + str(Label("//:local_runner.template.sh")) + ")` " + " ".join(wrap_args(stage_args.get(stage, []))) + " \\\"$$\\@\\\" > $@",
             outs = ["logs/" + platform + "/%s/%s/local_runner_script_%s.sh" %(output_folder_name, variant, stage)],
         ) for ((_, previous_stage), (i, stage)) in zip([(0, 'n/a')] + enumerate(stages), enumerate(stages))]
     [
@@ -248,18 +248,19 @@ def build_openroad(
                 srcs = stage_sources[stage] + ([name + target_ext + "_" + stage, Label('mock_area.tcl')] if stage == 'floorplan' else []) +
                 ([name + target_ext + "_" + previous + "_mock_area"] if stage != 'clock_period' else []) +
                 ([name + target_ext + "_synth_mock_area"] if stage == 'floorplan' else []),
-                cmd = "$(location " + str(Label("//:orfs")) + ") " + ' '.join([s for s in stage_args[stage] if not any([sub in s for sub in ('DIE_AREA', 'CORE_AREA', 'CORE_UTILIZATION')])]) +
+                cmd = "$(location " + str(Label("//:orfs")) + ") " +
+		' '.join(wrap_args([s for s in stage_args[stage] if not any([sub in s for sub in ('DIE_AREA', 'CORE_AREA', 'CORE_UTILIZATION')])])) +
 		' ' +
-                ' '.join([
+                ' '.join(wrap_args([
                     "FLOW_VARIANT=mock_area",
                     "bazel-" + stage + ("-mock_area" if stage == 'floorplan' else "")
-                ]) +
+                ])) +
 		' ' +
-                ' '.join({
+                ' '.join(wrap_args({
                     'floorplan': ["MOCK_AREA=" + str(mock_area), "MOCK_AREA_TCL=$(location " + str(Label('mock_area.tcl')) + ")"],
                     'synth': ["SYNTH_GUT=1"],
                     'generate_abstract': ["ABSTRACT_SOURCE=2_floorplan"]
-                    }.get(stage, [])),
+                    }.get(stage, []))),
                 outs = [s.replace("/" + variant + "/", "/mock_area/") for s in outs.get(stage, [])]
                 )
         for (previous, stage) in zip(['n/a'] + mock_stages, mock_stages)]
@@ -268,7 +269,7 @@ def build_openroad(
             name = target_name + "_memory",
             tools = [Label("//:orfs")],
             srcs = stage_sources['synth'] + [name + "_clock_period"],
-            cmd = "$(location " + str(Label("//:orfs")) + ") " + ' '.join(stage_args['synth']) + ' memory',
+            cmd = "$(location " + str(Label("//:orfs")) + ") " + ' '.join(wrap_args(stage_args['synth'])) + ' memory',
             outs = outs['memory']
             )
 
@@ -277,6 +278,6 @@ def build_openroad(
         tools = [Label("//:orfs")],
         srcs = stage_sources[stage] + ([name + target_ext + "_" + previous] if stage not in ('clock_period', 'synth_sdc', 'synth') else []) +
         ([name + target_ext + "_generate_abstract_mock_area"] if mock_area != None and stage == "generate_abstract" else []),
-        cmd = "$(location " + str(Label("//:orfs")) + ") " + ' '.join(stage_args[stage]) + " bazel-" + stage + ("_mock_area" if mock_area != None and stage == "generate_abstract" else "") + " elapsed",
+        cmd = "$(location " + str(Label("//:orfs")) + ") " + ' '.join(wrap_args(stage_args[stage])) + " bazel-" + stage + ("_mock_area" if mock_area != None and stage == "generate_abstract" else "") + " elapsed",
         outs = outs.get(stage, []),
     ) for ((_, previous), (i, stage)) in zip([(0, 'n/a')] + enumerate(stages), enumerate(stages))]


### PR DESCRIPTION
This PR fixes issues with escaping environment variables with spaces, e.g. `"DIE_AREA=0 0 400 400"`.

The most important change here is the transition from the usage of `run_binary()` rule from [Aspect Bazel Lib](https://github.com/aspect-build/bazel-lib) to simple native [genrules](https://bazel.build/reference/be/general#genrule). This change was required because of a bug in the implementation of `run_binary()` rule in `Aspect Bazel Lib` (see https://github.com/aspect-build/bazel-lib/issues/666). The implementation from [Bazel Skylib](https://github.com/bazelbuild/bazel-skylib) is also prone to this bug and additionally has problems with expanding `RULEDIR` built-in make variable (see https://github.com/bazelbuild/bazel-skylib/issues/438).
Additionally, a slightly modified version of `wrap_args()` helper function which wraps contents of env vars with spaces into single quotes was also reintroduced to the codebase. 

CC @oharboe 