### PR TITLE
Add suport for external PDKs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -174,3 +174,49 @@ sh_binary(
     srcs = ["docker_shell.sh"],
     visibility = ["//visibility:public"],
 )
+
+# buildifier: disable=duplicated-name
+build_openroad(
+    name = "tag_array_64x184",
+    external_pdk = "@external_pdk//asap7",
+    io_constraints = ":io-sram",
+    mock_abstract = True,
+    mock_stage = "floorplan",
+    sdc_constraints = ":constraints-sram",
+    stage_args = {
+        "floorplan": [
+            "CORE_UTILIZATION=40",
+            "CORE_ASPECT_RATIO=2",
+        ],
+        "place": ["PLACE_DENSITY=0.65"],
+    },
+    variant = "external_pdk",
+    verilog_files = ["test/mock/tag_array_64x184.sv"],
+)
+
+# buildifier: disable=duplicated-name
+build_openroad(
+    name = "L1MetadataArray",
+    external_pdk = "@external_pdk//asap7",
+    io_constraints = ":io",
+    macro_variants = {"tag_array_64x184": "external_pdk"},
+    macros = ["tag_array_64x184"],
+    mock_abstract = True,
+    mock_stage = "grt",
+    sdc_constraints = ":test/constraints-top.sdc",
+    stage_args = {
+        "synth": ["SYNTH_HIERARCHICAL=1"],
+        "floorplan": [
+            "CORE_UTILIZATION=3",
+            "RTLMP_FLOW=True",
+            "CORE_MARGIN=2",
+            "MACRO_PLACE_HALO=30 30",
+        ],
+        "place": [
+            "PLACE_DENSITY=0.20",
+            "PLACE_PINS_ARGS=-annealing",
+        ],
+    },
+    variant = "external_pdk",
+    verilog_files = ["test/rtl/L1MetadataArray.sv"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,3 +14,12 @@ oci.pull(
     platforms = ["linux/amd64"],
 )
 use_repo(oci, "orfs_image")
+
+# To have the external PDK examples working uncomment the code below
+# and set the `urls` attribute to the archive with external PDK
+#bazel_dep(name = "external_pdk", version = "1.0.0")
+#archive_override(
+#    module_name = "external_pdk",
+#    patches = ["//external_pdk:external_pdk.patch"],
+#    urls = "",
+#)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "c09af78761abb4873cb004a525a717f0e8524cf35a55e16ef999919d688e2649",
+  "moduleFileHash": "07e4368cfbbe05abdb79ca996ef48d3d03592f5e8efe0706a34907e00a126e9c",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"

--- a/external_pdk/external_pdk.patch
+++ b/external_pdk/external_pdk.patch
@@ -1,0 +1,32 @@
+diff --git a/BUILD b/BUILD
+new file mode 100644
+index 0000000..0d57ccb
+--- /dev/null
++++ BUILD
+@@ -0,0 +1,3 @@
++package(
++	default_visibility = ["//visibility:public"],
++)
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..8419e9b
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1 @@
++module(name="external_pdk")
+diff --git a/asap7/BUILD b/asap7/BUILD
+new file mode 100644
+index 0000000..c92202a
+--- /dev/null
++++ asap7/BUILD
+@@ -0,0 +1,10 @@
++package(
++	default_visibility = ["//visibility:public"],
++)
++filegroup(
++	name = "asap7",
++	srcs = glob([
++		"**"
++	]),
++    visibility = ["//visibility:public"],
++)


### PR DESCRIPTION
This PR modifies bazel macros to add support for running physical design flows with external PDKs provided in the format accepted by ORFS (for more information please refer to: https://openroad-flow-scripts.readthedocs.io/en/latest/contrib/PlatformBringUp.html#platform-configuration).

PR adds new `external_pdk` attribute to the `build_openroad()` macro. This attribute points to bazel external dependency with the unpacked PDK archive. The directory of this PDK is then set as the value of `PLATFORM_HOME` env var and the name of the PDK is set as `PLATFORM` env var. When ORFS flow is launched, those env vars are used to construct the `PLATFORM_DIR` env var which points ORFS tools to the directory of the external PDK.

Two example build configurations were added for testing purposes.

> **Important Note:** Currently, the external PDK bazel dependency is not specified (see changes in `MODULE.bazel` file).
In order to test the PR it is required to prepare a mocked external PDK (e.g. `asap7` of [ORFS](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts)) and refer to it in the `urls` attribute of `archive_override` like so:
`urls = "file://<local path to asap7.tar.gz>",`

CC @oharboe 