### PR TITLE
 Avoid copying source files to the output

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -625,7 +625,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         template = ctx.file._deploy_template,
         output = exe,
         substitutions = {
-            "${GENFILES}": " ".join([f.short_path for f in [config_short] + results + ctx.files.src + ctx.files.data]),
+            "${GENFILES}": " ".join([f.short_path for f in [config_short] + results + ctx.files.data]),
             "${CONFIG}": config_short.short_path,
             "${MAKE}": make.short_path,
         },
@@ -644,7 +644,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
             ),
             runfiles = ctx.runfiles(
                 [config_short, make, ctx.executable._openroad, ctx.executable._klayout, ctx.file._makefile] +
-                results + ctx.files.src + ctx.files.data + ctx.files._tcl + ctx.files._opengl + ctx.files._qt_plugins + ctx.files._gio_modules,
+                results + ctx.files.data + ctx.files._tcl + ctx.files._opengl + ctx.files._qt_plugins + ctx.files._gio_modules,
                 transitive_files = depset(transitive = transitive_inputs),
             ),
         ),


### PR DESCRIPTION
# Avoid copying source files to the output directory

This PR addresses the unnecessary copying of source files to the output directory in the `openroad.bzl` script.

## Example

Before modifications:

```
$ bazel run L1MetadataArray_place -- `pwd`/build
$ find build/ | grep -v external | grep floorplan
build/results/asap7/L1MetadataArray/base/2_floorplan.odb
build/results/asap7/L1MetadataArray/base/2_floorplan.sdc
```

After:

```
$ bazel run L1MetadataArray_place -- `pwd`/build
$ find build/ | grep -v external | grep floorplan
```

## Modifications

This PR modifies the following:

* `openroad.bzl`
  * Modified the `GENFILES` substitution to exclude `ctx.files.src`, ensuring that source files are not copied to the output directory.
  * Updated the runfiles section to exclude `ctx.files.src`, aligning it with the updated `GENFILES` logic.