### PR TITLE
sram: fix fakeram clock problem

### DIFF
--- a/sram/fakeram/sdq_17x64.lib
+++ b/sram/fakeram/sdq_17x64.lib
@@ -1565,7 +1565,7 @@ library (sdq_17x64) {
       timing () {
         related_pin : "clk";
         timing_sense : positive_unate;
-        timing_type : combinational;
+        timing_type : rising_edge;
         cell_rise (delay_template_7x7_x1) {
           index_1 ("5, 10, 20, 40, 80, 160, 320");
           index_2 ("5.76, 11.52, 23.04, 46.08, 92.16, 184.32, 368.64");


### PR DESCRIPTION
@jeffng-or @maliberty To view results:

```
bazel run //sram:top_fakeram_grt `pwd`/build
build/make gui_grt
```


in2reg 9.49+32.10=41.59ps
reg2out=633.21ps

633.21ps for a 17x64 SRAM at 7nm seems high...

```
>>> report_checks -from {addr_in[0]} -to {u_sdq_17x64/addr_in[0]}
Startpoint: addr_in[0] (input port)
Endpoint: u_sdq_17x64 (rising edge-triggered flip-flop clocked by clk)
Path Group: in2reg
Path Type: max

  Delay    Time   Description
---------------------------------------------------------
   0.00    0.00 ^ input external delay
   0.00    0.00 ^ addr_in[0] (in)
   9.49    9.49 ^ input1/Y (BUFx2_ASAP7_75t_R)
   0.00    9.49 ^ u_sdq_17x64/addr_in[0] (sdq_17x64)
           9.49   data arrival time

  80.00   80.00   max_delay
   0.00   80.00   clock reconvergence pessimism
 -47.90   32.10   library setup time
          32.10   data required time
---------------------------------------------------------
          32.10   data required time
          -9.49   data arrival time
---------------------------------------------------------
          22.62   slack (MET)


>>> report_checks -from {u_sdq_17x64/rd_out[0]} -to {rd_out[0]}
Startpoint: u_sdq_17x64/rd_out[0] (internal pin)
Endpoint: rd_out[0] (output port)
Path Group: reg2out
Path Type: max

  Delay    Time   Description
---------------------------------------------------------
   0.00    0.00 v u_sdq_17x64/rd_out[0] (sdq_17x64)
 633.21  633.21 v output72/Y (BUFx2_ASAP7_75t_R)
   0.00  633.21 v rd_out[0] (out)
         633.21   data arrival time

  80.00   80.00   max_delay
   0.00   80.00   output external delay
          80.00   data required time
---------------------------------------------------------
          80.00   data required time
        -633.21   data arrival time
---------------------------------------------------------
        -553.21   slack (VIOLATED)
```


![image](https://github.com/user-attachments/assets/5acf0b5a-51e6-4042-8e8a-35326420e5dd)
