### PR TITLE
Migrate tests from megaboom to bazel-orfs

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -3,29 +3,49 @@
 set -e
 
 target_name=${TARGET:-"tag_array_64x184"}
-flow=${FLOW:-"local_make"}
 if [[ -z "$STAGES" ]]; then
-  if [[ "$target_name" == L1MetadataArray_* ]]; then
-    STAGES=("synth_sdc" "synth" "floorplan" "place" "generate_abstract")
-  else
-    STAGES=("synth_sdc" "synth" "floorplan" "generate_abstract")
-  fi
+  STAGES=("synth" "floorplan" "place" "cts" "grt" "route")
 else
   eval "STAGES=($STAGES)"
 fi
 
-echo "Build tag_array_64x184 macro"
-for stage in ${STAGES[@]}
+echo "Build ${target_name} macro"
+for stage in "${STAGES[@]}"
 do
   if [[ -z $SKIP_BUILD ]] ; then
-    echo "query make script target"
-    bazel query ${target_name}_${stage}_scripts
-    bazel query ${target_name}_${stage}_scripts --output=build
-    echo "build make script"
-    bazel build --subcommands --verbose_failures --sandbox_debug ${target_name}_${stage}_scripts
+    echo "[${target_name}] ${stage}: Query dependency target"
+    bazel query "${target_name}_${stage}_deps"
+    bazel query "${target_name}_${stage}_deps" --output=build
+    echo "[${target_name}] ${stage}: Build dependency"
+    bazel run --subcommands --verbose_failures --sandbox_debug "${target_name}_${stage}_deps" -- "$(pwd)/build"
   fi
   if [[ -z $SKIP_RUN ]] ; then
-    echo "run make script"
-    ./bazel-bin/${target_name}_${stage}_${flow} bazel-${stage}
+    stages=()
+    if [[ $stage == "synth" ]]; then
+        stages+=("do-yosys-canonicalize")
+        stages+=("do-yosys-keep-hierarchy")
+        stages+=("do-yosys")
+        stages+=("do-synth")
+    elif [[ $stage == "grt" ]]; then
+        stages+=("do-5_1_grt")
+    elif [[ $stage == "route" ]]; then
+        stages+=("do-5_2_fillcell")
+        stages+=("do-5_3_route")
+    else
+        stages+=("do-${stage}")
+    fi
+    for local_stage in "${stages[@]}"
+    do
+        echo "[${target_name}] ${local_stage}: Run make script"
+        build/make "${local_stage}"
+    done
   fi
 done
+
+if [[ -z $SKIP_BUILD && -z $SKIP_ABSTRACT ]]; then
+    echo "query abstract target"
+    bazel query "${target_name}_generate_abstract"
+    bazel query "${target_name}_generate_abstract" --output=build
+    echo "build abstract"
+    bazel build --subcommands --verbose_failures --sandbox_debug "${target_name}_generate_abstract"
+fi

--- a/.github/scripts/extract_docker_revision.py
+++ b/.github/scripts/extract_docker_revision.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+import sys
+from typing import Optional
+
+
+def find_docker_orfs(data: dict) -> Optional[dict]:
+    """
+    Recursively search for the 'docker_orfs' configuration in
+    the provided JSON data.
+
+    Parameters
+    ----------
+    data : dict
+        The JSON data to search for the 'docker_orfs' configuration.
+
+    Returns
+    -------
+    Optional[dict]
+        The 'docker_orfs' configuration if found, otherwise None.
+    """
+    if isinstance(data, dict):
+        if 'docker_orfs' in data:
+            return data['docker_orfs']
+        for key, value in data.items():
+            result = find_docker_orfs(value)
+            if result:
+                return result
+    elif isinstance(data, list):
+        for item in data:
+            result = find_docker_orfs(item)
+            if result:
+                return result
+    return None
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or not Path(sys.argv[1]).exists():
+        print(f"Usage: {sys.argv[0]} <MODULE.bazel>")
+        exit(1)
+
+    with open(sys.argv[1], 'r') as file:
+        try:
+            data = json.load(file)
+        except json.JSONDecodeError:
+            print(f"Unable to parse JSON data from {sys.argv[1]}")
+            exit(1)
+
+        docker_orfs = find_docker_orfs(data)
+        if docker_orfs is None or docker_orfs.get('attributes', None) is None:
+            print("Unable to find 'docker_orfs' configuration in the provided file")    # noqa: E501
+            exit(1)
+
+    docker_tag = docker_orfs.get('attributes').get('image', None)
+    docker_sha256 = docker_orfs.get('attributes').get('sha256', None)
+
+    if docker_tag is None or docker_sha256 is None:
+        print("Unable to find correct Docker tag or SHA256 in the provided file.")
+        print(f"Obtained Docker tag: {docker_tag}")
+        print(f"Obtained Docker SHA256: {docker_sha256}")
+        exit(1)
+
+    print(json.dumps({
+            'image': f"{docker_tag}@sha256:{docker_sha256}",
+            'tag': docker_tag,
+            'sha256': docker_sha256
+    }))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
           - "lb_32x128_generate_abstract"
           - "lb_32x128_test_generate_abstract"
           - "L1MetadataArray_generate_abstract"
