### PR TITLE
Docker flow: Forward `stdin`

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -692,7 +692,7 @@ def build_openroad(
             make_pattern,
             design_config,
             stage_config,
-            False,
+            True,
             entrypoint = Label("//:docker_shell"),
             docker_image = docker_image,
             interactive = True,


### PR DESCRIPTION
In order to interpret `.tcl` scripts using `./bazel-bin/Top_variant_floorplan_docker open_floorplan < script.tcl`, `docker_shell` must pass `stdin` to `make`. If there are less ill-advised ways to achieve this, any help would be appreciated.

@oharboe 