### PR TITLE
Do not inherit env vars from the caller environment

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --incompatible_strict_action_env


### PR DESCRIPTION
This PR adds `.bazelrc` configuration file with an option that prevents bazel from inheriting environment variables from the environment of the `bazel` caller.
This fixes cache invalidation when environment variable like e.g. `PATH` changes.

CC @oharboe 