### PR TITLE
Sram mix floorplan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         STAGE_TARGET:
+          - "//sram:top_mix_grt"
           - "tag_array_64x184_generate_abstract"
           - "tag_array_64x184_report"
           - "lb_32x128_generate_abstract"

--- a/sram/BUILD
+++ b/sram/BUILD
@@ -30,8 +30,8 @@ orfs_flow(
     macros = [":sdq_17x64_generate_abstract"],
     args = FAST_SETTINGS | {
         "SDC_FILE": "$(location :fakeram/constraints-sram.sdc)",
-        "DIE_AREA": "0 0 100 100",
-        "CORE_AREA": "2 2 98 98",
+        "DIE_AREA": "0 0 80 80",
+        "CORE_AREA": "2 2 78 78",
         "RTLMP_FLOW": "True",
         "CORE_MARGIN": "2",
         "MACRO_PLACE_HALO": "2 2",
@@ -84,6 +84,16 @@ orfs_run(
     script = ":write_macros.tcl",
 )
 
+orfs_run(
+    name = "top_write_floorplan",
+    gui = False,
+    src = ":top_floorplan",
+    outs = [
+        ":floorplan.def",
+    ],
+    script = ":write_floorplan.tcl",
+)
+
 # buildifier: disable=duplicated-name
 orfs_flow(
     name = "top",
@@ -91,17 +101,16 @@ orfs_flow(
     abstract_stage = "grt",
     args = FAST_SETTINGS | {
         "SDC_FILE": "$(location :fakeram/constraints-sram.sdc)",
-        "DIE_AREA": "0 0 100 100",
-        "CORE_AREA": "2 2 98 98",
-        "CORE_MARGIN": "2",
+        "FLOORPLAN_DEF": "$(location :floorplan.def)",
         "MACRO_PLACEMENT_TCL": "$(location :macro_placement.tcl)",
         "ADDITIONAL_LEFS": "$(location :lef_file)",
         "ADDITIONAL_LIBS": "$(location :fakeram/sdq_17x64.lib)",
     },
     sources =  {
+        "SDC_FILE": [":fakeram/constraints-sram.sdc"],
+        "FLOORPLAN_DEF": ":floorplan.def",
         "ADDITIONAL_LEFS" : [":lef_file"],
         "ADDITIONAL_LIBS" : [":fakeram/sdq_17x64.lib"],
-        "SDC_FILE": [":fakeram/constraints-sram.sdc"],
         "MACRO_PLACEMENT_TCL": [":macro_placement.tcl"],
     },
     verilog_files = [":fakeram/top.v"],

--- a/sram/write_floorplan.tcl
+++ b/sram/write_floorplan.tcl
@@ -1,0 +1,5 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 2_floorplan.odb 2_floorplan.sdc
+
+set f [file join $::env(WORK_HOME) "floorplan.def"]
+write_def $f


### PR DESCRIPTION
@hovind top_floorplan_deps targets can't be used for orfs_run() yet, so I used top_floorplan instead.

```
$ bazel build //sram:top_mix_floorplan
INFO: Invocation ID: d1f804db-8926-43a4-a737-4694b3d30be3
ERROR: /home/oyvind/bazel-orfs/sram/BUILD:87:9: in src attribute of orfs_run rule //sram:top_write_floorplan: '//sram:top_floorplan_deps' does not have mandatory providers: 'OrfsInfo'
ERROR: /home/oyvind/bazel-orfs/sram/BUILD:87:9: Analysis of target '//sram:top_write_floorplan' failed
ERROR: Analysis of target '//sram:top_mix_floorplan' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.065s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```

I'd like to be able to run the this step with a locally hacked ORFS:

```
$ bazel run //sram:top_write_floorplan `pwd`/build
INFO: Invocation ID: 20f20bd4-5760-4fc6-b31c-6f90cb06ed3e
ERROR: Cannot run target //sram:top_write_floorplan: Not executable
INFO: Elapsed time: 0.034s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Build failed. Not running target
```
