### PR TITLE
openroad: Fix `out` label

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -529,7 +529,7 @@ def create_out_rule(name = "out_make_script"):
         tools = ["@bazel-orfs//:out_script"],
         srcs = [],
         cmd = "cp $(location @bazel-orfs//:out_script) $@",
-        visibility = ["//visibility:private"],
+        visibility = [":__subpackages__"],
         outs = ["out"],
     )
 
@@ -733,9 +733,9 @@ def build_openroad(
         native.filegroup(
             name = target_name_stage + "_scripts",
             srcs = [
+                "//:out",
                 target_name_stage + "_make_local_script",
                 target_name_stage + "_make_docker_script",
-                ":out",
                 target_name_stage + "_local_make",
                 target_name_stage + "_docker",
             ],


### PR DESCRIPTION
When doing `bazel build '...'` I get:
```
//subpackage:tag_array_64x184_synth_sdc_make: missing input file '//subpackage:out'
```
```
$ bazel cquery 'somepath(//subpackage:tag_array_64x184_clock_period_make, //subpackage:out)'
INFO: Analyzed 2 targets (0 packages loaded, 0 targets configured).
INFO: Found 2 targets...
//subpackage:tag_array_64x184_clock_period_make (6220210)
//subpackage:tag_array_64x184_clock_period_scripts (6220210)
//subpackage:out (null)
```

reveals the offending dependency path.

I made an initial suggestion on how to fix this, that assumes `create_out_rule()` is instantiated on the `WORKSPACE` level. ~On closer thought, however, I wonder why `//...:..._scripts` should depend on `//:out` at all?~ Nevermind, found https://github.com/Pinata-Consulting/ascenium-antmicro/issues/35#issuecomment-2112422323.

@eszpotanski 