### PR TITLE
Speed up ORFS version change

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,5 @@ orfs.default(
     image = "openroad/orfs:v3.0-1206-gc6ea30d2",
     sha256 = "c3b9263892e166684f6e3cd5498a556bc2b9a858b4dc36f3b7ea4ed92fb0b2f5",
 )
-use_repo(orfs, "com_github_docker_buildx_file")
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -63,7 +63,7 @@
   "moduleExtensions": {
     "//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "42x9Wez2cJ4mcTzytkWEzBr9ilyB80Y3HGoSJdZwb6w=",
+        "bzlTransitiveDigest": "3M3hmhztcAwi6uswGCdjF5FgnO5uqg++9EL87+pYTZo=",
         "usagesDigest": "RoKQ58e2BcjvelRsNgQYmhaBp32ZF9K1xFepyxgVCwI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -89,17 +89,6 @@
                 "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz"
               ]
             }
-          },
-          "com_github_docker_buildx_file": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_file",
-            "attributes": {
-              "executable": true,
-              "sha256": "8d486f0088b7407a90ad675525ba4a17d0a537741b9b33fe3391a88cafa2dd0b",
-              "urls": [
-                "https://github.com/docker/buildx/releases/download/v0.15.1/buildx-v0.15.1.linux-amd64"
-              ]
-            }
           }
         },
         "recordedRepoMappingEntries": [
@@ -107,11 +96,6 @@
             "",
             "bazel_tools",
             "bazel_tools"
-          ],
-          [
-            "",
-            "com_github_docker_buildx_file",
-            "_main~orfs_repositories~com_github_docker_buildx_file"
           ],
           [
             "",

--- a/docker.bzl
+++ b/docker.bzl
@@ -3,36 +3,50 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch")
 
 def _impl(repository_ctx):
-    docker_path = repository_ctx.path(repository_ctx.attr._docker).realpath
-    image_archive = repository_ctx.path("data.tar")
-    dockerfile = repository_ctx.path("Dockerfile")
-
-    repository_ctx.file(dockerfile, content = "FROM {}@sha256:{}".format(repository_ctx.attr.image, repository_ctx.attr.sha256))
-
-    build_result = repository_ctx.execute(
-        [
-            docker_path,
-            "build",
-            "--file",
-            dockerfile,
-            "--output",
-            "type=tar,dest={}".format(image_archive),
-            ".",
-        ],
-    )
-    if build_result.return_code != 0:
-        fail("Failed to build {}:".format(repository_ctx.attr.image), build_result.stderr)
-
-    repository_ctx.report_progress("Built {}.".format(repository_ctx.attr.image))
-
-    repository_ctx.extract(archive = image_archive)
-    repository_ctx.delete(image_archive)
-    repository_ctx.report_progress("Extracted {}.".format(repository_ctx.attr.image))
+    image = "{}@sha256:{}".format(repository_ctx.attr.image, repository_ctx.attr.sha256)
 
     python_name = "python3"
     python = repository_ctx.which(python_name)
     if not python:
         fail("Failed to find {}.".format(python_name))
+    docker_name = "docker"
+    docker = repository_ctx.which(docker_name)
+    if not docker:
+        fail("Failed to find {}.".format(docker_name))
+
+    run = repository_ctx.execute(
+        [
+            docker,
+            "run",
+            "-td",
+            "--rm",
+            image,
+        ],
+    )
+    if run.return_code != 0:
+        fail("Failed to start container: {}".format(run.stderr), run.return_code)
+    container_id = run.stdout.strip()
+    cp = repository_ctx.execute(
+        [
+            docker,
+            "cp",
+            "{}:/".format(container_id),
+            ".",
+        ],
+    )
+    stop = repository_ctx.execute(
+        [
+            docker,
+            "stop",
+            container_id,
+        ],
+    )
+    if stop.return_code != 0:
+        print("Container {} has not been stopped".format(container_id))  # buildifier: disable=print
+    if cp.return_code != 0:
+        fail("Failed to copy image content: {}".format(cp.stderr), cp.return_code)
+
+    repository_ctx.report_progress("Extracted {}.".format(repository_ctx.attr.image))
 
     patcher = repository_ctx.path(repository_ctx.attr._patcher).realpath
     patchelf = repository_ctx.path(repository_ctx.attr._patchelf).realpath
@@ -45,7 +59,7 @@ def _impl(repository_ctx):
         ],
     )
     if patcher_result.return_code != 0:
-        fail("Failed to run {}:".format(repository_ctx.attr._patcher), build_result.stderr)
+        fail("Failed to run {}:".format(repository_ctx.attr._patcher), patcher_result.stderr)
 
     repository_ctx.report_progress("Fixed `RUNPATH`s for {}.".format(repository_ctx.attr.image))
 
