### PR TITLE
Use `docker_shell` directly

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@ exports_files(["mock_area.tcl"])
 exports_files([
     "orfs",
     "out_script",
+    "docker_shell",
 ])
 
 exports_files(
@@ -175,12 +176,6 @@ oci_tarball(
     name = "orfs_env",
     image = "@orfs_image",
     repo_tags = ["openroad/flow-ubuntu22.04-builder:latest"],
-)
-
-sh_binary(
-    name = "docker_shell",
-    srcs = ["docker_shell.sh"],
-    visibility = ["//visibility:public"],
 )
 
 # buildifier: disable=duplicated-name

--- a/docker_shell
+++ b/docker_shell
@@ -20,17 +20,18 @@ function handle_sigterm() {
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ $DIR == */external/bazel-orfs~override ]]; then
-	WORKSPACE_ROOT=$(realpath $DIR/../../../../../../..)
+	WORKSPACE_ROOT=$(realpath -L $DIR/../../../..)
 else
-	WORKSPACE_ROOT=$(realpath $DIR/../../../../..)
+	WORKSPACE_ROOT=$(realpath $DIR/../..)
 fi
-WORKSPACE_EXECROOT=$WORKSPACE_ROOT/execroot/_main
+WORKSPACE_EXECROOT=$DIR
 WORKSPACE_EXTERNAL=$WORKSPACE_ROOT/external
 
 # Automatically mount bazel-orfs directory if it is used as module with local_path_override
 if [[ $DIR == */external/bazel-orfs~override ]]; then
 	BAZEL_ORFS_DIR=$(realpath $WORKSPACE_ROOT/external/bazel-orfs~override)
 	DOCKER_ARGS="$DOCKER_ARGS -v $BAZEL_ORFS_DIR:$BAZEL_ORFS_DIR"
+	WORKSPACE_EXECROOT=$(realpath -L $DIR/../..)
 fi
 
 XSOCK=/tmp/.X11-unix_$uuid

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -270,7 +270,7 @@ def get_entrypoint_cmd(
     if (use_docker_flow):
         if entrypoint == None:
             entrypoint = Label("//:docker_shell")
-        entrypoint = " $(location " + str(entrypoint) + ")" + fmt_whitespace
+        entrypoint = " $$(pwd)/$(location " + str(entrypoint) + ")" + fmt_whitespace
     else:
         if entrypoint == None:
             entrypoint = Label("//:orfs")


### PR DESCRIPTION
This PR changes how `docker_shell` is used - instead of wrapping it with `sh_binary`, it used directly. This should make the cache hits more robust.