### PR TITLE
Make path to ORFS configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build sample stage targets
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/antmicro/bazel-orfs@sha256:78b4c15830d75e026dc2294b280cb5ff1200f6ee7902a714dca71fd61b5b2e4e
+      image: ghcr.io/antmicro/bazel-orfs@sha256:555bd997a785b15a694687739a027b74ac4c3bdaee3bed1fb631ed48241c1b6f
     defaults:
       run:
         shell: bash
@@ -51,7 +51,7 @@ jobs:
     name: Execute sample _make scripts
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/antmicro/bazel-orfs@sha256:78b4c15830d75e026dc2294b280cb5ff1200f6ee7902a714dca71fd61b5b2e4e
+      image: ghcr.io/antmicro/bazel-orfs@sha256:555bd997a785b15a694687739a027b74ac4c3bdaee3bed1fb631ed48241c1b6f
     defaults:
       run:
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update -y && \
     mkdir -p $USER_HOME && \
     cd $USER_HOME && \
     git clone --recursive https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts && \
+    echo "export ORFS=$USER_HOME/OpenROAD-flow-scripts" > $USER_HOME/orfs_path.sh && \
     cd $USER_HOME/OpenROAD-flow-scripts && \
     git checkout $ORFS_REF && \
     export SUDO_USER=$USERNAME && \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@ This repository contains [Bazel](https://bazel.build/) rules for wrapping Physic
 
 ## Requirements
 
-* [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) - must reside under `~/OpenROAD-flow-scripts`. `bazel-orfs` intentionally does not treat OpenROAD-flow-scripts as a installable versioned tool, but prefers to rely on `~/OpenROAD-flow-scripts` such that it is easy to hack ORFS and OpenROAD.
+* [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) - fully autonomous, RTL-GDSII flow for rapid architecture and design space exploration, early prediction of QoR and detailed physical design implementation. Please refer to Local Build [instructions](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/docs/user/BuildLocally.md) for installing ORFS.
+* `~/orfs_path.sh` - script that must export environment variable `ORFS` with path to `OpenROAD-flow-scripts`. `bazel-orfs` intentionally does not treat OpenROAD-flow-scripts as an installable versioned tool, but prefers to rely on `~/orfs_path.sh` script so that it is easy to hack ORFS and OpenROAD. **WARNING: OpenROAD-flow-scripts is not registered by this build system. Any change to OpenROAD, yosys or OpenROAD-flow-scripts WILL NOT invalidate previously built artifacts**.
 * [Bazelisk](https://bazel.build/install/bazelisk) or [Bazel](https://bazel.build/install) - if using `bazel`, please refer to `.bazelversion` file for the recommended version of the tool.
 
 ## Usage
 
-Core functionality is implemented as `build_openroad()` bazel macro in `openroad.bzl` file.
+Assuming `OpenROAD-flow-scripts` is located in the home directory, the contents of `~/orfs_path.sh` should look like this:
+
+```
+export ORFS=~/OpenROAD-flow-scripts
+```
+
+The core functionality is implemented as `build_openroad()` bazel macro in `openroad.bzl` file.
 
 In order to use `build_openroad()` macro in Bazel Workspace in other project it is required to pull `bazel-orfs` as external dependency through one of [Bazel Workspace Rules](https://bazel.build/reference/be/workspace). For example in project's WORKSPACE:
 

--- a/orfs
+++ b/orfs
@@ -2,7 +2,7 @@
 set -ex
 ORFS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-export ORFS=~/OpenROAD-flow-scripts
+source ~/orfs_path.sh
 export FLOW_HOME=$ORFS/flow
 export MAKEFILES=$FLOW_HOME/Makefile
 


### PR DESCRIPTION
This PR moves the task of specifying path to ORFS outside of this repository and build systems that are used here.
It hardcodes an implicit dependency on `orfs_path.sh` script which is expected to be placed in the home directory. The script must contain a definition of `ORFS` environment variable with a path to local installation of `OpenROAD-flow-script`.

This modification breaks bazel's [hermeticity](https://bazel.build/basics/hermeticity) in order to allow changing the path to local ORFS installation without the need of rebuilding expensive targets.

Additionally, it is important to remember that changing version of ORFS, OpenROAD, yosys, etc., as well as any manual modification to the build system, TCL scripts, environment variables configuration and tools source code in the scope of ORFS repository **will not** cause invalidation of previous builds. It is the user's responsibility to rebuild artifacts when necessary to keep the integrity of the build after modifications made to local OpenROAD-flow-scripts setup.