### PR TITLE
added context name to name of make file

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -928,7 +928,7 @@ def _make_impl(ctx, stage, steps, forwarded_names = [], result_names = [], objec
         content = _config_content(extra_arguments | _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(ctx.attr.src[OrfsInfo], short = True)),
     )
 
-    make = ctx.actions.declare_file("make_{}_{}".format(ctx.attr.variant, stage))
+    make = ctx.actions.declare_file("make_{}_{}_{}".format(ctx.attr.name, ctx.attr.variant, stage))
     ctx.actions.expand_template(
         template = ctx.file._make_template,
         output = make,
@@ -1040,7 +1040,7 @@ orfs_floorplan = add_orfs_make_rule_(
     ),
     attrs = openroad_attrs() | {
         "extra_envs": attr.label(
-            doc = "File with exported environmenta variables.",
+            doc = "File with exported environment variables.",
             allow_single_file = True,
         ),
     },


### PR DESCRIPTION
When running the mock_area flow with more than one SRAM, the same make file output declaration is used by multiple SRAMS:

 ```
ERROR: file 'make_mock_area_2_floorplan' is generated by these conflicting actions:
Label: //:sdq_17x64_floorplan_mock_area, //:ebtb_128x40_floorplan_mock_area
RuleClass: orfs_floorplan rule
```

Added the context name to the name of the output file to disambiguate it when the code is called for multiple SRAMs.

Caveat: this is not fully tested and I don't know the other usages of this file (e.g. there might be other hookups that also need to be updated to the new file name). It seems to get beyond the error that I was seeing and also seems to be running when I turn mock_area off.

megaboom test case: https://github.com/The-OpenROAD-Project/megaboom/pull/128