### PR TITLE
Fix permission denied errors

### DIFF
--- a/docker_shell.sh
+++ b/docker_shell.sh
@@ -44,6 +44,9 @@ fi
 export DESIGN_CONFIG_PREFIXED=$WORKSPACE_EXECROOT/$DESIGN_CONFIG
 export STAGE_CONFIG_PREFIXED=$WORKSPACE_EXECROOT/$STAGE_CONFIG
 
+# Make bazel-bin writable
+chmod -R +w $WORKSPACE_EXECROOT/bazel-out/k8-fastbuild/bin
+
 # Most of these options below has to do with allowing to
 # run the OpenROAD GUI from within Docker.
 docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) \

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -642,7 +642,7 @@ def build_openroad(
             name = target_name + "_" + stage + "_make_script",
             tools = [Label("//:orfs")],
             srcs = [make_script_template, design_config, stage_config, make_pattern],
-            cmd = "echo \"#!/bin/bash\nchmod -R +w . && \" `cat $(location " + str(make_script_template) + ")` " + entrypoint_cmd + " \\\"$$\\@\\\" > $@",
+            cmd = "echo \"#!/bin/bash\n\"`cat $(location " + str(make_script_template) + ")` " + entrypoint_cmd + " \\\"$$\\@\\\" > $@",
             outs = ["logs/%s/%s/%s/make_script_%s.sh" % (platform, out_dir, variant, stage)],
         )
 
@@ -677,7 +677,7 @@ def build_openroad(
         name = target_name + "_memory_make_script",
         tools = [Label("//:orfs")],
         srcs = [make_script_template, design_config, stage_config, make_pattern],
-        cmd = "echo \"#!/bin/bash\nchmod -R +w . && \" `cat $(location " + str(make_script_template) + ")` " + entrypoint_cmd + " \\\"$$\\@\\\" > $@",
+        cmd = "echo \"#!/bin/bash\n \" `cat $(location " + str(make_script_template) + ")` " + entrypoint_cmd + " \\\"$$\\@\\\" > $@",
         outs = ["logs/%s/%s/%s/make_script_memory.sh" % (platform, out_dir, variant)],
     )
     native.sh_binary(

--- a/orfs
+++ b/orfs
@@ -15,6 +15,9 @@ fi
 
 export WORK_HOME=$BUILD_DIR/$RULEDIR
 
+# Make bazel-bin writable
+chmod -R +w $WORK_HOME
+
 source $ORFS/env.sh
 
 "$@"


### PR DESCRIPTION
This PR addresses the permission issues, which results in failing with `Permission error` or getting stuck with `[...] overriding mode 0555 (r-xr-xr-x)?`. It makes sure that files in workspace (`bazel-bin` directory) are writable and can be overridden.