### PR TITLE
ORFS: Bump docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     name: Local flow - test _scripts targets
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04@sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181
+      image: ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04@sha256:ef18800147f1b09fd00366c32b2266da4944d59d588680ed05d2685fbae2531a
     defaults:
       run:
         shell: bash

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "rules_oci", version = "1.7.4")
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "orfs_image",
-    digest = "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
+    digest = "sha256:ef18800147f1b09fd00366c32b2266da4944d59d588680ed05d2685fbae2531a",
     image = "ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04",
     platforms = ["linux/amd64"],
 )


### PR DESCRIPTION
Use ORFS docker image built on top of https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/9b86e54c852ec4e77a94b7ba3c3bfcf012d6adba