### PR TITLE
sram: fix floorplan.def

### DIFF
--- a/sram/write_floorplan.tcl
+++ b/sram/write_floorplan.tcl
@@ -1,4 +1,14 @@
-source $::env(SCRIPTS_DIR)/floorplan.tcl
+# Make a minimal floorplan.def that we can read in using
+# FLOORPLAN_DEF
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_synth.v 1_synth.sdc
+
+set additional_args ""
+append_env_var additional_args ADDITIONAL_SITES -additional_sites 1
+initialize_floorplan -die_area $::env(DIE_AREA) \
+                        -core_area $::env(CORE_AREA) \
+                        -site $::env(PLACE_SITE) \
+                        {*}$additional_args
 
 set f [file join $::env(WORK_HOME) "floorplan.def"]
 write_def $f


### PR DESCRIPTION
@maliberty This still does not avoid the warnings below. How can I whittle down the .def further so that I can use it in FLOORPLAN_DEF?

I would have thought that the `-floorplan_initialize` is used exactly for reading in only what is needed out of the .def file. What else is the `-floorplan_initialize` option for?

```
read_def -floorplan_initialize $env(FLOORPLAN_DEF)
```

https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/65658416797b4133a851af2929195c92278dfe1b/flow/scripts/floorplan.tcl#L59


```
[INFO ODB-0127] Reading DEF file: bazel-out/k8-fastbuild/bin/sram/floorplan.def
[INFO ODB-0128] Design: top
[WARNING ODB-0437] Pin directions are ignored from floorplan DEF files.
[WARNING ODB-0437] Pin directions are ignored from floorplan DEF files.
[WARNING ODB-0437] Pin directions are ignored from floorplan DEF files.
[WARNING ODB-0437] Pin directions are ignored from floorplan DEF files.
```

