### PR TITLE
Update README.md with in-place Local Flow build targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -123,7 +123,7 @@ orfs_flow(
         },
         "floorplan": {
             "CORE_UTILIZATION": "3",
-            "RTLMP_FLOW": "True",
+            "RTLMP_FLOW": "1",
             "CORE_MARGIN": "2",
             "MACRO_PLACE_HALO": "30 30",
         },


### PR DESCRIPTION
# Update README.md with in-place Local Flow build targets

This PR updates the `README.md` file to provide instructions for running the Local Flow build steps in place.

This PR modifies the following:

* `README.md`
  * Revised Local Flow build commands to use `make do-<stage>` instead of `make <stage>`, aligning with updated usage practices
  * Corrected minor typos
* `BUILD` - Updated the `RTLMP_FLOW` parameter from `True` to `1` to ensure proper handling of Boolean-like variables