### PR TITLE
synth: build/make gui_synth fix

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -393,7 +393,8 @@ def yosys_substitutions(ctx):
     return {
         "${MAKE_PATH}": ctx.executable._make.path,
         "${YOSYS_PATH}": ctx.executable._yosys.path,
-        "${OPENROAD_PATH}": "",
+        # FIXME only needed for build/make gui_synth
+        "${OPENROAD_PATH}": ctx.executable._openroad.path,
     }
 
 default_substitutions = {
@@ -476,6 +477,14 @@ def yosys_only_attrs():
             allow_files = True,
             cfg = "exec",
             default = Label("@docker_orfs//:yosys-abc"),
+        ),
+        # FIXME only needed for build/make gui_synth
+        "_openroad": attr.label(
+            doc = "OpenROAD binary.",
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = Label("@docker_orfs//:openroad"),
         ),
         "_yosys": attr.label(
             doc = "Yosys binary.",
@@ -636,7 +645,8 @@ def _yosys_env(ctx, config):
     return _default_env(ctx, config) | {
         "ABC": ctx.executable._abc.path,
         "YOSYS_EXE": ctx.executable._yosys.path,
-        "OPENROAD_EXE": "",
+        # FIXME only needed for make/gui_synth, not for building
+        "OPENROAD_EXE": ctx.executable._openroad.path,
         "TCL_LIBRARY": commonpath(ctx.files._tcl),
     }
 
@@ -686,6 +696,7 @@ def _yosys_impl(ctx):
             [
                 config,
                 ctx.executable._abc,
+                ctx.executable._openroad,
                 ctx.executable._yosys,
                 ctx.executable._make,
                 ctx.file._makefile,
@@ -717,6 +728,7 @@ def _yosys_impl(ctx):
                 config,
                 ctx.executable._abc,
                 ctx.executable._yosys,
+                ctx.executable._openroad,
                 ctx.executable._make,
                 ctx.file._makefile,
             ],
@@ -758,7 +770,7 @@ def _yosys_impl(ctx):
                 [dep[OrfsInfo].lib for dep in ctx.attr.deps if dep[OrfsInfo].lib],
             ),
             runfiles = ctx.runfiles(
-                synth_outputs + canon_logs + synth_logs + [canon_output, config_short, make, ctx.executable._yosys, ctx.executable._make, ctx.file._makefile] +
+                synth_outputs + canon_logs + synth_logs + [canon_output, config_short, make, ctx.executable._yosys, ctx.executable._openroad, ctx.executable._make, ctx.file._makefile] +
                 ctx.files.verilog_files + ctx.files.data + ctx.files._tcl,
                 transitive_files = depset(transitive = transitive_inputs),
             ),


### PR DESCRIPTION
Fixes the use-case below, but adds a openroad dependency to synthesis stage, which we don't want.

```
$ bazel run //sram:top_fakeram_synth `pwd`/build
INFO: Invocation ID: e4503934-006a-48df-9122-93d487b05d85
INFO: Analyzed target //sram:top_fakeram_synth (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //sram:top_fakeram_synth up-to-date:
  bazel-bin/sram/results/asap7/top/fakeram/1_synth.v
  bazel-bin/sram/results/asap7/top/fakeram/1_synth.sdc
  bazel-bin/sram/results/asap7/top/fakeram/mem.json
  bazel-bin/sram/results/asap7/top/fakeram/1_synth.rtlil
INFO: Elapsed time: 0.050s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/sram/top_fakeram_synth.sh /home/oyvind/bazel-orfs/build
make: Nothing to be done for 'yosys-dependencies'.
$ build/make open_synth
external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -no_init -threads 16   external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/scripts/sta-synth.tcl
OpenROAD HEAD-HASH-NOTFOUND 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 16 thread(s).
[INFO ODB-0227] LEF file: external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/platforms/asap7/lef/asap7_tech_1x_201209.lef, created 24 layers, 9 vias
[INFO ODB-0227] LEF file: external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/platforms/asap7/lef/asap7sc7p5t_28_R_1x_220121a.lef, created 212 library cells
[INFO ODB-0227] LEF file: sram/fakeram/sdq_17x64.lef, created 1 library cells
The design is gutted when mocking floorplan
openroad> report_clock_properties
Clock                   Period          Waveform
----------------------------------------------------
openroad> 
```
