### PR TITLE
Fixed _make_impl environment variable configuration

### DIFF
--- a/docker.BUILD.bazel
+++ b/docker.BUILD.bazel
@@ -32,6 +32,12 @@ filegroup(
 )
 
 filegroup(
+    name = "libstdbuf.so",
+    srcs = ["usr/libexec/coreutils/libstdbuf.so"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "openroad",
     data = [
         ":ld.so",
@@ -71,6 +77,7 @@ filegroup(
     name = "klayout",
     data = [
         ":ld.so",
+        ":libstdbuf.so",
     ],
     srcs = ["usr/bin/klayout"],
     visibility = ["//visibility:public"],

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -204,6 +204,44 @@ def commonpath(files):
     path, _, _ = prefix.rpartition("/")
     return path
 
+def preloadwrap(command, library):
+    """
+    Return `command` wrapped in an `LD_PRELOAD` statement.
+
+    Args:
+      command: The command to be wrapped.
+      library: The library to be preloaded.
+
+    Returns:
+      The wrapped command.
+    """
+    return "LD_PRELOAD=" + library + " " + command
+
+def envwrap(command):
+    """
+    Return `command` argument wrapped in an `env -S` statement.
+
+    Args:
+      command: The command to be wrapped.
+
+    Returns:
+      The wrapped command.
+    """
+    return "env -S " + command
+
+def pathatlevel(path, level):
+    """
+    Return `path` argument, `level` directories back.
+
+    Args:
+      path: Path to be prepended.
+      level: The level of the parent directory to go to.
+
+    Returns:
+      The edited path.
+    """
+    return "/".join([".." for _ in range(level)] + [path])
+
 def flow_substitutions(ctx):
     return {
         "${MAKEFILE_PATH}": ctx.file._makefile.path,
@@ -218,6 +256,7 @@ def openroad_substitutions(ctx):
         "${TCL_LIBRARY}": commonpath(ctx.files._tcl),
         "${LIBGL_DRIVERS_PATH}": commonpath(ctx.files._opengl),
         "${QT_PLUGIN_PATH}": commonpath(ctx.files._qt_plugins),
+        "${QT_QPA_PLATFORM_PLUGIN_PATH}": commonpath(ctx.files._qt_plugins),
         "${GIO_MODULE_DIR}": commonpath(ctx.files._gio_modules),
     }
 
@@ -264,6 +303,10 @@ def flow_attrs():
         "_make_template": attr.label(
             default = ":make.tpl",
             allow_single_file = True,
+        ),
+        "_libstdbuf": attr.label(
+            allow_single_file = ["libstdbuf.so"],
+            default = Label("@docker_orfs//:libstdbuf.so"),
         ),
     }
 
@@ -684,8 +727,10 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
             "DESIGN_CONFIG": config.path,
             "FLOW_HOME": ctx.file._makefile.dirname,
             "OPENROAD_EXE": ctx.executable._openroad.path,
-            "KLAYOUT_CMD": ctx.executable._klayout.path,
+            "KLAYOUT_CMD": envwrap(preloadwrap(ctx.executable._klayout.path, ctx.file._libstdbuf.path)),
             "TCL_LIBRARY": commonpath(ctx.files._tcl),
+            "QT_QPA_PLATFORM_PLUGIN_PATH": pathatlevel(commonpath(ctx.files._qt_plugins), 5),
+            "QT_PLUGIN_PATH": commonpath(ctx.files._qt_plugins),
         },
         inputs = depset(
             ctx.files.src +


### PR DESCRIPTION
This PR addresses issues regarding missing definitions for `QT_QPA_PLATFORM_PATH` in the environment and a malformed link to `libstdbuf.so` in `klayout`.

The error logs for those problems:
```
[WARNING GUI-0076] Could not find the Qt platform plugin "offscreen" in ""
```
```
external/bazel-orfs~~orfs_repositories~docker_orfs/usr/bin/klayout: /home/jbylicki/.cache/bazel/_bazel_jbylicki/1cb0e4ab858bdcd626912cbee0441148/external/bazel-orfs~~orfs_repositories~docker_orfs/usr/bin/../lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_ABI_DT_RELR' not found (required by /usr/lib/coreutils/libstdbuf.so)
external/bazel-orfs~~orfs_repositories~docker_orfs/usr/bin/klayout: /home/jbylicki/.cache/bazel/_bazel_jbylicki/1cb0e4ab858bdcd626912cbee0441148/external/bazel-orfs~~orfs_repositories~docker_orfs/usr/bin/../lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/lib/coreutils/libstdbuf.so)
```

 