### PR TITLE
.bazelrc: delete, it is a docker vestige

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,0 @@
-build --incompatible_strict_action_env


### PR DESCRIPTION
'build --incompatible_strict_action_env' is no longer needed