### PR TITLE
build_openroad: Introduce debug_prints attribute

### DIFF
--- a/docker_shell.sh
+++ b/docker_shell.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 set -e
+if [[ -n $DEBUG_PRINTS ]]; then
+    set -x
+    export DEBUG="x"
+fi
+
 uuid=$(uuidgen)
 
 function handle_sigterm() {
@@ -103,7 +108,7 @@ function run_docker() {
 	$DOCKER_ARGS \
 	${OR_IMAGE:-openroad/flow-ubuntu22.04-builder:latest} \
 	bash -c \
-	"set -e
+	"set -e$DEBUG
 	. ./env.sh
 	cd \$BUILD_DIR
 	$ARGUMENTS

--- a/orfs
+++ b/orfs
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
+if [[ -n $DEBUG_PRINTS ]]; then
+    set -x
+fi
+
 WORKSPACE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ -z $FLOW_HOME ]]; then


### PR DESCRIPTION
This PR adds optional `debug_prints` attribute to the `build_openroad()` macro. It enables shell command traces and echoes from `make`. It is disabled by default.