### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: bazel-orfs build tests
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  build-stage-target:
+    name: Build sample stage targets
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/antmicro/bazel-orfs@sha256:78b4c15830d75e026dc2294b280cb5ff1200f6ee7902a714dca71fd61b5b2e4e
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        STAGE_TARGET: ["tag_array_64x184_generate_abstract", "L1MetadataArray_test_generate_abstract"]
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+    steps:
+      # Workaround for https://github.com/actions/runner/issues/863
+      - name: Override HOME env var
+        shell: bash
+        run: |
+          echo HOME=/root | sudo tee -a $GITHUB_ENV
+      - name: Print info
+        run: |
+          echo "USER: "$(whoami)
+          echo "PWD: "$(pwd)
+          ls -la
+          echo "HOME: "$HOME
+          cd ~/OpenROAD-flow-scripts
+          echo "OpenROAD-flow-scripts SHA: "$(git rev-parse HEAD)
+          source ./env.sh
+          yosys --version
+          openroad -version
+      - name: Checkout bazel-orfs
+        uses: actions/checkout@v4
+      - name: query target
+        run: |
+          bazel query ${{ matrix.STAGE_TARGET }}
+          bazel query ${{ matrix.STAGE_TARGET }} --output=build
+      - name: build target
+        run: |
+          bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+
+  test-make-script-target:
+    name: Execute sample _make scripts
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/antmicro/bazel-orfs@sha256:78b4c15830d75e026dc2294b280cb5ff1200f6ee7902a714dca71fd61b5b2e4e
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        CONFIG: [ { stage_target: "L1MetadataArray_test_floorplan", orfs_make_target: "do-floorplan" }, { stage_target: "L1MetadataArray_test_cts", orfs_make_target: "do-cts" } ]
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+    steps:
+      # Workaround for https://github.com/actions/runner/issues/863
+      - name: Override HOME env var
+        shell: bash
+        run: |
+          echo HOME=/root | sudo tee -a $GITHUB_ENV
+      - name: Print info
+        run: |
+          echo "USER: "$(whoami)
+          echo "PWD: "$(pwd)
+          ls -la
+          echo "HOME: "$HOME
+          cd ~/OpenROAD-flow-scripts
+          echo "OpenROAD-flow-scripts SHA: "$(git rev-parse HEAD)
+          source ./env.sh
+          yosys --version
+          openroad -version
+      - name: Checkout bazel-orfs
+        uses: actions/checkout@v4
+      - name: query stage target
+        run: |
+          bazel query ${{ matrix.CONFIG.stage_target }}
+          bazel query ${{ matrix.CONFIG.stage_target }} --output=build
+      - name: query make script target
+        run: |
+          bazel query ${{ matrix.CONFIG.stage_target }}_make
+          bazel query ${{ matrix.CONFIG.stage_target }}_make --output=build
+      - name: build make script
+        run: |
+          bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.CONFIG.stage_target }}_make
+      - name: build stage target dependencies
+        run: |
+          bazel build $(bazel query "deps(${{ matrix.CONFIG.stage_target }}) except ${{ matrix.CONFIG.stage_target }}")
+      - name: run make script
+        run: |
+          ./bazel-bin/${{ matrix.CONFIG.stage_target }}_make ${{ matrix.CONFIG.orfs_make_target }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -1,0 +1,27 @@
+name: docker update
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/The-OpenROAD-Project/bazel-orfs
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build docker image
+        run: |
+          docker build -t "${{ env.IMAGE }}" .
+
+      - name: Login to GitHub Container Registry (GHCR)
+        if: github.event_name != 'pull_request' && github.repository == 'The-OpenROAD-Project/bazel-orfs'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: gha
+          password: ${{ github.token }}
+
+      - name: Push container image to GitHub Container Registry (GHCR)
+        if: github.event_name != 'pull_request' && github.repository == 'The-OpenROAD-Project/bazel-orfs'
+        run: docker push $IMAGE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:22.04
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+ARG USERNAME=root
+ARG USER_HOME=/root
+ARG ORFS_REF=067099e79f308b77cb7f031f37d2f9ca2ac25b7b
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y sudo git vim wget python-is-python3 && \
+    # Setup ORFS under ~
+    mkdir -p $USER_HOME && \
+    cd $USER_HOME && \
+    git clone --recursive https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts && \
+    cd $USER_HOME/OpenROAD-flow-scripts && \
+    git checkout $ORFS_REF && \
+    export SUDO_USER=$USERNAME && \
+    sudo ./setup.sh && \
+    ./build_openroad.sh --local && \
+    # test ORFS build
+    source ./env.sh && yosys -help && openroad -help && cd flow && make -j $(nproc) && \
+    # Install bazelisk as bazel
+    sudo wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel && \
+    sudo chmod +x /usr/local/bin/bazel
+
+WORKDIR $USER_HOME


### PR DESCRIPTION
This PR adds CI setup for this repository. It consists of 2 workflows:
* `docker update`
  * Is triggered manually
  * Builds docker image with environment required for running `bazel-orfs` tests and pushes the image to repository container registry.
  * The image contains prebuilt [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD) and [yosys](https://github.com/YosysHQ/yosys) together with [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) installed in location expected by `bazel-orfs`. 
* `bazel-orfs build tests`
  * uses docker image built in the workflow above
  * currently references docker image from fork repository container registry (built by: https://github.com/antmicro/bazel-orfs/actions/runs/8016819208)
  * This workflow defines two matrix jobs
     * `Build sample stage targets` which builds regular `stage` targets
     * `Execute sample _make scripts` which first generates the `make` script from `_make` targets, then builds dependencies for running this script and finally runs the script.
   * Correctness of the workflow was verified in the following run: https://github.com/antmicro/bazel-orfs/actions/runs/8019655148 
     
After merging this PR the following actions should be carried out:

- [ ] Launch `docker update` manual workflow
- [ ] Upon successful finish of the workflow, open follow-up PR which changes the container image used in this CI to the one from upstream repository container registry.