### PR TITLE
Stop using entrypoint attribute

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,6 @@ exports_files(["make_script.template.sh"])
 
 build_openroad(
     name = "tag_array_64x184",
-    entrypoint = "//:entrypoint.mk",
     io_constraints = "io-sram.tcl",
     mock_abstract = True,
     mock_area = 0.20,
@@ -38,7 +37,6 @@ build_openroad(
 
 build_openroad(
     name = "L1MetadataArray",
-    entrypoint = "//:entrypoint.mk",
     io_constraints = "io.tcl",
     macros = ["tag_array_64x184"],
     mock_abstract = True,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The macro can now be placed in the BUILD file. The macro usage can look like thi
 ```
 build_openroad(
     name = "L1MetadataArray",
-    entrypoint = "//:entrypoint.mk",
     verilog_files=["test/rtl/L1MetadataArray.sv"],
     variant="test",
     macros=["tag_array_64x184"],
@@ -56,12 +55,6 @@ build_openroad(
     mock_abstract=True,
     mock_stage="grt"
 )
-```
-
-It is important to provide an `entrypoint` argument which contains a path to Makefile located inside the repository which loads `bazel-orfs`. This Makefile should include `config.mk` from `bazel-orfs`. This can be done with the help of `BAZEL_ORFS` environment variable:
-
-```
-include $(BAZEL_ORFS)/config.mk
 ```
 
 Macro from the example above spawns the following bazel targets:
@@ -105,7 +98,7 @@ The example comes from the `BUILD` file in this repository. For details about ta
 
 ### orfs script
 
-This script loads the ORFS environment, sets the 'BAZEL_ORFS` environment variable and evaluates the rest of the command line that called the script.
+This script loads the ORFS environment and evaluates the rest of the command line that called the script.
 
 ### openroad.bzl
 

--- a/config.mk
+++ b/config.mk
@@ -4,13 +4,6 @@ export PLATFORM=asap7
 
 export WORK_HOME_READ?=$(WORK_HOME)
 
--include $(BAZEL_ORFS)/clock_period-bazel.mk
--include $(BAZEL_ORFS)/synth-bazel.mk
--include $(BAZEL_ORFS)/synth_sdc-bazel.mk
--include $(BAZEL_ORFS)/floorplan-bazel.mk
--include $(BAZEL_ORFS)/place-bazel.mk
--include $(BAZEL_ORFS)/cts-bazel.mk
--include $(BAZEL_ORFS)/grt-bazel.mk
--include $(BAZEL_ORFS)/route-bazel.mk
--include $(BAZEL_ORFS)/final-bazel.mk
--include $(BAZEL_ORFS)/generate_abstract-bazel.mk
+# $(MAKE_PATTERN) stores the path to file with make patterns
+# that will be called in the given flow.
+include $(MAKE_PATTERN)

--- a/entrypoint.mk
+++ b/entrypoint.mk
@@ -1,1 +1,0 @@
--include config.mk

--- a/orfs
+++ b/orfs
@@ -8,5 +8,4 @@ export MAKEFILES=$FLOW_HOME/Makefile
 
 source $ORFS/env.sh
 
-export BAZEL_ORFS=$ORFS_DIR
 "$@"


### PR DESCRIPTION
This PR modifies the build rules to not depend on `entrypoint` attribute. It also removes `BAZEL_ORFS` environment variable as it is no longer required. A new environment variable `MAKE_PATTERN` is introduced to keep path to `*.mk` file relevant to given stage of ORFS flow.
It also includes a small cleanup with regards to loops used in the macro definition.

In subsequent PR the `entrypoint` attribute will be removed from the repository entirely. This will be done after https://github.com/The-OpenROAD-Project/megaboom/pull/25 is merged.