### PR TITLE
CI: Add lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,23 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Lint Bazel files
+    runs-on: ubuntu-22.04
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+    steps:
+      - name: Download buildifier
+        run: |
+          wget https://github.com/bazelbuild/buildtools/releases/download/v6.4.0/buildifier-linux-amd64 -O /usr/local/bin/buildifier
+          chmod +x /usr/local/bin/buildifier
+          buildifier -version
+      - name: Checkout bazel-orfs
+        uses: actions/checkout@v4
+      - name: Check Bazel files
+        run: |
+          buildifier -lint warn -r .
+
   build-stage-target:
     name: Build sample stage targets
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This is a small improvement to the CI.
This PR adds an additional job which installs [buildifier](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md) tool and uses it to check the formatting of bazel files. It is a nice and easy way to keep all build files formatted in a standard way.