### PR TITLE
Make GRT a separate step

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -92,6 +92,9 @@ orfs_flow(
     },
     verilog_files = ["//another:tag_array_64x184.sv"],
     visibility = [":__subpackages__"],
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )
 
 LB_STAGE_ARGS = {
@@ -117,6 +120,9 @@ orfs_flow(
     stage_args = LB_STAGE_ARGS,
     stage_sources = LB_STAGE_SOURCES,
     verilog_files = LB_VERILOG_FILES,
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )
 
 # buildifier: disable=duplicated-name
@@ -127,6 +133,9 @@ orfs_flow(
     stage_sources = LB_STAGE_SOURCES,
     variant = "test",
     verilog_files = LB_VERILOG_FILES,
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )
 
 orfs_flow(
@@ -153,6 +162,9 @@ orfs_flow(
         "synth": [":test/constraints-top.sdc"],
     },
     verilog_files = ["test/rtl/L1MetadataArray.sv"],
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )
 
 orfs_run(
@@ -176,6 +188,9 @@ orfs_flow(
         "synth": [":test/constraints-top.sdc"],
     },
     verilog_files = ["test/rtl/Mul.sv"],
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )
 
 filegroup(

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ orfs_flow(
         "synth": [":test/constraints-top.sdc"],
     },
     verilog_files = ["test/rtl/L1MetadataArray.sv"],
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,19 @@ Dependency targets:
   //:L1MetadataArray_canonicalize_deps
   //:L1MetadataArray_cts_deps
   //:L1MetadataArray_floorplan_deps
+  //:L1MetadataArray_grt_deps
   //:L1MetadataArray_place_deps
   //:L1MetadataArray_route_deps
   //:L1MetadataArray_synth_deps
 
 Stage targets:
   //:L1MetadataArray_canonicalize
-  //:L1MetadataArray_synth
-  //:L1MetadataArray_floorplan
-  //:L1MetadataArray_place
   //:L1MetadataArray_cts
+  //:L1MetadataArray_floorplan
+  //:L1MetadataArray_grt
+  //:L1MetadataArray_place
   //:L1MetadataArray_route
+  //:L1MetadataArray_synth
 
 Abstract targets:
   //:L1MetadataArray_generate_abstract
@@ -224,6 +226,7 @@ The stages are as follows:
 * `floorplan`
 * `place`
 * `cts` (clock tree synthesis)
+* `grt` (global route)
 * `route`
 * `final`
 
@@ -350,6 +353,7 @@ CLI and GUI is not available for all stages, consequently these targets are crea
 * `floorplan`
 * `place`
 * `cts` (clock tree synthesis)
+* `grt` (global route)
 * `route`
 * `final`
 

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -685,7 +685,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         target of a ctx.attr.srcs list.
     """
     variant = ctx.attr.variant
-    all_arguments = extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.srcs[0][OrfsInfo])
+    all_arguments = extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(*[src[OrfsInfo] for src in ctx.attr.srcs])
     output_dir = "{}/{}/{}".format(_platform(ctx), _module_top(ctx), variant)
     config = ctx.actions.declare_file("results/{}/{}.mk".format(output_dir, stage))
     ctx.actions.write(
@@ -780,7 +780,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
     config_short = ctx.actions.declare_file("results/{}/{}.short.mk".format(output_dir, stage))
     ctx.actions.write(
         output = config_short,
-        content = _config_content(extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.srcs[0][OrfsInfo], short = True)),
+        content = _config_content(extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(short = True, *[src[OrfsInfo] for src in ctx.attr.srcs])),
     )
 
     make = ctx.actions.declare_file("make_{}".format(stage))

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -1063,7 +1063,8 @@ def orfs_flow(
         stage_args = {},
         abstract_stage = None,
         variant = None,
-        visibility = ["//visibility:private"]):
+        visibility = ["//visibility:private"],
+        common_args = {}):
     """
     Creates targets for running physical design flow with OpenROAD-flow-scripts.
 
@@ -1076,6 +1077,7 @@ def orfs_flow(
       abstract_stage: string with physical design flow stage name which controls the name of the files generated in _generate_abstract stage
       variant: name of the target variant, added right after the module name
       visibility: the visibility attribute on a target controls whether the target can be used in other packages
+      common_args: dictionary of arguments that are passed to every stage. They are be overridden by stage_args.
     """
     steps = []
     for step in STAGE_IMPLS:
@@ -1093,7 +1095,7 @@ def orfs_flow(
     synth_step = steps[1]
     canonicalize_step.impl(
         name = name_template.format(name, canonicalize_step.stage),
-        arguments = stage_args.get(synth_step.stage, {}),
+        arguments = common_args | stage_args.get(synth_step.stage, {}),
         data = stage_sources.get(synth_step.stage, []),
         deps = macros,
         module_top = name,
@@ -1108,7 +1110,7 @@ def orfs_flow(
 
     synth_step.impl(
         name = name_template.format(name, synth_step.stage),
-        arguments = stage_args.get(synth_step.stage, {}),
+        arguments = common_args | stage_args.get(synth_step.stage, {}),
         data = stage_sources.get(synth_step.stage, []),
         deps = macros,
         canonicalized = name_template.format(name, canonicalize_step.stage),
@@ -1125,7 +1127,7 @@ def orfs_flow(
         step.impl(
             name = name_template.format(name, step.stage),
             srcs = srcs,
-            arguments = stage_args.get(step.stage, {}),
+            arguments = common_args | stage_args.get(step.stage, {}),
             data = stage_sources.get(step.stage, []),
             variant = variant,
             visibility = visibility,

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -331,7 +331,7 @@ def yosys_only_attrs():
 
 def openroad_only_attrs():
     return {
-        "src": attr.label(
+        "srcs": attr.label_list(
             providers = [DefaultInfo],
         ),
         "_makefile": attr.label(
@@ -389,10 +389,18 @@ def openroad_attrs():
     return flow_attrs() | openroad_only_attrs()
 
 def _module_top(ctx):
-    return ctx.attr.module_top if hasattr(ctx.attr, "module_top") else ctx.attr.src[TopInfo].module_top
+    if hasattr(ctx.attr, "module_top"):
+        return ctx.attr.module_top
+    if hasattr(ctx.attr, "src"):
+        return ctx.attr.src[TopInfo].module_top
+    return ctx.attr.srcs[0][TopInfo].module_top
 
 def _platform(ctx):
-    return ctx.attr.pdk[PdkInfo].name if hasattr(ctx.attr, "pdk") else ctx.attr.src[PdkInfo].name
+    if hasattr(ctx.attr, "pdk"):
+        return ctx.attr.pdk[PdkInfo].name
+    if hasattr(ctx.attr, "src"):
+        return ctx.attr.src[PdkInfo].name
+    return ctx.attr.srcs[0][PdkInfo].name
 
 def _required_arguments(ctx):
     return {
@@ -660,7 +668,7 @@ orfs_synth = rule(
 
 def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_names = [], report_names = [], extra_arguments = {}):
     variant = ctx.attr.variant
-    all_arguments = extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.src[OrfsInfo])
+    all_arguments = extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.srcs[0][OrfsInfo])
     output_dir = "{}/{}/{}".format(_platform(ctx), _module_top(ctx), variant)
     config = ctx.actions.declare_file("results/{}/{}.mk".format(output_dir, stage))
     ctx.actions.write(
@@ -697,14 +705,14 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
     for report in report_names:
         reports.append(ctx.actions.declare_file("reports/{}/{}".format(output_dir, report)))
 
-    previous_logs = ctx.attr.src[LoggingInfo].logs
-    previous_reports = ctx.attr.src[LoggingInfo].reports
+    previous_logs = []
+    previous_reports = []
+
+    for src in ctx.attr.srcs:
+        previous_logs += src[LoggingInfo].logs
+        previous_reports += src[LoggingInfo].reports
 
     transitive_inputs = [
-        ctx.attr.src[OrfsInfo].additional_gds,
-        ctx.attr.src[OrfsInfo].additional_lefs,
-        ctx.attr.src[OrfsInfo].additional_libs,
-        ctx.attr.src[PdkInfo].files,
         ctx.attr._openroad[DefaultInfo].default_runfiles.files,
         ctx.attr._openroad[DefaultInfo].default_runfiles.symlinks,
         ctx.attr._klayout[DefaultInfo].default_runfiles.files,
@@ -714,6 +722,12 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         ctx.attr._make[DefaultInfo].default_runfiles.files,
         ctx.attr._make[DefaultInfo].default_runfiles.symlinks,
     ]
+
+    for src in ctx.attr.srcs:
+        transitive_inputs.append(src[OrfsInfo].additional_gds)
+        transitive_inputs.append(src[OrfsInfo].additional_lefs)
+        transitive_inputs.append(src[OrfsInfo].additional_libs)
+        transitive_inputs.append(src[PdkInfo].files)
 
     for datum in ctx.attr.data:
         transitive_inputs.append(datum.default_runfiles.files)
@@ -735,7 +749,9 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
             "TCL_LIBRARY": commonpath(ctx.files._tcl),
         },
         inputs = depset(
-            ctx.files.src +
+            # 5_2_route stage requires congestion.rpt report
+            (previous_reports if stage == '5_2_route' else []) +
+            ctx.files.srcs +
             ctx.files.data +
             ctx.files._tcl +
             [config, ctx.executable._openroad, ctx.executable._klayout, ctx.file._makefile, ctx.executable._make],
@@ -747,7 +763,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
     config_short = ctx.actions.declare_file("results/{}/{}.short.mk".format(output_dir, stage))
     ctx.actions.write(
         output = config_short,
-        content = _config_content(extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.src[OrfsInfo], short = True)),
+        content = _config_content(extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.srcs[0][OrfsInfo], short = True)),
     )
 
     make = ctx.actions.declare_file("make_{}".format(stage))
@@ -768,16 +784,23 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         },
     )
 
+    additional_gds = []
+    additional_lefs = []
+    additional_libs = []
+
+    for src in ctx.attr.srcs:
+        additional_gds.append(src[OrfsInfo].additional_gds)
+        additional_lefs.append(src[OrfsInfo].additional_lefs)
+        additional_libs.append(src[OrfsInfo].additional_libs)
+
+    transitive_srcs_outs = additional_gds + additional_lefs + additional_libs
+
     return [
         DefaultInfo(
             executable = exe,
             files = depset(
                 results,
-                transitive = [
-                    ctx.attr.src[OrfsInfo].additional_gds,
-                    ctx.attr.src[OrfsInfo].additional_lefs,
-                    ctx.attr.src[OrfsInfo].additional_libs,
-                ],
+                transitive = transitive_srcs_outs,
             ),
             runfiles = ctx.runfiles(
                 [config_short, make, ctx.executable._openroad, ctx.executable._klayout, ctx.file._makefile, ctx.executable._make] +
@@ -787,12 +810,8 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         ),
         OutputGroupInfo(
             deps = depset(
-                [config_short] + ctx.files.src + ctx.files.data,
-                transitive = [
-                    ctx.attr.src[OrfsInfo].additional_gds,
-                    ctx.attr.src[OrfsInfo].additional_lefs,
-                    ctx.attr.src[OrfsInfo].additional_libs,
-                ],
+                [config_short] + ctx.files.srcs + ctx.files.data,
+                transitive = transitive_srcs_outs,
             ),
             logs = depset(logs),
             reports = depset(reports),
@@ -801,10 +820,10 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
         OrfsDepInfo(
             make = make,
             config = config_short,
-            files = [config_short] + ctx.files.src + ctx.files.data,
+            files = [config_short] + ctx.files.srcs + ctx.files.data,
             runfiles = ctx.runfiles(transitive_files = depset(
                 [config_short, make, ctx.executable._openroad, ctx.executable._klayout, ctx.file._makefile, ctx.executable._make] +
-                ctx.files.src + ctx.files.data + ctx.files._tcl + ctx.files._opengl + ctx.files._qt_plugins + ctx.files._gio_modules,
+                ctx.files.srcs + ctx.files.data + ctx.files._tcl + ctx.files._opengl + ctx.files._qt_plugins + ctx.files._gio_modules,
                 transitive = transitive_inputs,
             )),
         ),
@@ -813,16 +832,16 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
             gds = gds,
             lef = lef,
             lib = lib,
-            additional_gds = ctx.attr.src[OrfsInfo].additional_gds,
-            additional_lefs = ctx.attr.src[OrfsInfo].additional_lefs,
-            additional_libs = ctx.attr.src[OrfsInfo].additional_libs,
+            additional_gds = depset(transitive = additional_gds),
+            additional_lefs = depset(transitive = additional_lefs),
+            additional_libs = depset(transitive = additional_libs),
         ),
         LoggingInfo(
             logs = logs + previous_logs,
             reports = reports + previous_reports,
         ),
-        ctx.attr.src[PdkInfo],
-        ctx.attr.src[TopInfo],
+        ctx.attr.srcs[0][PdkInfo],
+        ctx.attr.srcs[0][TopInfo],
     ]
 
 def add_orfs_make_rule_(
@@ -898,26 +917,52 @@ orfs_cts = add_orfs_make_rule_(
     ),
 )
 
+orfs_grt = add_orfs_make_rule_(
+    implementation = lambda ctx: _make_impl(
+        ctx = ctx,
+        stage = "5_1_grt",
+        steps = [
+            "do-5_1_grt",
+        ],
+        result_names = [
+            "5_1_grt.odb"
+        ],
+        log_names = [
+            "5_1_grt.log",
+        ],
+        report_names = [
+            "5_global_route.rpt",
+            "congestion.rpt",
+        ],
+    ),
+    attrs = openroad_attrs(),
+    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, PdkInfo, TopInfo],
+    executable = True,
+)
+
 orfs_route = add_orfs_make_rule_(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
-        stage = "5_route",
-        steps = ["do-route"],
+        stage = "5_2_route",
+        steps = [
+            "do-5_2_fillcell",
+            "do-5_3_route", "do-5_route", "do-5_route.sdc"
+        ],
         result_names = [
             "5_route.odb",
             "5_route.sdc",
         ],
         log_names = [
-            "5_1_grt.log",
             "5_2_fillcell.log",
             "5_3_route.log",
         ],
         report_names = [
             "5_route_drc.rpt",
-            "5_global_route.rpt",
-            "congestion.rpt",
         ],
     ),
+    attrs = openroad_attrs(),
+    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, PdkInfo, TopInfo],
+    executable = True,
 )
 
 orfs_final = add_orfs_make_rule_(
@@ -955,11 +1000,11 @@ orfs_abstract = rule(
         stage = "7_abstract",
         steps = ["do-generate_abstract"],
         result_names = [
-            "{}.lef".format(ctx.attr.src[TopInfo].module_top),
-            "{}.lib".format(ctx.attr.src[TopInfo].module_top),
+            "{}.lef".format(ctx.attr.srcs[0][TopInfo].module_top),
+            "{}.lib".format(ctx.attr.srcs[0][TopInfo].module_top),
         ],
         extra_arguments =
-            {"ABSTRACT_SOURCE": _extensionless_basename(ctx.attr.src[OrfsInfo].odb)},
+            {"ABSTRACT_SOURCE": _extensionless_basename(ctx.attr.srcs[0][OrfsInfo].odb)},
     ),
     attrs = openroad_attrs(),
     provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
@@ -986,6 +1031,7 @@ STAGE_IMPLS = [
     struct(stage = "floorplan", impl = orfs_floorplan),
     struct(stage = "place", impl = orfs_place),
     struct(stage = "cts", impl = orfs_cts),
+    struct(stage = "grt", impl = orfs_grt),
     struct(stage = "route", impl = orfs_route),
     struct(stage = "final", impl = orfs_final),
 ]
@@ -1055,14 +1101,19 @@ def orfs_flow(
     )
 
     for step, prev in zip(steps[2:], steps[1:]):
+        srcs = [name_template.format(name, prev.stage)]
+        if step.stage == 'route':
+            srcs.append(name_template.format(name, "cts"))
+
         step.impl(
             name = name_template.format(name, step.stage),
-            src = name_template.format(name, prev.stage),
+            srcs = srcs,
             arguments = stage_args.get(step.stage, {}),
             data = stage_sources.get(step.stage, []),
             variant = variant,
             visibility = visibility,
         )
+
         orfs_deps(
             name = name_template.format(name, prev.stage) + "_deps",
             src = name_template.format(name, prev.stage),

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -667,6 +667,23 @@ orfs_synth = rule(
 )
 
 def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_names = [], report_names = [], extra_arguments = {}):
+    """
+    Implementation function for the OpenROAD-flow-scripts stages.
+
+    Args:
+      ctx: The context object.
+      stage: The stage name.
+      steps: Makefile targets to run.
+      result_names: The names of the result files.
+      object_names: The names of the object files.
+      log_names: The names of the log files.
+      report_names: The names of the report files.
+      extra_arguments: Extra arguments to add to the configuration.
+
+    Returns:
+        A list of providers. The returned PdkInfo and TopInfo providers are taken from the first
+        target of a ctx.attr.srcs list.
+    """
     variant = ctx.attr.variant
     all_arguments = extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.srcs[0][OrfsInfo])
     output_dir = "{}/{}/{}".format(_platform(ctx), _module_top(ctx), variant)

--- a/subpackage/BUILD
+++ b/subpackage/BUILD
@@ -30,4 +30,7 @@ orfs_flow(
         "synth": ["//:test/constraints-top.sdc"],
     },
     verilog_files = ["//:test/rtl/L1MetadataArray.sv"],
+    common_args = {
+        "GENERATE_ARTIFACTS_ON_FAILURE": "1",
+    },
 )


### PR DESCRIPTION
This PR introduces `grt` as a separate stage from `route`.

Now, stages may have multiple source stages instead of only one. This was needed, as the new `route` stage needs both `congestion.rpt` file, which comes from the `grt` route, and `4_cts.sdc` file, which is produced by a `cts` stage. 

Attaching `before` and `after` outputs produced by:
`bazel query "deps(//:L1MetadataArray_generate_abstract)" --output=graph --noimplicit_deps --notool_deps > graph && xdot graph`

![before](https://github.com/user-attachments/assets/b38905c5-28e0-4b36-a9f3-2f488a738a56)
![after](https://github.com/user-attachments/assets/1a73296c-88f5-4bc6-965e-ec86d632e852)
