### PR TITLE
Change order in which targets are displayed at the end of the build

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -695,9 +695,15 @@ def build_openroad(
         )
 
         # Scripts target
+        # Specifies additional dependencies to ensure _local_make and _docker are printed at the end
         native.filegroup(
             name = target_name_stage + "_scripts",
-            srcs = [target_name_stage + "_local_make", target_name_stage + "_docker"],
+            srcs = [
+                target_name_stage + "_make_local_script",
+                target_name_stage + "_make_docker_script",
+                target_name_stage + "_local_make",
+                target_name_stage + "_docker",
+            ],
         )
 
     # Generate general config for design stage targets
@@ -794,7 +800,7 @@ def build_openroad(
         # Target building `target_name` `stage` dependencies and generating `stage` scripts
         native.filegroup(
             name = target_name + "_" + stage + "_make",
-            srcs = [target_name + "_" + stage + "_scripts"] + stage_sources[stage] +
-                   ([target_name + "_" + previous] if stage not in ("clock_period", "synth_sdc") else []) +
-                   ([target_name + "_generate_abstract_mock_area"] if mock_area != None and stage == "generate_abstract" else []),
+            srcs = stage_sources[stage] + ([target_name + "_" + previous] if stage not in ("clock_period", "synth_sdc") else []) +
+                   ([target_name + "_generate_abstract_mock_area"] if mock_area != None and stage == "generate_abstract" else []) +
+                   [target_name + "_" + stage + "_scripts"],
         )


### PR DESCRIPTION
This PR changes order of displayed targets, so that generated scripts are printed at the end.

Before:
```
INFO: Found 1 target...
Target //:tag_array_64x184_floorplan_make up-to-date:
  bazel-bin/logs/asap7/tag_array_64x184/base/make_script_floorplan.sh
  bazel-bin/tag_array_64x184_floorplan_local_make
  bazel-bin/logs/asap7/tag_array_64x184/base/make_docker_script_floorplan.sh
  bazel-bin/tag_array_64x184_floorplan_docker
  bazel-bin/results/asap7/tag_array_64x184/base/1_synth.v
  bazel-bin/logs/asap7/tag_array_64x184/base/1_1_yosys.log
  bazel-bin/logs/asap7/tag_array_64x184/base/1_1_yosys_hier_report.log
```
```
INFO: Analyzed target //:tag_array_64x184_floorplan_scripts (1 packages loaded, 21 targets configured).
INFO: Found 1 target...
Target //:tag_array_64x184_floorplan_scripts up-to-date:
  bazel-bin/logs/asap7/tag_array_64x184/base/make_script_floorplan.sh
  bazel-bin/tag_array_64x184_floorplan_local_make
  bazel-bin/logs/asap7/tag_array_64x184/base/make_docker_script_floorplan.sh
  bazel-bin/tag_array_64x184_floorplan_docker
```

After:
```
INFO: Analyzed target //:tag_array_64x184_floorplan_make (1 packages loaded, 31 targets configured).
INFO: Found 1 target...
Target //:tag_array_64x184_floorplan_make up-to-date:
  bazel-bin/results/asap7/tag_array_64x184/base/1_synth.v
  bazel-bin/logs/asap7/tag_array_64x184/base/1_1_yosys.log
  bazel-bin/logs/asap7/tag_array_64x184/base/1_1_yosys_hier_report.log
  bazel-bin/logs/asap7/tag_array_64x184/base/make_script_floorplan.sh
  bazel-bin/logs/asap7/tag_array_64x184/base/make_docker_script_floorplan.sh
  bazel-bin/tag_array_64x184_floorplan_local_make
  bazel-bin/tag_array_64x184_floorplan_docker
```
```
INFO: Analyzed target //:tag_array_64x184_floorplan_scripts (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:tag_array_64x184_floorplan_scripts up-to-date:
  bazel-bin/logs/asap7/tag_array_64x184/base/make_script_floorplan.sh
  bazel-bin/logs/asap7/tag_array_64x184/base/make_docker_script_floorplan.sh
  bazel-bin/tag_array_64x184_floorplan_local_make
  bazel-bin/tag_array_64x184_floorplan_docker
```