### PR TITLE
orfs_flow: test SKIP_REPORT_METRICS=1

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -65,9 +65,23 @@ orfs_flow(
         "floorplan": SRAM_FLOOR_PLACE_ARGUMENTS | {
             "CORE_UTILIZATION": "40",
             "CORE_ASPECT_RATIO": "2",
+            "SKIP_REPORT_METRICS": "1"
         },
         "place": SRAM_FLOOR_PLACE_ARGUMENTS | {
             "PLACE_DENSITY": "0.40",
+            "SKIP_REPORT_METRICS": "1",
+        },
+        "cts": {
+            "SKIP_REPORT_METRICS": "1",
+        },
+        "grt": {
+            "SKIP_REPORT_METRICS": "1",
+        },
+        "route": {
+            "SKIP_REPORT_METRICS": "1",
+        },
+        "final": {
+            "SKIP_REPORT_METRICS": "1",
         },
     },
     stage_sources = {


### PR DESCRIPTION
This requires creating an empty file when reports are disabled because bazel does not have conditional outputs