### PR TITLE
Include chmod in _make scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ In the second rule (`sh_binary`) the `runfiles` directory for the script is crea
 ```
 bazel build $(bazel query "deps(L1MetadataArray_test_floorplan) except L1MetadataArray_test_floorplan")
 bazel build L1MetadataArray_test_floorplan_make
-cd bazel-bin && chmod -R +w . && cd ..
 ./bazel-bin/L1MetadataArray_test_floorplan_make do-floorplan
 ```
 

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -276,7 +276,7 @@ def build_openroad(
                        Label("//:make_script.template.sh"),
                    ] +
                    all_sources,
-            cmd = "echo `cat $(location " + str(Label("//:make_script.template.sh")) + ")` " + " ".join(wrap_args(stage_args.get(stage, []))) + " \\\"$$\\@\\\" > $@",
+            cmd = "echo \"chmod -R +w . && \" `cat $(location " + str(Label("//:make_script.template.sh")) + ")` " + " ".join(wrap_args(stage_args.get(stage, []))) + " \\\"$$\\@\\\" > $@",
             outs = ["logs/" + platform + "/%s/%s/make_script_%s.sh" % (output_folder_name, variant, stage)],
         )
         for stage in stages


### PR DESCRIPTION
This PR modifies `_make` genrules so that generated shell script will set write permissions in cwd (which is expected to be `bazel-bin`). This allows removing additional manual step o changing permissions between generating the script and running it.