### PR TITLE
Add targets running OpenROAD GUI with Docker image

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -6,7 +6,7 @@ target_name=${TARGET:-"tag_array_64x184"}
 flow=${FLOW:-"local_make"}
 if [[ -z "$STAGES" ]]; then
   if [[ "$target_name" == L1MetadataArray_* ]]; then
-    STAGES=("synth_sdc" "synth" "floorplan" "place" "cts" "grt" "generate_abstract")
+    STAGES=("synth_sdc" "synth" "floorplan" "place" "generate_abstract")
   else
     STAGES=("synth_sdc" "synth" "memory" "floorplan" "generate_abstract")
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         STAGE_TARGET:
           - "tag_array_64x184_generate_abstract_make"
           - "L1MetadataArray_test_generate_abstract_make"
-          - "L1MetadataArray_full_generate_abstract_make"
+          - "L1MetadataArray_full_final_gui"
           - "L1MetadataArray_test_gds_final_make"
           - "tag_array_64x184_memory_make"
     env:
@@ -67,6 +67,13 @@ jobs:
       - name: build target
         run: |
           bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+      - name: open target
+        if: matrix.STAGE_TARGET == 'L1MetadataArray_full_final_gui'
+        run: |
+          for stage in "synth" "floorplan" "place" "cts" "route" "final"; do
+            bazel build --subcommands --verbose_failures --sandbox_debug L1MetadataArray_full_${stage}_scripts
+            echo | ./bazel-bin/L1MetadataArray_full_${stage}_docker open_${stage}
+          done
 
   test-scripts-target-docker:
     name: Docker flow - test _scripts targets
@@ -99,6 +106,7 @@ jobs:
       - name: build docker stage targets - L1MetadataArray_test
         env:
           TARGET: L1MetadataArray_test
+          STAGES: synth_sdc synth floorplan place cts grt generate_abstract
         run: .github/scripts/build_local_target.sh
 
   test-scripts-target-local:
@@ -142,8 +150,14 @@ jobs:
         run: .github/scripts/build_local_target.sh
       - name: build local stage targets - L1MetadataArray_test
         env:
-          TARGET: L1MetadataArray_test
+          TARGET: L1MetadataArray_test_gds
+          STAGES: synth_sdc synth floorplan place cts grt route final generate_abstract
         run: .github/scripts/build_local_target.sh
+      - name: open target
+        run: |
+          for stage in "synth" "floorplan" "place" "cts" "route" "final"; do
+            echo | bazel-bin/L1MetadataArray_test_gds_${stage}_local_make open_${stage}
+          done
 
   test-docker-local-targets:
     name: Run ORFS using docker and local flow

--- a/BUILD
+++ b/BUILD
@@ -122,7 +122,7 @@ build_openroad(
             "MACRO_PLACE_HALO=10 10",
         ],
         "place": [
-            "PLACE_DENSITY=0.20",
+            "PLACE_DENSITY=0.10",
             "PLACE_PINS_ARGS=-annealing",
         ],
     }, ['SKIP_REPORT_METRICS=1']),

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Make targets:
   //:L1MetadataArray_test_generate_abstract_make
   //:L1MetadataArray_test_memory_make
 
+GUI targets:
+  //:L1MetadataArray_test_synth_gui
+  //:L1MetadataArray_test_floorplan_gui
+  //:L1MetadataArray_test_place_gui
+  //:L1MetadataArray_test_cts_gui
+
 Config generation targets:
 
   Design config:
@@ -142,6 +148,7 @@ These are the genrules spawned in this macro:
 * Make targets (named: `target_name + “_” + stage + “_make”`)
   * Builds all dependencies required for the stage and generates scripts
 * Special mock flow: Mock Area targets (named: `target_name + “_” + stage + “_mock_area”`)
+* GUI targets (named: `target_name + “_” + stage + “_gui”`)
 
 #### Docker flow
 
@@ -213,6 +220,30 @@ Used for estimating sizes of macros with long build times and checking if they w
 #### Memory Targets
 
 These targets print RAM summaries for a given module.
+
+#### GUI Targets
+
+Those targets are used to prepare environment for running OpenROAD CLI or GUI with Docker flow. E.g. `bazel build L1MetadataArray_full_final_gui` builds all dependencies required for running `open_final` and `gui_final` targets.
+
+CLI and GUI is not available for all stages, consequently these targets are created only for:
+* synthesis
+* floorplan
+* place
+* clock tree synthesis
+* route
+* final
+
+To use them with local flow it is enough to call generated script with `open_{stage}` or gui_{stage}` make target:
+
+```
+# Build dependencies
+bazel build L1MetadataArray_full_final_gui
+
+# Run GUI with local flow
+./bazel-bin/L1MetadataArray_full_final_local_make gui_final
+# or docker flow
+./bazel-bin/L1MetadataArray_full_final_docker gui_final
+```
 
 ### Constraints handling
 


### PR DESCRIPTION
This PR adds `*_gui` targets for Docker flow, which has to be called with `run`, e.g.:
```
bazel run L1MetadataArray_full_final_gui
```

GUI for local flow works fine, apart from synthesis stage, which requires additional LEF files - new target `*_gui_synth_make` resolves this issue.