+          - "data_2048x8_generate_abstract"
+          - "regfile_128x65_floorplan"
           - "subpackage:L1MetadataArray_generate_abstract"
+          - "subpackage:tag_array_64x184_generate_abstract"
     env:
       DEBIAN_FRONTEND: "noninteractive"
     steps:
@@ -61,6 +64,38 @@ jobs:
         run: |
           bazel query ${{ matrix.STAGE_TARGET }}
           bazel query ${{ matrix.STAGE_TARGET }} --output=build
-      - name: build target
+      - name: Build report
+        if: ${{ endsWith(matrix.STAGE_TARGET, '_report') }}
         run: |
           bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+      - name: Run target
+        if: ${{ !endsWith(matrix.STAGE_TARGET, '_report') }}
+        run: |
+          bazel run --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }} -- `pwd`/build
+
+
+  test-target-local:
+    name: Local flow - test targets
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+    steps:
+      - name: Print info
+        run: |
+          echo "USER: "$(whoami)
+          echo "PWD: "$(pwd)
+          echo "HOME: "$HOME
+          ls -la
+      - name: Checkout bazel-orfs
+        uses: actions/checkout@v4
+      - name: Build local stage targets - tag_array_64x184
+        env:
+          TARGET: tag_array_64x184
+        run: .github/scripts/build_local_target.sh
+      - name: Build local stage targets - L1MetadataArray
+        env:
+          TARGET: L1MetadataArray
+        run: .github/scripts/build_local_target.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
           bazel run --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }} -- `pwd`/build
 
 
-  test-target-local:
-    name: Local flow - test targets
+  test-target-local-clean-setup:
+    name: Local flow - clean setup
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -89,6 +89,61 @@ jobs:
           echo "PWD: "$(pwd)
           echo "HOME: "$HOME
           ls -la
