### PR TITLE
Format generated _make script

### DIFF
--- a/make_script.template.sh
+++ b/make_script.template.sh
@@ -1,8 +1,16 @@
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash;
+#!/bin/bash
+set -uo pipefail
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
   source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
   source "$0.runfiles/$f" 2>/dev/null ||
   source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
   source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e;
+  {
+    echo>&2 "ERROR: cannot find $f"
+    exit 1
+  }
+f=
+set -e
 


### PR DESCRIPTION
This PR breaks generated _make scripts into multiple lines. Example for `L1MetadataArray_test_floorplan_make`:
```bash
#!/bin/bash
set -uo pipefail
set +e
f=bazel_tools/tools/bash/runfiles/runfiles.bash
source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
  source "$0.runfiles/$f" 2>/dev/null ||
  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null ||
  {
    echo>&2 "ERROR: cannot find $f"
    exit 1
  }
f=
set -e
DESIGN_CONFIG=$(rlocation _main/L1MetadataArray_test_config.mk) \
 STAGE_CONFIG=$(rlocation _main/L1MetadataArray_test_floorplan_config.mk) \
 MAKE_PATTERN=$(rlocation _main/floorplan-bazel.mk) \
 RULEDIR=bazel-out/k8-fastbuild/bin \
 $(rlocation _main/orfs) \
 make  $@
```