### PR TITLE
bazel run: synth/canonicalize nit

### DIFF
--- a/deploy.tpl
+++ b/deploy.tpl
@@ -70,6 +70,10 @@ main() {
   cp --force "$make" "$dst/make"
   cp --force --no-preserve=all "$config" "$dst/config.mk"
 
+  if [[ "$make" == *synth* || "$make" == *canonicalize* ]]; then
+    "$dst/make" yosys-dependencies
+  fi
+
   exit $?
 }
 

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -544,7 +544,7 @@ def _yosys_impl(ctx, canonicalize, log_names = [], report_names = []):
     ctx.actions.expand_template(
         template = ctx.file._make_template,
         output = make,
-        substitutions = flow_substitutions(ctx) | yosys_substitutions(ctx) | {'"$@"': 'WORK_HOME="./{}" DESIGN_CONFIG="config.mk" {} "$@"'.format(ctx.label.package, "yosys-dependencies" if not canonicalize else "")},
+        substitutions = flow_substitutions(ctx) | yosys_substitutions(ctx) | {'"$@"': 'WORK_HOME="./{}" DESIGN_CONFIG="config.mk" "$@"'.format(ctx.label.package)},
     )
 
     exe = ctx.actions.declare_file(ctx.attr.name + ".sh")


### PR DESCRIPTION
yosys-dependencies is now run during bazel run so that e.g. make memory does not first spit out lots of surprising output