### PR TITLE
eqy: Add `eqy_test` rule for equivalence checking and test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+load("//:eqy.bzl", "eqy_test")
 load("//:openroad.bzl", "orfs_flow", "orfs_run")
 
 # FIXME: this shouldn't be required
@@ -145,4 +146,42 @@ orfs_run(
         "report.yaml",
     ],
     script = ":report.tcl",
+)
+
+orfs_flow(
+    name = "Mul",
+    abstract_stage = "synth",
+    stage_args = {
+        "synth": {
+            "SDC_FILE": "$(location :test/constraints-top.sdc)",
+        },
+    },
+    stage_sources = {
+        "synth": [":test/constraints-top.sdc"],
+    },
+    verilog_files = ["test/rtl/Mul.sv"],
+)
+
+filegroup(
+    name = "Mul_synth_verilog",
+    srcs = [
+        "Mul_synth",
+    ],
+    output_group = "1_synth.v",
+)
+
+eqy_test(
+    name = "Mul_synth_eqy",
+    depth = 2,
+    module_top = "Mul",
+    gold_verilog_files = [
+        "test/rtl/Mul.sv",
+    ],
+    gate_verilog_files = [
+        ":Mul_synth_verilog",
+        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_AO_RVT_TT_201020.v",
+        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_OA_RVT_TT_201020.v",
+        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+    ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,3 +11,13 @@ orfs.default(
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "oss_cad_suite",
+    build_file = "oss_cad_suite.BUILD.bazel",
+    sha256 = "e6434197cd3a31dd90899886b0f4b92ebf1f832eb9abb3a8802e120c2ca5cc73",
+    strip_prefix = "oss-cad-suite",
+    urls = ["https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2024-08-28/oss-cad-suite-linux-x64-20240828.tgz"],
+)

--- a/docker.BUILD.bazel
+++ b/docker.BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel-orfs//:openroad.bzl", "orfs_pdk")
 exports_files(
     glob([
         "OpenROAD-flow-scripts/**/*.tcl",
+        "OpenROAD-flow-scripts/flow/platforms/asap7/work_around_yosys/*.v",
     ]),
     visibility = ["//visibility:public"],
 )

--- a/eqy.bzl
+++ b/eqy.bzl
@@ -1,0 +1,81 @@
+def _eqy_test_impl(ctx):
+    eqy = ctx.actions.declare_file(ctx.attr.name + ".eqy")
+    ctx.actions.expand_template(
+        template = ctx.file._eqy_template,
+        output = eqy,
+        substitutions = {
+            "${DEPTH}": str(ctx.attr.depth),
+            "${GATE}": " ".join([file.short_path for file in ctx.files.gate_verilog_files]),
+            "${GOLD}": " ".join([file.short_path for file in ctx.files.gold_verilog_files]),
+            "${TOP}": ctx.attr.module_top,
+        },
+    )
+
+    script = ctx.actions.declare_file(ctx.attr.name + ".run.sh")
+    ctx.actions.write(script, content = """
+# !/bin/sh
+exec {} "$@" {}
+
+""".format(ctx.executable._eqy.short_path, eqy.short_path), is_executable = True)
+
+    return [
+        DefaultInfo(
+            files = depset([script]),
+            executable = script,
+            runfiles = ctx.runfiles(
+                files =
+                    [eqy, ctx.executable._eqy, ctx.executable._yosys, ctx.executable._yosys_smtbmc] + ctx.files.gate_verilog_files + ctx.files.gold_verilog_files,
+                transitive_files =
+                    depset(transitive = [
+                        ctx.attr._eqy[DefaultInfo].default_runfiles.files,
+                        ctx.attr._eqy[DefaultInfo].default_runfiles.symlinks,
+                        ctx.attr._yosys[DefaultInfo].default_runfiles.files,
+                        ctx.attr._yosys[DefaultInfo].default_runfiles.symlinks,
+                        ctx.attr._yosys_smtbmc[DefaultInfo].default_runfiles.files,
+                        ctx.attr._yosys_smtbmc[DefaultInfo].default_runfiles.symlinks,
+                    ]),
+            ),
+        ),
+    ]
+
+eqy_test = rule(
+    implementation = _eqy_test_impl,
+    attrs = {
+        "gate_verilog_files": attr.label_list(
+            allow_files = True,
+            providers = [DefaultInfo],
+        ),
+        "gold_verilog_files": attr.label_list(
+            allow_files = True,
+            providers = [DefaultInfo],
+        ),
+        "module_top": attr.string(mandatory = True),
+        "depth": attr.int(mandatory = True),
+        "_eqy": attr.label(
+            doc = "Eqy binary.",
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = Label("@oss_cad_suite//:eqy"),
+        ),
+        "_yosys": attr.label(
+            doc = "Yosys binary.",
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = Label("@oss_cad_suite//:yosys"),
+        ),
+        "_yosys_smtbmc": attr.label(
+            doc = "Yosys smtbmc binary.",
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = Label("@oss_cad_suite//:yosys_smtbmc"),
+        ),
+        "_eqy_template": attr.label(
+            default = "eqy.tpl",
+            allow_single_file = True,
+        ),
+    },
+    test = True,
+)

--- a/eqy.tpl
+++ b/eqy.tpl
@@ -1,0 +1,17 @@
+[gold]
+read_verilog -sv ${GOLD}
+prep -top ${TOP}
+memory_map
+
+[gate]
+read_verilog -sv ${GATE}
+prep -top ${TOP}
+memory_map
+
+[collect *]
+
+[strategy sby]
+use sby
+depth ${DEPTH}
+engine smtbmc bitwuzla
+

--- a/oss_cad_suite.BUILD.bazel
+++ b/oss_cad_suite.BUILD.bazel
@@ -1,0 +1,84 @@
+filegroup(
+    name = "tabby",
+    data = glob([
+        "lib/python3.11/**/*.py",
+        "lib/python3.11/**/*.pyc",
+        "lib/python3.11/**/*.so",
+        "lib/ld-linux-x86-64.so.2",
+        "lib/libc.so.6",
+        "lib/libm.so.6",
+        "lib/libpython3.11.so.1.0",
+        "libexec/python3.11",
+    ]),
+    srcs = ["bin/tabbypy3"],
+)
+
+filegroup(
+    name = "bitwuzla",
+    srcs = ["bin/bitwuzla"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "eqy",
+    data = [
+        ":sby",
+        ":tabby",
+        "libexec/eqy",
+        "share/yosys/python3/eqy_job.py",
+        "share/yosys/plugins/eqy_combine.so",
+        "share/yosys/plugins/eqy_partition.so",
+        "share/yosys/plugins/eqy_recode.so",
+    ],
+    srcs = ["bin/eqy"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "sby",
+    data = [
+        ":tabby",
+        "lib/libsqlite3.so.0",
+        "libexec/sby",
+        "share/yosys/python3/sby_autotune.py",
+        "share/yosys/python3/sby_cmdline.py",
+        "share/yosys/python3/sby_core.py",
+        "share/yosys/python3/sby_design.py",
+        "share/yosys/python3/sby_engine_abc.py",
+        "share/yosys/python3/sby_engine_aiger.py",
+        "share/yosys/python3/sby_engine_btor.py",
+        "share/yosys/python3/sby_engine_smtbmc.py",
+        "share/yosys/python3/sby_jobserver.py",
+        "share/yosys/python3/sby_mode_bmc.py",
+        "share/yosys/python3/sby_mode_cover.py",
+        "share/yosys/python3/sby_mode_live.py",
+        "share/yosys/python3/sby_mode_prove.py",
+        "share/yosys/python3/sby_sim.py",
+        "share/yosys/python3/sby_status.py",
+    ],
+    srcs = ["bin/sby"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "yosys",
+    data = glob([
+        "lib/libtcl8.6.so",
+        "lib/libreadline.so.8",
+        "lib/libstdc++.so.6",
+        "libexec/yosys",
+        "share/yosys/**",
+    ]),
+    srcs = ["bin/yosys"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "yosys_smtbmc",
+    data = [
+        ":bitwuzla",
+        "libexec/yosys-smtbmc",
+    ],
+    srcs = ["bin/yosys-smtbmc"],
+    visibility = ["//visibility:public"],
+)

--- a/test/rtl/Mul.sv
+++ b/test/rtl/Mul.sv
@@ -1,0 +1,9 @@
+module Mul(
+  input  [7:0] io_src_0,
+               io_src_1,
+  output [7:0] io_dst
+);
+  assign io_dst = io_src_0 * io_src_1;
+endmodule
+
+


### PR DESCRIPTION
@hovind FYI

```
$ bazel run Mul_synth_eqy
INFO: Analyzed target //:Mul_synth_eqy (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:Mul_synth_eqy up-to-date:
  bazel-bin/Mul_synth_eqy.run.sh
INFO: Elapsed time: 0.213s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh ./Mul_synth_eqy.run.sh
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //:Mul_synth_eqy
-----------------------------------------------------------------------------
EQY 15:47:26 [Mul_synth_eqy] read_gold: starting process "yosys -ql Mul_synth_eqy/gold.log Mul_synth_eqy/gold.ys"
EQY 15:47:26 [Mul_synth_eqy] read_gold: finished (returncode=0)
EQY 15:47:26 [Mul_synth_eqy] read_gate: starting process "yosys -ql Mul_synth_eqy/gate.log Mul_synth_eqy/gate.ys"
EQY 15:47:26 [Mul_synth_eqy] read_gate: finished (returncode=0)
EQY 15:47:26 [Mul_synth_eqy] combine: starting process "yosys -ql Mul_synth_eqy/combine.log Mul_synth_eqy/combine.ys"
EQY 15:47:26 [Mul_synth_eqy] combine: finished (returncode=0)
EQY 15:47:26 [Mul_synth_eqy] partition: starting process "cd Mul_synth_eqy; yosys -ql partition.log partition.ys"
EQY 15:47:26 [Mul_synth_eqy] partition: finished (returncode=0)
EQY 15:47:26 [Mul_synth_eqy] run: starting process "make -C Mul_synth_eqy -f strategies.mk"
EQY 15:47:26 [Mul_synth_eqy] run: make: Entering directory '/home/oyvind/.cache/bazel/_bazel_oyvind/6e078b44989a9ce1500a63165a20fd2a/execroot/_main/bazel-out/k8-fastbuild/bin/Mul_synth_eqy.run.sh.runfiles/_main/Mul_synth_eqy'
EQY 15:47:26 [Mul_synth_eqy] run: Running strategy 'sby' on 'Mul.io_dst'..
EQY 15:47:26 [Mul_synth_eqy] run: Could not prove equivalence of partition 'Mul.io_dst' using strategy 'sby': partitions not equivalent
EQY 15:47:26 [Mul_synth_eqy] run: make -f strategies.mk summary
EQY 15:47:26 [Mul_synth_eqy] run: make[1]: Entering directory '/home/oyvind/.cache/bazel/_bazel_oyvind/6e078b44989a9ce1500a63165a20fd2a/execroot/_main/bazel-out/k8-fastbuild/bin/Mul_synth_eqy.run.sh.runfiles/_main/Mul_synth_eqy'
EQY 15:47:26 [Mul_synth_eqy] run: make[1]: Leaving directory '/home/oyvind/.cache/bazel/_bazel_oyvind/6e078b44989a9ce1500a63165a20fd2a/execroot/_main/bazel-out/k8-fastbuild/bin/Mul_synth_eqy.run.sh.runfiles/_main/Mul_synth_eqy'
EQY 15:47:26 [Mul_synth_eqy] run: make: Leaving directory '/home/oyvind/.cache/bazel/_bazel_oyvind/6e078b44989a9ce1500a63165a20fd2a/execroot/_main/bazel-out/k8-fastbuild/bin/Mul_synth_eqy.run.sh.runfiles/_main/Mul_synth_eqy'
EQY 15:47:26 [Mul_synth_eqy] run: finished (returncode=0)
EQY 15:47:26 [Mul_synth_eqy] Warning: Failed to prove equivalence for 1/1 partitions:
EQY 15:47:26 [Mul_synth_eqy] Failed to prove equivalence of partition Mul.io_dst
EQY 15:47:26 [Mul_synth_eqy] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:00 (0)
EQY 15:47:26 [Mul_synth_eqy] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:00 (0)
EQY 15:47:26 [Mul_synth_eqy] DONE (FAIL, rc=2)
```

