### PR TITLE
Move `out` script from MegaBoom

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 load("@rules_oci//oci:defs.bzl", "oci_tarball")
-load("//:openroad.bzl", "build_openroad", "add_options_all_stages")
+load("//:openroad.bzl", "add_options_all_stages", "build_openroad", "create_out_rule")
 
 # FIXME: this shouldn't be required
 exports_files(glob(["*.mk"]))
@@ -8,7 +8,12 @@ exports_files(glob(["scripts/mem_dump.*"]))
 
 exports_files(["mock_area.tcl"])
 
-exports_files(["orfs"])
+exports_files([
+    "orfs",
+    "out_script",
+])
+
+create_out_rule()
 
 filegroup(
     name = "util",
@@ -115,19 +120,22 @@ build_openroad(
         "lb_32x128",
     ],
     sdc_constraints = ":test/constraints-top.sdc",
-    stage_args = add_options_all_stages({
-        "synth": ["SYNTH_HIERARCHICAL=1"],
-        "floorplan": [
-            "CORE_UTILIZATION=3",
-            "RTLMP_FLOW=True",
-            "CORE_MARGIN=2",
-            "MACRO_PLACE_HALO=10 10",
-        ],
-        "place": [
-            "PLACE_DENSITY=0.10",
-            "PLACE_PINS_ARGS=-annealing",
-        ],
-    }, ['SKIP_REPORT_METRICS=1']),
+    stage_args = add_options_all_stages(
+        {
+            "synth": ["SYNTH_HIERARCHICAL=1"],
+            "floorplan": [
+                "CORE_UTILIZATION=3",
+                "RTLMP_FLOW=True",
+                "CORE_MARGIN=2",
+                "MACRO_PLACE_HALO=10 10",
+            ],
+            "place": [
+                "PLACE_DENSITY=0.10",
+                "PLACE_PINS_ARGS=-annealing",
+            ],
+        },
+        ["SKIP_REPORT_METRICS=1"],
+    ),
     variant = "test_gds",
     verilog_files = ["test/rtl/L1MetadataArray.sv"],
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "2aca7cf8613c58b798ea6d8c170ebd5b597f1db83a21c7135f4a3925551c6506",
+  "moduleFileHash": "c09af78761abb4873cb004a525a717f0e8524cf35a55e16ef999919d688e2649",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -42,7 +42,7 @@
               "tagName": "pull",
               "attributeValues": {
                 "name": "orfs_image",
-                "digest": "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
+                "digest": "sha256:ef18800147f1b09fd00366c32b2266da4944d59d588680ed05d2685fbae2531a",
                 "image": "ghcr.io/antmicro/openroad-flow-scripts/ubuntu22.04",
                 "platforms": [
                   "linux/amd64"
@@ -1812,7 +1812,7 @@
               "scheme": "https",
               "registry": "ghcr.io",
               "repository": "antmicro/openroad-flow-scripts/ubuntu22.04",
-              "identifier": "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
+              "identifier": "sha256:ef18800147f1b09fd00366c32b2266da4944d59d588680ed05d2685fbae2531a",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@orfs_image_linux_amd64"
               },
@@ -2147,7 +2147,7 @@
               "scheme": "https",
               "registry": "ghcr.io",
               "repository": "antmicro/openroad-flow-scripts/ubuntu22.04",
-              "identifier": "sha256:b13b35193bec45cb708bd9a5ee3546a7f20378e3c977a4c49f00e9c1c8a71181",
+              "identifier": "sha256:ef18800147f1b09fd00366c32b2266da4944d59d588680ed05d2685fbae2531a",
               "platform": "linux/amd64",
               "target_name": "orfs_image_linux_amd64"
             }

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ git_override(
 )
 ```
 
-Then load the macro in BUILD file where it should be used:
+Then load the macro in BUILD file where it should be used, and create rule for `out` script, which can find the latest file with logs:
 
 ```
-load("@bazel-orfs//:openroad.bzl", "build_openroad")
+load("@bazel-orfs//:openroad.bzl", "build_openroad", "create_out_rule")
+create_out_rule()
 ```
 
 The macro can now be placed in the BUILD file. The macro usage can look like this:
@@ -270,6 +271,12 @@ Created shell scripts, apart from facilitating quick tests of ORFS modifications
 * Make targets patterns
 * entrypoint command line
 
+Additionally, script finding the latest log files will be created - by default it displays full path (without symlinks) to the `bazel-bin` and with `--tail` option it shows full path to the latest log.
+It can be found under the path:
+```
+bazel-bin/out
+```
+
 #### Make Targets
 
 Targets build all necessary dependencies for chosen stage and both scripts from scripts target.
@@ -358,6 +365,9 @@ bazel build L1MetadataArray_test_cts_make
 # Build CTS stage for L1MetadataArray macro with local of Docker flow
 ./bazel-bin/L1MetadataArray_test_cts_local_make bazel-cts
 ./bazel-bin/L1MetadataArray_test_cts_docker bazel-cts
+
+# Tail the latest log file
+tail -f $(./bazel-bin/out -t)
 ```
 
 ### Using the local flow

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -517,6 +517,22 @@ def resolve_path(label):
         return "/".join([native.package_name(), label])
     return label
 
+def create_out_rule(name = "out_make_script"):
+    """
+    Spawns target which creates out script.
+
+    Args:
+        name: name of the created target
+    """
+    native.genrule(
+        name = name,
+        tools = ["@bazel-orfs//:out_script"],
+        srcs = [],
+        cmd = "cp $(location @bazel-orfs//:out_script) $@",
+        visibility = ["//visibility:private"],
+        outs = ["out"],
+    )
+
 def build_openroad(
         name,
         variant = "base",
@@ -680,7 +696,7 @@ def build_openroad(
             entrypoint = Label("//:docker_shell"),
             docker_image = docker_image,
             interactive = True,
-	    debug_prints = debug_prints
+            debug_prints = debug_prints,
         )
         target_name_stage = target_name + "_" + stage
 
@@ -719,6 +735,7 @@ def build_openroad(
             srcs = [
                 target_name_stage + "_make_local_script",
                 target_name_stage + "_make_docker_script",
+                ":out",
                 target_name_stage + "_local_make",
                 target_name_stage + "_docker",
             ],

--- a/out_script
+++ b/out_script
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Find this path:
+#
+# /home/user/.cache/bazel/_bazel_user/7e6ad621f3f951c3ee6f5b179289b54e/execroot/_main/bazel-out/k8-fastbuild/bin/
+#
+# Where:
+# _bazel_user is a folder where "user" is the username
+# 7e6ad621f3f951c3ee6f5b179289b54e is the MD5 hash of the path name of workspace root
+#     (as described in https://bazel.build/remote/output-directories#layout)
+#
+# Then print out the path
+
+import os
+import sys
+import re
+import argparse
+import hashlib
+from pathlib import Path
+from glob import glob
+
+PROJECT_DIR = Path(__file__).parent.resolve()
+
+
+def find_path(main_directory = PROJECT_DIR):
+    if str(PROJECT_DIR).endswith(str(Path("execroot/_main/bazel-out/k8-fastbuild/bin"))):
+        # Script inside bazel cache directory
+        return str(PROJECT_DIR)
+
+    # Script in project's root
+    path = os.path.expanduser("~/.cache/bazel/_bazel_" + os.getlogin())
+    if not os.path.exists(path):
+        print("Path does not exist: " + path)
+        sys.exit(1)
+
+    hash = hashlib.new("md5")
+    hash.update(str(PROJECT_DIR).encode())
+    d = hash.hexdigest()
+    if re.match(r'[a-z0-9]{32}', d):
+        path2 = os.path.join(path, d,
+                             "execroot/_main/bazel-out/k8-fastbuild/bin")
+        if os.path.exists(path2):
+            return path2
+
+    print("Could not find path")
+    sys.exit(1)
+
+
+def find_newest_log(path):
+    files = glob(path + "/**/*.log", recursive=True)
+    return max(files, key=os.path.getmtime, default=None)
+
+
+if __name__ == "__main__":
+    # print(sys.argv[0], os.getcwd())
+    # exit()
+    path = find_path()
+    args = sys.argv[1:]
+    parser = argparse.ArgumentParser()
+    # add actions in argparser
+    # print - default action
+    # tail - print last 10 lines
+    parser.add_argument("-t", "--tail", action="store_true")
+    args = parser.parse_args(args)
+    if args.tail:
+        # scan recursively to find the most recent file ending in
+        # .tmp.log:
+        #
+        # path + '/logs/asap7/DigitalTop/2_6_floorplan_pdn.tmp.log'
+        tmpfile = find_newest_log(path + '/logs')
+        if tmpfile is None:
+            print("Could not find tmp file")
+            sys.exit(1)
+        print(tmpfile)
+    else:
+        print(path)


### PR DESCRIPTION
This PR moves `out` script for finding the latest file with log from MegaBoom to bazel-orfs.

The `_scripts` targets were extended to also create `bazel-bin/out` script.