### PR TITLE
Fix env var wrapping

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -47,6 +47,7 @@ build_openroad(
             "CORE_UTILIZATION=3",
             "RTLMP_FLOW=True",
             "CORE_MARGIN=2",
+            "MACRO_PLACE_HALO=10 10",
         ],
         "place": [
             "PLACE_DENSITY=0.20",


### PR DESCRIPTION
This PR fixes issues with wrapping into quotes environment variables with spaces in their values when using `_make` targets.
The first commit adds additional argument for the example `floorplan` stage which have spaces in its value (`MACRO_PLACE_HALO=10 10`).
When using `_make` targets this env var was not quoted appropriately which caused make to interpret second part of this value as target name resulting in errors such as those (see [this](https://github.com/antmicro/bazel-orfs/actions/runs/8324089522/job/22774960281#step:10:41) CI run)
```
make: *** No rule to make target '10'.  Stop.
```
The fix modifies the `wrap_args()` helper function to include additional escaping sequences for the single quotes in order to preserve those when building shell scripts for running `_make` targets.

CC @oharboe
