### PR TITLE
Break dependency chain for _make script generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The shell script is produced by `genrule` by concatenating template script `make
 In the second rule (`sh_binary`) the `runfiles` directory for the script is created and filled with dependencies so that the script can be executed straight from the output directory. It is important to remember that, by default, bazel output directory is not writeable so running the ORFS flow with generated script will fail unless correct permissions are set for the directory. Example usage of `Make` targets can look like this:
 
 ```
-bazel build $(bazel query "deps(L1MetadataArray_test_floorplan)")
+bazel build $(bazel query "deps(L1MetadataArray_test_floorplan) except L1MetadataArray_test_floorplan")
 bazel build L1MetadataArray_test_floorplan_make
 cd bazel-bin && chmod -R +w . && cd ..
 ./bazel-bin/L1MetadataArray_test_floorplan_make do-floorplan

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -275,7 +275,7 @@ def build_openroad(
                        Label("//:orfs-bazel.mk"),
                        Label("//:make_script.template.sh"),
                    ] +
-                   stage_sources[stage],
+                   all_sources,
             cmd = "echo `cat $(location " + str(Label("//:make_script.template.sh")) + ")` " + " ".join(wrap_args(stage_args.get(stage, []))) + " \\\"$$\\@\\\" > $@",
             outs = ["logs/" + platform + "/%s/%s/make_script_%s.sh" % (output_folder_name, variant, stage)],
         )


### PR DESCRIPTION
This PR is a continuation of https://github.com/The-OpenROAD-Project/bazel-orfs/pull/5.
It breaks the dependency chain for `_make` script targets. We don't want to build all dependencies required for **running** the script. It is only required to build dependencies for **building** the script itself. It is up to the user to provide all the requirements for running the script.
Building dependencies for running `_make` script should be done separately with e.g.:
```
bazel build $(bazel query "deps(stage_target) except <stage_target>")
```

CC @oharboe, @nekronos