### PR TITLE
Reintroduce `mock_area` feature

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -64,9 +64,9 @@ BLOCK_FLOORPLAN = {
 orfs_flow(
     name = "tag_array_64x184",
     args = SRAM_SYNTH_ARGUMENTS | SRAM_FLOOR_PLACE_ARGUMENTS | {
-            "CORE_UTILIZATION": "40",
-            "CORE_ASPECT_RATIO": "2",
-            "SKIP_REPORT_METRICS": "1",
+        "CORE_UTILIZATION": "40",
+        "CORE_ASPECT_RATIO": "2",
+        "SKIP_REPORT_METRICS": "1",
     },
     stage_sources = {
         "synth": [":constraints-sram"],
@@ -77,13 +77,10 @@ orfs_flow(
     visibility = [":__subpackages__"],
 )
 
-LB_STAGE_ARGS = {
-    "synth": SRAM_SYNTH_ARGUMENTS,
-    "floorplan": SRAM_FLOOR_PLACE_ARGUMENTS | {
-        "CORE_UTILIZATION": "40",
-        "CORE_ASPECT_RATIO": "2",
-    },
-    "place": SRAM_FLOOR_PLACE_ARGUMENTS | {"PLACE_DENSITY": "0.65"},
+LB_ARGS = SRAM_SYNTH_ARGUMENTS | SRAM_FLOOR_PLACE_ARGUMENTS | {
+    "CORE_UTILIZATION": "40",
+    "CORE_ASPECT_RATIO": "2",
+    "PLACE_DENSITY": "0.65",
 }
 
 LB_STAGE_SOURCES = {
@@ -97,7 +94,8 @@ LB_VERILOG_FILES = ["test/rtl/lb_32x128.sv"]
 orfs_flow(
     name = "lb_32x128",
     abstract_stage = "floorplan",
-    stage_args = LB_STAGE_ARGS,
+    mock_area = 1.0,
+    args = LB_ARGS,
     stage_sources = LB_STAGE_SOURCES,
     verilog_files = LB_VERILOG_FILES,
 )
@@ -106,7 +104,7 @@ orfs_flow(
 orfs_flow(
     name = "lb_32x128",
     abstract_stage = "place",
-    stage_args = LB_STAGE_ARGS,
+    args = LB_ARGS,
     stage_sources = LB_STAGE_SOURCES,
     variant = "test",
     verilog_files = LB_VERILOG_FILES,

--- a/make.tpl
+++ b/make.tpl
@@ -24,4 +24,7 @@ else
   fi
   export MAKE_PATH="$(command -v make)"
 fi
+if [[ -f "${EXTRA_ENVS}" ]]; then
+  source "${EXTRA_ENVS}"
+fi
 exec $MAKE_PATH --file "$FLOW_HOME/Makefile" "$@"

--- a/mock_area.tcl
+++ b/mock_area.tcl
@@ -1,12 +1,22 @@
-read_db $::env(RESULTS_DIR)/../base/2_floorplan.odb
+proc tee {file content} {
+	puts $content
+	puts $file $content
+}
+
+set out_file [lindex [split $::env(OUTPUTS) ":"] 0]
+
+read_db $::env(RESULTS_DIR)/2_floorplan.odb
 set db [::ord::get_db]
 set dbu_per_uu [expr double([[$db getTech] getDbUnitsPerMicron])]
 set block [[$db getChip] getBlock]
 set die_bbox [$block getDieArea]
 set core_bbox [$block getCoreArea]
 set scale [expr $::env(MOCK_AREA) / $dbu_per_uu]
-#set scale [expr 0.5 / $dbu_per_uu]
-puts "export DIE_AREA=\"0 0 [expr $scale*[$die_bbox xMax]] [expr $scale*[$die_bbox yMax]]\""
-puts "export CORE_AREA=\"[expr $scale*[$core_bbox xMin]] [expr $scale*[$core_bbox yMin]] \
+
+set file [open $out_file w]
+tee $file "export DIE_AREA=\"0 0 [expr $scale*[$die_bbox xMax]] [expr $scale*[$die_bbox yMax]]\""
+tee $file "export CORE_AREA=\"[expr $scale*[$core_bbox xMin]] [expr $scale*[$core_bbox yMin]] \
 [expr $scale*([$die_bbox xMax] - ([$die_bbox xMax] - [$core_bbox xMax]))] \
 [expr $scale*([$die_bbox yMax] - ([$die_bbox yMax] - [$core_bbox yMax]))]\""
+tee $file "export CORE_UTILIZATION="
+close $file


### PR DESCRIPTION
This PR reintroduces `mock_area` feature: creating additional mock area targets, which scale `CORE_AREA` and `DIE_AREA`, and use them to run floorplan and generate_abstract.

This PR also contains some minor README cleanup, like removing information about canonicalize targets.