### PR TITLE
Remove unused variables and attributes

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -55,7 +55,6 @@ def build_openroad(
         stage_args = {},
         mock_abstract = False,
         mock_stage = "place",
-        orfs_version = 4,
         mock_area = None,
         platform = "asap7",
         macro_variant = "base"):
@@ -142,7 +141,6 @@ def build_openroad(
 
     base_args = [
         "WORK_HOME=$(RULEDIR)",
-        "ORFS_VERSION=" + str(orfs_version),
         "DESIGN_NAME=" + name,
         "FLOW_VARIANT=" + variant,
         "DESIGN_CONFIG=$(location " + str(Label("//:config.mk")) + ")",


### PR DESCRIPTION
This PR removes 3 unused variables or macro attributes from `openroad.bzl`:
* `macro_targets` - unused variable
* `entrypoint` - discontinued in https://github.com/The-OpenROAD-Project/bazel-orfs/pull/11 and https://github.com/The-OpenROAD-Project/megaboom/pull/25
* `orfs_version` - unused attribute which sets `ORFS_VERSION` environment variable which is not used in [bazel-orfs](https://github.com/The-OpenROAD-Project/bazel-orfs), [megaboom](https://github.com/The-OpenROAD-Project/megaboom) or [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts)