### PR TITLE
sram: mix .lib and .lef files

### DIFF
--- a/sram/BUILD
+++ b/sram/BUILD
@@ -65,6 +65,39 @@ orfs_flow(
     verilog_files = [":fakeram/top.v"],
 )
 
+
+filegroup(
+    name = "lef_file",
+    srcs = [
+        "sdq_17x64_generate_abstract",
+    ],
+    output_group = "sdq_17x64.lef",
+)
+
+# buildifier: disable=duplicated-name
+orfs_flow(
+    name = "top",
+    variant="mix",
+    abstract_stage = "grt",
+    args = FAST_SETTINGS | {
+        "SDC_FILE": "$(location //sram:fakeram/constraints-sram.sdc)",
+        "DIE_AREA": "0 0 100 100",
+        "CORE_AREA": "2 2 98 98",
+        "RTLMP_FLOW": "True",
+        "CORE_MARGIN": "2",
+        "MACRO_PLACE_HALO": "2 2",
+        "ADDITIONAL_LEFS": "$(location :lef_file)",
+        "ADDITIONAL_LIBS": "$(location //sram:fakeram/sdq_17x64.lib)",
+    },
+    sources =  {
+        "ADDITIONAL_LEFS" : [":lef_file"],
+        "ADDITIONAL_LIBS" : ["//sram:fakeram/sdq_17x64.lib"],
+        "SDC_FILE": ["//sram:fakeram/constraints-sram.sdc"],
+    },
+    verilog_files = ["//sram:fakeram/top.v"],
+)
+
+
 # buildifier: disable=duplicated-name
 orfs_flow(
     name = "sdq_17x64",


### PR DESCRIPTION
@hovind Failing example of trying to mix and match .lib and .lef files:

```
$ bazel build //sram:top_mix_synth
INFO: Invocation ID: a5629799-b434-4c4b-b0c8-91ead8eec75f
INFO: Analyzed target //sram:top_mix_synth (0 packages loaded, 0 targets configured).
ERROR: /home/oyvind/bazel-orfs/sram/BUILD:69:10: Action sram/results/asap7/top/mix/1_synth.rtlil failed: missing input file '//sram:results/asap7/sdq_17x64/base/sdq_17x64.lef'
ERROR: /home/oyvind/bazel-orfs/sram/BUILD:69:10: Action sram/results/asap7/top/mix/1_synth.rtlil failed: 1 input file(s) do not exist
Target //sram:top_mix_synth failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /home/oyvind/bazel-orfs/sram/BUILD:69:10 Action sram/results/asap7/top/mix/1_synth.rtlil failed: 1 input file(s) do not exist
INFO: Elapsed time: 0.113s, Critical Path: 0.00s
INFO: 2 processes: 2 internal.
ERROR: Build did NOT complete successfully
```