### PR TITLE
orfs: fewer surprises now that cwd is in the build folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,16 +338,6 @@ filegroup(
 )
 ```
 
-The constraint file should also source the additional TCL script in a very specific manner.
-The additional sourced files have to be placed in the same directory as the constraint file.
-Constraint file should use environment variable `SDC_FILE` or `IO_CONSTRAINT` defined for the ORFS flow to fetch the path to itself and use it to source the additional file.
-Here is the example:
-
-```
-set script_path [ file dirname $::env(IO_CONSTRAINTS) ]
-source $script_path/util.tcl
-```
-
 ## Tutorial
 
 This tutorial uses the `docker flow` to run the physical design flow with ORFS.

--- a/test/constraints-sram.sdc
+++ b/test/constraints-sram.sdc
@@ -1,6 +1,4 @@
-set script_path [ file dirname $::env(SDC_FILE) ]
-# We expect util.tcl in the same directory as this file
-source $script_path/util.tcl
+source test/util.tcl
 
 # Set the clock name and period
 set clk_period 400 

--- a/test/io-sram.tcl
+++ b/test/io-sram.tcl
@@ -1,5 +1,3 @@
-set script_path [ file dirname $::env(IO_CONSTRAINTS) ]
-# We expect util.tcl in the same directory as this file
-source $script_path/util.tcl
+source test/util.tcl
 
 set_io_pin_constraint -region left:* -pin_names [match_pins {(R|W)[0-9]+_.*}]

--- a/test/io.tcl
+++ b/test/io.tcl
@@ -1,5 +1,3 @@
-set script_path [ file dirname $::env(IO_CONSTRAINTS) ]
-# We expect util.tcl in the same directory as this file
-source $script_path/util.tcl
+source test/util.tcl
 
 set_io_pin_constraint -region left:* -pin_names [match_pins (io|auto)_.*]


### PR DESCRIPTION
relative paths work.

@eszpotanski @lpawelcz I want to reduce the number of surprises and differences between using ORFS standalone and using bazel-orfs.