### PR TITLE
_make targets: do not depend on previous stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,11 @@ Two targets are spawned for each ORFS stage. First generates a shell script, sec
 bazel-bin/<target_name>_make
 ```
 
-The shell script is produced by `genrule` by concatenating template script `make_script.template.sh` with `make` and environment variables specific for given stage. Template file contains boilerplate code for enabling features of [bazel bash runfiles library](https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash) and a call to `orfs` script. The runfiles library is used for accessing script dependencies stored in `runfiles` driectory. Attribute `srcs` of the genrule contains dependencies required for running the script (e.g.: `orfs` script, make target patterns, TCL scripts, results of previous flow stages).
+The shell script is produced by `genrule` by concatenating template script `make_script.template.sh` with `make` and environment variables specific for given stage. Template file contains boilerplate code for enabling features of [bazel bash runfiles library](https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash) and a call to `orfs` script. The runfiles library is used for accessing script dependencies stored in `runfiles` driectory. Attribute `srcs` of the genrule contains dependencies required for running the script (e.g.: `orfs` script, make target patterns, TCL scripts). Those dependencies don't include results of previous flow stages and because of that, it is required to build those before running the generated script.
 In the second rule (`sh_binary`) the `runfiles` directory for the script is created and filled with dependencies so that the script can be executed straight from the output directory. It is important to remember that, by default, bazel output directory is not writeable so running the ORFS flow with generated script will fail unless correct permissions are set for the directory. Example usage of `Make` targets can look like this:
 
 ```
+bazel build $(bazel query "deps(L1MetadataArray_test_floorplan)")
 bazel build L1MetadataArray_test_floorplan_make
 cd bazel-bin && chmod -R +w . && cd ..
 ./bazel-bin/L1MetadataArray_test_floorplan_make do-floorplan

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -267,18 +267,20 @@ def build_openroad(
                                 stage_sources.get(stage, []))
         stage_args[stage] = ["make"] + base_args + stage_args.get(stage, [])
 
-    [native.genrule(
-        name = target_name + "_" + stage + "_make_script",
-        tools = [],
-        srcs = [
-                   Label("//:orfs-bazel.mk"),
-                   Label("//:make_script.template.sh"),
-               ] +
-               stage_sources[stage] +
-               [("//:" + target_name + "_" + previous_stage)] if stage not in ("clock_period", "synth_sdc", "synth") else [],
-        cmd = "echo `cat $(location " + str(Label("//:make_script.template.sh")) + ")` " + " ".join(wrap_args(stage_args.get(stage, []))) + " \\\"$$\\@\\\" > $@",
-        outs = ["logs/" + platform + "/%s/%s/make_script_%s.sh" % (output_folder_name, variant, stage)],
-    ) for ((_, previous_stage), (i, stage)) in zip([(0, "n/a")] + enumerate(stages), enumerate(stages))]
+    [
+        native.genrule(
+            name = target_name + "_" + stage + "_make_script",
+            tools = [],
+            srcs = [
+                       Label("//:orfs-bazel.mk"),
+                       Label("//:make_script.template.sh"),
+                   ] +
+                   stage_sources[stage],
+            cmd = "echo `cat $(location " + str(Label("//:make_script.template.sh")) + ")` " + " ".join(wrap_args(stage_args.get(stage, []))) + " \\\"$$\\@\\\" > $@",
+            outs = ["logs/" + platform + "/%s/%s/make_script_%s.sh" % (output_folder_name, variant, stage)],
+        )
+        for stage in stages
+    ]
     [
         native.sh_binary(
             name = target_name + "_" + stage + "_make",


### PR DESCRIPTION
We don't want to depend on the previous stages because that forces rebuilds that are potentially unnecessary. It should be possible to use old artifact, generate the script and continue the flow with it.

CC @oharboe 