### PR TITLE
Added including logs and reports in the `bazel run` output directory

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -66,7 +66,7 @@ orfs_flow(
         "floorplan": SRAM_FLOOR_PLACE_ARGUMENTS | {
             "CORE_UTILIZATION": "40",
             "CORE_ASPECT_RATIO": "2",
-            "SKIP_REPORT_METRICS": "1"
+            "SKIP_REPORT_METRICS": "1",
         },
         "place": SRAM_FLOOR_PLACE_ARGUMENTS | {
             "SKIP_REPORT_METRICS": "1",

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -414,12 +414,18 @@ def _yosys_impl(ctx, canonicalize, log_names = [], report_names = []):
     for report in report_names:
         reports.append(ctx.actions.declare_file("reports/{}/{}/base/{}".format(_platform(ctx), _module_top(ctx), report)))
 
+    previous_logs = []
+    previous_reports = []
     if canonicalize:
         verilog_files = ctx.files.verilog_files
         rtlil = []
         synth_outputs = [ctx.actions.declare_file(result_dir + "1_synth.rtlil")]
-        previous_logs = []
-        previous_reports = []
+
+        for dep in ctx.attr.deps:
+            if dep[LoggingInfo].logs:
+                previous_logs.extend(dep[LoggingInfo].logs)
+            if dep[LoggingInfo].reports:
+                previous_reports.extend(dep[LoggingInfo].reports)
     else:
         verilog_files = []
         rtlil = [ctx.attr.canonicalized[CanonicalizeInfo].rtlil]
@@ -428,8 +434,8 @@ def _yosys_impl(ctx, canonicalize, log_names = [], report_names = []):
             ctx.actions.declare_file(result_dir + "1_synth.sdc"),
             ctx.actions.declare_file(result_dir + "mem.json"),
         ]
-        previous_logs = ctx.attr.canonicalized[LoggingInfo].logs
-        previous_reports = ctx.attr.canonicalized[LoggingInfo].reports
+        previous_logs.extend(ctx.attr.canonicalized[LoggingInfo].logs)
+        previous_reports.extend(ctx.attr.canonicalized[LoggingInfo].logs)
 
     command = _add_optional_generation_to_command("make $@", logs + reports)
 

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -669,7 +669,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         template = ctx.file._deploy_template,
         output = exe,
         substitutions = {
-            "${GENFILES}": " ".join([f.short_path for f in [config_short] + results + ctx.files.data]),
+            "${GENFILES}": " ".join([f.short_path for f in [config_short] + results + ctx.files.data + logs + reports]),
             "${CONFIG}": config_short.short_path,
             "${MAKE}": make.short_path,
         },
@@ -688,7 +688,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
             ),
             runfiles = ctx.runfiles(
                 [config_short, make, ctx.executable._openroad, ctx.executable._klayout, ctx.file._makefile] +
-                results + ctx.files.data + ctx.files._tcl + ctx.files._opengl + ctx.files._qt_plugins + ctx.files._gio_modules,
+                results + ctx.files.data + ctx.files._tcl + ctx.files._opengl + ctx.files._qt_plugins + ctx.files._gio_modules + logs + reports,
                 transitive_files = depset(transitive = transitive_inputs),
             ),
         ),

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -38,8 +38,8 @@ LoggingInfo = provider(
     "Logs and reports for current and previous stages",
     fields = [
         "logs",
-        "reports"
-    ]
+        "reports",
+    ],
 )
 
 CanonicalizeInfo = provider(
@@ -741,13 +741,25 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         ),
         LoggingInfo(
             logs = logs + previous_logs,
-            reports = reports + previous_reports
+            reports = reports + previous_reports,
         ),
         ctx.attr.src[PdkInfo],
         ctx.attr.src[TopInfo],
     ]
 
-orfs_floorplan = rule(
+def add_orfs_make_rule_(
+        implementation,
+        attrs = openroad_attrs(),
+        provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
+        executable = True):
+    return rule(
+        implementation = implementation,
+        attrs = attrs,
+        provides = provides,
+        executable = executable,
+    )
+
+orfs_floorplan = add_orfs_make_rule_(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "2_floorplan",
@@ -768,12 +780,9 @@ orfs_floorplan = rule(
             "2_floorplan_final.rpt",
         ],
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
-    executable = True,
 )
 
-orfs_place = rule(
+orfs_place = add_orfs_make_rule_(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "3_place",
@@ -791,12 +800,9 @@ orfs_place = rule(
         ],
         report_names = [],
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
-    executable = True,
 )
 
-orfs_cts = rule(
+orfs_cts = add_orfs_make_rule_(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "4_cts",
@@ -812,12 +818,9 @@ orfs_cts = rule(
             "4_cts_final.rpt",
         ],
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
-    executable = True,
 )
 
-orfs_route = rule(
+orfs_route = add_orfs_make_rule_(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "5_route",
@@ -837,12 +840,9 @@ orfs_route = rule(
             "congestion.rpt",
         ],
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
-    executable = True,
 )
 
-orfs_final = rule(
+orfs_final = add_orfs_make_rule_(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "6_final",
@@ -866,9 +866,6 @@ orfs_final = rule(
             "VSS.rpt",
         ],
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
-    executable = True,
 )
 
 def _extensionless_basename(file):
@@ -904,8 +901,6 @@ orfs_deps = rule(
     } | openroad_attrs(),
     executable = True,
 )
-
-
 
 STAGE_IMPLS = [
     struct(stage = "canonicalize", impl = orfs_canonicalize),


### PR DESCRIPTION
This PR introduces LoggingInfo provider, which passes current and previous logs and reports. In addition to that, it includes logs and reports in the build directory, e.g. for command:

```
bazel run //:L1MetadataArray_cts -- `pwd`/build
```

It includes all logs and reports up to built target.