+      - name: Checkout bazel-orfs
+        uses: actions/checkout@v4
+      - name: Build local stage targets - tag_array_64x184
+        env:
+          TARGET: tag_array_64x184
+        run: .github/scripts/build_local_target.sh
+      - name: Build local stage targets - L1MetadataArray
+        env:
+          TARGET: L1MetadataArray
+        run: .github/scripts/build_local_target.sh
+
+  generate-config:
+    name: Generate configs
+    runs-on: ubuntu-22.04
+    outputs:
+      docker-tag: ${{ steps.docker-image.outputs.docker-orfs }}
+    steps:
+      - name: Checkout bazel-orfs
+        uses: actions/checkout@v4
+      - name: Lint Bazel files
+        run: bazel mod tidy && git diff --exit-code
+      - name: Extract Docker tag
+        id: docker-image
+        run: |
+          revision=$(python3 .github/scripts/extract_docker_revision.py MODULE.bazel.lock)
+          echo "docker-orfs=$revision" | tee -a $GITHUB_OUTPUT
+
+  test-target-local-preinstalled-orfs:
+    name: Local flow - preinstalled orfs
+    runs-on: ubuntu-22.04
+    needs: generate-config
+    container:
+      image: ${{ fromJSON(needs.generate-config.outputs.docker-tag).image }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+      FLOW_HOME: /OpenROAD-flow-scripts/flow
+    steps:
+      - name: Print info and setup orfs
+        run: |
+          echo "USER: "$(whoami)
+          echo "PWD: "$(pwd)
+          echo "HOME: "$HOME
+          ls -la
+          cd /OpenROAD-flow-scripts
+          echo "OpenROAD-flow-scripts SHA: "$(git rev-parse HEAD)
+          source ./env.sh
+          yosys --version
+          openroad -version
+      - name: Install bazelisk as bazel
+        run: |
+          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel
+          chmod +x /usr/local/bin/bazel
       - name: Checkout bazel-orfs
         uses: actions/checkout@v4
       - name: Build local stage targets - tag_array_64x184

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,6 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           swap-storage: false
-      - name: Print info
-        run: |
-          echo "USER: "$(whoami)
-          echo "PWD: "$(pwd)
-          echo "HOME: "$HOME
-          ls -la
       - name: Checkout bazel-orfs
         uses: actions/checkout@v4
       - name: query target
@@ -83,12 +77,6 @@ jobs:
     env:
       DEBIAN_FRONTEND: "noninteractive"
     steps:
-      - name: Print info
-        run: |
-          echo "USER: "$(whoami)
-          echo "PWD: "$(pwd)
-          echo "HOME: "$HOME
-          ls -la
       - name: Checkout bazel-orfs
         uses: actions/checkout@v4
       - name: Build local stage targets - tag_array_64x184
@@ -129,12 +117,8 @@ jobs:
       DEBIAN_FRONTEND: "noninteractive"
       FLOW_HOME: /OpenROAD-flow-scripts/flow
     steps:
-      - name: Print info and setup orfs
+      - name: orfs setup
         run: |
-          echo "USER: "$(whoami)
-          echo "PWD: "$(pwd)
-          echo "HOME: "$HOME
-          ls -la
           cd /OpenROAD-flow-scripts
           echo "OpenROAD-flow-scripts SHA: "$(git rev-parse HEAD)
           source ./env.sh

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -63,7 +63,7 @@
   "moduleExtensions": {
     "//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "QBi+YhISAjw4QqUAPLtPaFfw3mWHftL+XC6x62hMv+o=",
+        "bzlTransitiveDigest": "6eEoCMP8ko4O/UCrzah7mGNTdhQAn0hHrFEu7ZNU5yg=",
         "usagesDigest": "xj7wfEDEDE8caOhOA7RBoXV50uID99H6X81CEPNP/rI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/subpackage/BUILD
+++ b/subpackage/BUILD
@@ -31,3 +31,30 @@ orfs_flow(
     },
     verilog_files = ["//:test/rtl/L1MetadataArray.sv"],
 )
+
+
+orfs_flow(
+    name = "tag_array_64x184",
+    abstract_stage = "floorplan",
+    stage_args = {
+        "synth": {
+            "SYNTH_MEMORY_MAX_BITS": "12000",
+            "SDC_FILE": "$(location //:constraints-sram)",
+        },
+        "floorplan": {
+            "CORE_UTILIZATION": "40",
+            "CORE_ASPECT_RATIO": "2",
+            "IO_CONSTRAINTS": "$(location //:io-sram)",
+        },
+        "place": {
+            "PLACE_DENSITY": "0.65",
+            "IO_CONSTRAINTS": "$(location //:io-sram)",
+        },
+    },
+    stage_sources = {
+        "synth": ["//:constraints-sram"],
+        "floorplan": ["//:io-sram"],
+        "place": ["//:io-sram"],
+    },
+    verilog_files = ["//:test/rtl/tag_array_64x184.sv"],
+)

--- a/test/rtl/data_2048x8.sv
+++ b/test/rtl/data_2048x8.sv
@@ -1,0 +1,55 @@
+// Standard header to adapt well known macros for prints and assertions.
+
+// Users can define 'ASSERT_VERBOSE_COND' to add an extra gate to assert error printing.
+`ifndef ASSERT_VERBOSE_COND_
+  `ifdef ASSERT_VERBOSE_COND
+    `define ASSERT_VERBOSE_COND_ (`ASSERT_VERBOSE_COND)
+  `else  // ASSERT_VERBOSE_COND
+    `define ASSERT_VERBOSE_COND_ 1
+  `endif // ASSERT_VERBOSE_COND
+`endif // not def ASSERT_VERBOSE_COND_
+
+// Users can define 'STOP_COND' to add an extra gate to stop conditions.
+`ifndef STOP_COND_
+  `ifdef STOP_COND
+    `define STOP_COND_ (`STOP_COND)
+  `else  // STOP_COND
+    `define STOP_COND_ 1
+  `endif // STOP_COND
+`endif // not def STOP_COND_
+
+// VCS coverage exclude_file
+module data_2048x8(
+  input  [10:0] R0_addr,
+  input         R0_en,
+                R0_clk,
+  output [7:0]  R0_data,
+  input  [10:0] W0_addr,
+  input         W0_en,
+                W0_clk,
+  input  [7:0]  W0_data,
+  input  [3:0]  W0_mask
+);
+
+  reg [7:0]  Memory[0:3];  // Reduced to 4 rows
+  reg        _R0_en_d0;
+  reg [1:0]  _R0_addr_d0;  // Reduced to 2 bits
+  reg [1:0]  _W0_addr_d0;  // Reduced to 2 bits
+  always @(posedge R0_clk) begin
+    _R0_en_d0 <= R0_en;
+    _R0_addr_d0 <= R0_addr[1:0] ^ R0_addr[5:4] ^ R0_addr[9:8];  // XOR upper and lower bits
+  end // always @(posedge)
+  always @(posedge W0_clk) begin
+    _W0_addr_d0 <= W0_addr[1:0] ^ W0_addr[5:4] ^ W0_addr[9:8];  // XOR upper and lower bits
+    if (W0_en & W0_mask[0])
+      Memory[_W0_addr_d0][32'h0 +: 2] <= W0_data[1:0];
+    if (W0_en & W0_mask[1])
+      Memory[_W0_addr_d0][32'h2 +: 2] <= W0_data[3:2];
+    if (W0_en & W0_mask[2])
+      Memory[_W0_addr_d0][32'h4 +: 2] <= W0_data[5:4];
+    if (W0_en & W0_mask[3])
+      Memory[_W0_addr_d0][32'h6 +: 2] <= W0_data[7:6];
+  end // always @(posedge)
+  assign R0_data = _R0_en_d0 ? Memory[_R0_addr_d0] : 8'bx;
+endmodule
+

--- a/test/rtl/regfile_128x65.sv
+++ b/test/rtl/regfile_128x65.sv
@@ -1,0 +1,75 @@
+// Standard header to adapt well known macros to our needs.
+
+// Users can define 'PRINTF_COND' to add an extra gate to prints.
+`ifndef PRINTF_COND_
+  `ifdef PRINTF_COND
+    `define PRINTF_COND_ (`PRINTF_COND)
+  `else  // PRINTF_COND
+    `define PRINTF_COND_ 1
+  `endif // PRINTF_COND
+`endif // not def PRINTF_COND_
+
+// VCS coverage exclude_file
+module regfile_128x65(
+  input  [6:0]  R0_addr,
+  input         R0_en,
+                R0_clk,
+  input  [6:0]  R1_addr,
+  input         R1_en,
+                R1_clk,
+  input  [6:0]  R2_addr,
+  input         R2_en,
+                R2_clk,
+  input  [6:0]  R3_addr,
+  input         R3_en,
+                R3_clk,
+  input  [6:0]  R4_addr,
+  input         R4_en,
+                R4_clk,
+  input  [6:0]  R5_addr,
+  input         R5_en,
+                R5_clk,
+  input  [6:0]  W0_addr,
+  input         W0_en,
+                W0_clk,
+  input  [64:0] W0_data,
+  input  [6:0]  W1_addr,
+  input         W1_en,
+                W1_clk,
+  input  [64:0] W1_data,
+  input  [6:0]  W2_addr,
+  input         W2_en,
+                W2_clk,
+  input  [64:0] W2_data,
+  input  [6:0]  W3_addr,
+  input         W3_en,
+                W3_clk,
+  input  [64:0] W3_data,
+  output [64:0] R0_data,
+                R1_data,
+                R2_data,
+                R3_data,
+                R4_data,
+                R5_data
+);
+
+  reg [64:0] Memory[0:15];
+  always @(posedge W0_clk) begin
+    if (W0_en)
+      Memory[W0_addr[3:0] ^ W0_addr[7:4]] <= W0_data;
+    if (W1_en)
+      Memory[W1_addr[3:0] ^ W1_addr[7:4]] <= W1_data;
+    if (W2_en)
+      Memory[W2_addr[3:0] ^ W2_addr[7:4]] <= W2_data;
+    if (W3_en)
+      Memory[W3_addr[3:0] ^ W3_addr[7:4]] <= W3_data;
+  end // always @(posedge)
+
+  assign R0_data = R0_en ? Memory[R0_addr[3:0] ^ R0_addr[7:4]] : 65'bx;
+  assign R1_data = R1_en ? Memory[R1_addr[3:0] ^ R1_addr[7:4]] : 65'bx;
+  assign R2_data = R2_en ? Memory[R2_addr[3:0] ^ R2_addr[7:4]] : 65'bx;
+  assign R3_data = R3_en ? Memory[R3_addr[3:0] ^ R3_addr[7:4]] : 65'bx;
+  assign R4_data = R4_en ? Memory[R4_addr[3:0] ^ R4_addr[7:4]] : 65'bx;
+  assign R5_data = R5_en ? Memory[R5_addr[3:0] ^ R5_addr[7:4]] : 65'bx;
+endmodule
+


### PR DESCRIPTION
This PR adds multiple tests, which come from Megaboom CI. To be more precise, moved are:
- `data_2048x8_generate_abstract` and `regfile_128x65_floorplan` targets. That includes their rules and source files.
- test subpackage `subpackage:tag_array_64x184_generate_abstract`
- `test-target-local-preinstalled-orfs` and `test-target-local-clean-setup` jobs, which test local flows. One is run in a docker container with openroad and yosys prebuilt, and the other one copies the binaries from a container. Both tests make use of a `build_local_target.sh` script, which runs and builds all steps of a given flow.