### PR TITLE
docker: default docker image name is same as ORFS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -155,7 +155,7 @@ build_openroad(
 oci_tarball(
     name = "orfs_env",
     image = "@orfs_image",
-    repo_tags = ["bazel-orfs/orfs_env:latest"],
+    repo_tags = ["openroad/flow-ubuntu22.04-builder:latest"],
 )
 
 sh_binary(

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -497,7 +497,7 @@ def build_openroad(
         mock_area = None,
         platform = "asap7",
         macro_variant = "base",
-        docker_image = "bazel-orfs/orfs_env:latest"):
+        docker_image = "openroad/flow-ubuntu22.04-builder:latest"):
     """
     Spawns targets for running physical design flow with OpenROAD-flow-scripts.
 
@@ -516,7 +516,7 @@ def build_openroad(
       mock_area: floating point number, spawns additional _mock_area targets if set
       platform: string specifying target platform for running physical design flow. Supported platforms: https://openroad-flow-scripts.readthedocs.io/en/latest/user/FlowVariables.html#platform
       macro_variant: variant of the ORFS flow the macro was built with
-      docker_image: docker image name or ID with ORFS environment. Referenced image must be available in local docker runtime. Defaults to `bazel-orfs/orfs_env:latest` which can be obtained by running: `bazel run orfs_env`
+      docker_image: docker image name or ID with ORFS environment. Referenced image must be available in local docker runtime. Defaults to `openroad/flow-ubuntu22.04-builder:latest` which can be obtained by running: `bazel run orfs_env`
     """
     target_ext = ("_" + variant if variant != "base" else "")
     target_name = name + target_ext


### PR DESCRIPTION
the user can specify a locked down version themself for production.

For local testing, the same docker tag as ORFS is
convenient as that makes compiling a docker image
from ORFS the regular way an obvious alternative
to using "bazel run orfs_env"

This begs the question as to why "bazel run orfs_env" now exists... Isn't that a CI concern for regression testing of bazel-orfs and not a user-concern?

Users, such as megaboom, are responsible for publishing and specifying the docker tag and url or furnishing the docker image in some out of bounds way(such as compiling locally).