### PR TITLE
Fixed out-of-sandbox library access path

### DIFF
--- a/docker.BUILD.bazel
+++ b/docker.BUILD.bazel
@@ -41,6 +41,7 @@ filegroup(
     name = "openroad",
     data = [
         ":ld.so",
+        ":qt_plugins",
     ],
     srcs = ["OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad"],
     visibility = ["//visibility:public"],

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -243,19 +243,6 @@ def envwrap(command):
     """
     return "env -S " + command
 
-def pathatlevel(path, level):
-    """
-    Return `path` argument, `level` directories back.
-
-    Args:
-      path: Path to be prepended.
-      level: The level of the parent directory to go to.
-
-    Returns:
-      The edited path.
-    """
-    return "/".join([".." for _ in range(level)] + [path])
-
 def flow_substitutions(ctx):
     return {
         "${MAKE_PATH}": ctx.executable._make.path,
@@ -273,7 +260,6 @@ def openroad_substitutions(ctx):
         "${TCL_LIBRARY}": commonpath(ctx.files._tcl),
         "${LIBGL_DRIVERS_PATH}": commonpath(ctx.files._opengl),
         "${QT_PLUGIN_PATH}": commonpath(ctx.files._qt_plugins),
-        "${QT_QPA_PLATFORM_PLUGIN_PATH}": commonpath(ctx.files._qt_plugins),
         "${GIO_MODULE_DIR}": commonpath(ctx.files._gio_modules),
     }
 
@@ -814,7 +800,7 @@ def _make_impl(ctx, stage, steps, result_names = [], object_names = [], log_name
             "OPENROAD_EXE": ctx.executable._openroad.path,
             "KLAYOUT_CMD": envwrap(preloadwrap(ctx.executable._klayout.path, ctx.file._libstdbuf.path)),
             "TCL_LIBRARY": commonpath(ctx.files._tcl),
-            "QT_QPA_PLATFORM_PLUGIN_PATH": pathatlevel(commonpath(ctx.files._qt_plugins), 5),
+            "QT_QPA_PLATFORM_PLUGIN_PATH": commonpath(ctx.files._qt_plugins),
             "QT_PLUGIN_PATH": commonpath(ctx.files._qt_plugins),
         },
         inputs = depset(


### PR DESCRIPTION
This is a follow-up to the merged draft PR https://github.com/The-OpenROAD-Project/bazel-orfs/pull/131 that fixes the issues regarding `QT_QPA_PLATFORM_PATH`. It adds `qt_plugins` dependency and fixes the path to the library (uses `commonpath(ctx.files._qt_plugins)`)