### PR TITLE
make_script.template.sh: Add comment about Bash runfiles library boilerplate code

### DIFF
--- a/make_script.template.sh
+++ b/make_script.template.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# The following lines are imported from Bazel Bash runfiles library
+# For more information please refer to the `Make targets` paragraph in the README
 set -uo pipefail
 set +e
 f=bazel_tools/tools/bash/runfiles/runfiles.bash


### PR DESCRIPTION
Point out that this is a boilerplate code of `Bazel Bash runfiles library` and refer to the `README` which describes this in detail.