### PR TITLE
Fix local flow in external repos

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -671,7 +671,7 @@ def build_openroad(
         stage_args = stage_args["synth"],
     )
     make_pattern = Label("//:memory-bazel.mk")
-    stage_config = Label("//:" + target_name + "_memory_config.mk")
+    stage_config = Label("@@//:" + target_name + "_memory_config.mk")
     entrypoint_cmd = get_entrypoint_cmd(make_pattern, design_config, stage_config, False)
     native.genrule(
         name = target_name + "_memory_make_script",

--- a/orfs
+++ b/orfs
@@ -6,7 +6,14 @@ export ORFS=~/OpenROAD-flow-scripts
 export FLOW_HOME=$ORFS/flow
 export MAKEFILES=$FLOW_HOME/Makefile
 export WORK_HOME=$WORKSPACE/$RULEDIR
-export BUILD_DIR=$WORKSPACE
+
+if [[ $WORKSPACE = * ]]
+then
+    export BUILD_DIR=$(echo $WORKSPACE | sed 's|external/bazel-orfs~override|execroot/_main|')
+else
+    export BUILD_DIR=$WORKSPACE
+fi
+
 
 source $ORFS/env.sh
 


### PR DESCRIPTION
@oharboe  this should fix the local flow.

This PR additionally adds the `docker_image` attribute to `build_openroad` macro which allows specifying docker image for given build. Please note that you may experience permission errors when building one part of the design with one docker image, and second part with other image.

