### PR TITLE
orfs: bump

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -30,8 +30,8 @@ do
     elif [[ $stage == "grt" ]]; then
         stages+=("do-5_1_grt")
     elif [[ $stage == "route" ]]; then
-        stages+=("do-5_2_fillcell")
-        stages+=("do-5_3_route")
+        stages+=("do-5_2_route")
+        stages+=("do-5_3_fillcell")
     else
         stages+=("do-${stage}")
     fi

--- a/BUILD
+++ b/BUILD
@@ -49,10 +49,11 @@ SRAM_ARGUMENTS = {
     "IO_CONSTRAINTS": "$(location :io-sram)",
     "PLACE_PINS_ARGS": "-min_distance 2 -min_distance_in_tracks",
     "PLACE_DENSITY": "0.42",
-    "REMOVE_ABC_BUFFERS": "1",
     # faster build
+    "REMOVE_ABC_BUFFERS": "1",
     "SKIP_CTS_REPAIR_TIMING": "1",
     "SKIP_REPORT_METRICS": "1",
+    "SKIP_INCREMENTAL_REPAIR": "1",
 }
 
 BLOCK_FLOORPLAN = {
@@ -61,9 +62,9 @@ BLOCK_FLOORPLAN = {
     "REMOVE_ABC_BUFFERS": "1",
 }
 
+# Run one macro through all stages
 orfs_flow(
     name = "tag_array_64x184",
-    abstract_stage = "cts",
     arguments = SRAM_ARGUMENTS | {
         "CORE_UTILIZATION": "40",
         "CORE_ASPECT_RATIO": "2",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,9 +8,9 @@ orfs = use_extension("//:extension.bzl", "orfs_repositories")
 orfs.default(
     # a local only or remote docker image. Local docker images do not
     # have a sha256.
-    image = "docker.io/openroad/orfs:v3.0-1405-g0dbabca8",
+    image = "docker.io/openroad/orfs:v3.0-1461-ge58a24fe",
     # Comment out line below for local only docker images
-    sha256 = "1ed4dfec052d79216cb7cb21dc412e34c5a95604c42c700dbcaf2dfa57faec79",
+    sha256 = "c597cc1c3916c96f19968e7690a7c4877943d9bef88026f291b01e1fbb6ef258",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -64,7 +64,7 @@
     "//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "nbzG4yf/eg5a7s7gTfA+1gy5C3WdHDukeOhUvYZYbOc=",
-        "usagesDigest": "2FNdEejd4uvURku45gvPilPQ8CbvRcohhdlIAJOyzkM=",
+        "usagesDigest": "yecBOsV/gRZTD+h3IYXJclXG0H46sLyQ+utv2m1M1vM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -73,8 +73,8 @@
             "bzlFile": "@@//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-1405-g0dbabca8",
-              "sha256": "1ed4dfec052d79216cb7cb21dc412e34c5a95604c42c700dbcaf2dfa57faec79",
+              "image": "docker.io/openroad/orfs:v3.0-1461-ge58a24fe",
+              "sha256": "c597cc1c3916c96f19968e7690a7c4877943d9bef88026f291b01e1fbb6ef258",
               "build_file": "@@//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -1115,8 +1115,8 @@ orfs_route = add_orfs_make_rule_(
         ctx = ctx,
         stage = "5_2_route",
         steps = [
-            "do-5_2_fillcell",
-            "do-5_3_route",
+            "do-5_2_route",
+            "do-5_3_fillcell",
             "do-5_route",
             "do-5_route.sdc",
         ],
@@ -1125,8 +1125,8 @@ orfs_route = add_orfs_make_rule_(
             "5_route.sdc",
         ],
         log_names = [
-            "5_2_fillcell.log",
-            "5_3_route.log",
+            "5_2_route.log",
+            "5_3_fillcell.log",
         ],
         report_names = [
             "5_route_drc.rpt",


### PR DESCRIPTION
tag_array_64x184_generate_abstract now runs through all stages as there was some breakage in routing after ORFS reordered the 5_3_fillcell to be after detailed routing.

Reordering of ORFS stages is rare, can't recall last time.