@@ -64,12 +78,6 @@ docker_pkg = repository_rule(
         "patch_cmds": attr.string_list(default = []),
         "patch_cmds_win": attr.string_list(default = []),
         "timeout": attr.int(default = 600),
-        "_docker": attr.label(
-            doc = "Docker command line interface.",
-            default = Label("@com_github_docker_buildx_file//file:downloaded"),
-            executable = True,
-            cfg = "exec",
-        ),
         "_patchelf": attr.label(
             doc = "Patchelf binary.",
             default = Label("@com_github_nixos_patchelf_download//:bin/patchelf"),

--- a/extension.bzl
+++ b/extension.bzl
@@ -4,7 +4,7 @@ from a OpenROAD-flow-scripts docker image and provides rules for its
 build stages.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//:docker.bzl", "docker_pkg")
 
@@ -20,14 +20,6 @@ _default_tag = tag_class(
 )
 
 def _orfs_dependencies():
-    maybe(
-        http_file,
-        name = "com_github_docker_buildx_file",
-        executable = True,
-        sha256 = "8d486f0088b7407a90ad675525ba4a17d0a537741b9b33fe3391a88cafa2dd0b",
-        urls = ["https://github.com/docker/buildx/releases/download/v0.15.1/buildx-v0.15.1.linux-amd64"],
-    )
-
     maybe(
         http_archive,
         name = "com_github_nixos_patchelf_download",

--- a/patcher.py
+++ b/patcher.py
@@ -3,75 +3,183 @@
 import argparse
 import os
 import subprocess
+import multiprocessing
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Optional
 
 DEFAULT_SEARCH_PATHS = [
-    '/lib64',
-    '/usr/lib/x86_64-linux-gnu',
+    "/lib64",
+    "/usr/lib/x86_64-linux-gnu",
 ]
 
-ELF_MAGIC = b'\x7fELF'
+ELF_MAGIC = b"\x7fELF"
 
-def magic(path):
+
+def magic(path: str) -> Optional[bytes]:
+    """
+    Returns first few bytes from the given file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the file
+
+    Returns
+    -------
+    Optional[bytes]
+        bytes or None
+    """
     if not os.path.isfile(path):
         return None
 
-    with open(path, 'rb') as f:
-        return f.read(len(ELF_MAGIC))
+    try:
+        with open(path, "rb") as f:
+            return f.read(len(ELF_MAGIC))
+    except FileNotFoundError:
+        return None
 
     return None
 
+
+def patch_prepare(args: argparse.Namespace, root: str, file: str) -> List:
+    """
+    Reads patchelf information (like rpath or interpreter)
+    and prepares patchelf commands. It also fixes links.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Program arguments
+    root : str
+        Root directory of the processed file
+    file : str
+        Name of the processed file
+
+    Returns
+    -------
+    List
+        List of prepared commands
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        Exception raised when subprocess fails
+    """
+    link = os.path.join(root, file)
+    if os.path.islink(link) and os.path.isabs(os.readlink(link)):
+        readlink = os.path.relpath(os.readlink(link), start=os.path.abspath("/"))
+        target = os.path.join(args.directory, readlink)
+        link_to_target = os.path.relpath(target, start=root)
+        os.unlink(link)
+        os.symlink(link_to_target, link)
+        return []
+
+    if magic(os.path.join(root, file)) != ELF_MAGIC:
+        return []
+
+    needed_result = subprocess.run(
+        [args.patchelf, "--print-needed", file], cwd=root, capture_output=True
+    )
+    needed_libs = needed_result.stdout.decode("utf-8").strip()
+    if not needed_libs:
+        return []
+
+    rpath_fragments = (
+        subprocess.check_output([args.patchelf, "--print-rpath", file], cwd=root)
+        .decode("utf-8")
+        .strip()
+    )
+    rpaths = []
+    for rpath in rpath_fragments.split(":") + DEFAULT_SEARCH_PATHS:
+        if not rpath:
+            continue
+
+        if "$ORIGIN" in rpath:
+            rpaths.append(rpath)
+        else:
+            elf = os.path.join("/", os.path.relpath(root, start=args.directory))
+            elf_to_rpath = os.path.relpath(rpath, start=elf)
+            rpaths.append(os.path.join("$ORIGIN", elf_to_rpath))
+
+    rpath = ":".join(rpaths).encode("utf-8")
+    cmds = [
+        (
+            [
+                args.patchelf,
+                "--force-rpath",
+                "--set-rpath",
+                rpath,
+                "--no-default-lib",
+                file,
+            ],
+            root,
+        )
+    ]
+
+    interpreter_result = subprocess.run(
+        [args.patchelf, "--print-interpreter", file], cwd=root, capture_output=True
+    )
+    if interpreter_result.returncode != 0:
+        return cmds
+
+    interpreter_old = interpreter_result.stdout.decode("utf-8").strip()
+    execution_root = os.path.normpath(os.path.join(args.directory, "..", ".."))
+    interp = os.path.relpath(interpreter_old, start="/")
+    execution_root_to_interp = os.path.relpath(
+        os.path.join(args.directory, interp), execution_root
+    )
+    cmds.append(
+        ([args.patchelf, "--set-interpreter", execution_root_to_interp, file], root),
+    )
+    return cmds
+
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('directory', help='Directory to patch.')
-    parser.add_argument('-p', '--patchelf', default = 'patchelf', help='`patchelf` binary to use.')
+    parser.add_argument("directory", help="Directory to patch.")
+    parser.add_argument(
+        "-p", "--patchelf", default="patchelf", help="`patchelf` binary to use."
+    )
+    parser.add_argument(
+        "-j", "--jobs", default=None, type=int, help="Number of threads to use."
+    )
     args = parser.parse_args()
 
-    for root, dirs, files in os.walk(args.directory):
-        for file in files:
-            link = os.path.join(root, file)
-            if os.path.islink(link) and os.path.isabs(os.readlink(link)):
-                target = os.path.join(args.directory, os.readlink(link))
-                link_to_target = os.path.relpath(target, start=root)
-                os.unlink(link)
-                os.symlink(link_to_target, link)
+    if args.jobs is None:
+        args.jobs = multiprocessing.cpu_count() // 2
+
+    futures, commands, failed_files = [], [], []
+    with ThreadPoolExecutor(max_workers=args.jobs) as executor:
+        for root, dirs, files in os.walk(args.directory):
+            for file in files:
+                futures.append(
+                    (
+                        executor.submit(
+                            patch_prepare,
+                            args,
+                            root,
+                            file,
+                        ),
+                        (root, file),
+                    )
+                )
+        for future, (root, file) in futures:
+            try:
+                command = future.result()
+            except subprocess.CalledProcessError as ex:
+                failed_files.append((root, file, ex))
                 continue
+            commands.extend(command)
 
-            if magic(os.path.join(root, file)) != ELF_MAGIC:
-                continue
+    if failed_files:
+        error_msg = "\n".join([f"{os.path.join(r, f)}" for r, f, _ in failed_files])
+        raise Exception(
+            f"Cannot prepare patchelf command for:\n{error_msg}"
+        ) from failed_files[0][2]
 
-            needed_result = subprocess.run([args.patchelf, '--print-needed', file], cwd=root, capture_output=True)
-            needed_libs = needed_result.stdout.decode('utf-8').strip()
-            if not needed_libs:
-                continue
-
-            rpath_fragments = subprocess.check_output([args.patchelf, '--print-rpath', file], cwd=root).decode('utf-8').strip()
-            rpaths = []
-            for rpath in rpath_fragments.split(':') + DEFAULT_SEARCH_PATHS:
-                if not rpath:
-                    continue
-
-                if '$ORIGIN' in rpath:
-                    rpaths.append(rpath)
-                else:
-                    elf = os.path.join('/', os.path.relpath(root, start=args.directory))
-                    elf_to_rpath = os.path.relpath(rpath, start=elf)
-                    rpaths.append(os.path.join('$ORIGIN', elf_to_rpath))
-
-            rpath = ":".join(rpaths).encode('utf-8')
-            subprocess.check_call([args.patchelf, '--force-rpath', '--set-rpath', rpath, '--no-default-lib', file], cwd=root)
-
-            interpreter_result = subprocess.run([args.patchelf, '--print-interpreter', file], cwd=root, capture_output=True)
-            if interpreter_result.returncode != 0:
-                continue
-
-            interpreter_old = interpreter_result.stdout.decode('utf-8').strip()
-            execution_root = os.path.normpath(os.path.join(args.directory, '..', '..'))
-            interp = os.path.relpath(interpreter_old, start = '/')
-            execution_root_to_interp = os.path.relpath(os.path.join(args.directory, interp), execution_root)
-            subprocess.check_call([args.patchelf, '--set-interpreter', execution_root_to_interp, file], cwd=root)
+    for command, root in commands:
+        subprocess.check_call(command, cwd=root)
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR changes how the `@docker_orfs` is created to speed up the process of changing the ORFS version.

First of all, instead of exporting Docker image to TAR file and extracting it, Docker container is run and files are copied directly from it.

Moreover, `patcher.py` script was parallelized - read-only commands are run in parallel preparing `patchelf` commands updating linking information, which are later on run sequentially.

When updating ORFS version from `v3.0-1114-g46acc762` to `v3.0-1154-gdfcf7c64`, following speedup can be observed:
* without cached image - decrease from 4m to 2m45s,
* with cached image - decrease from 2m30s to 1m30s.