### PR TITLE
test: add lb_32x128_top to inspect mock abstract usage

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -83,6 +83,7 @@ LB_ARGS = SRAM_ARGUMENTS | {
     "CORE_UTILIZATION": "40",
     "CORE_ASPECT_RATIO": "2",
     "PLACE_DENSITY": "0.65",
+    "PLACE_PINS_ARGS": "-min_distance 1 -min_distance_in_tracks",
 }
 
 LB_STAGE_SOURCES = {
@@ -93,13 +94,25 @@ LB_STAGE_SOURCES = {
 
 LB_VERILOG_FILES = ["test/mock/lb_32x128.sv"]
 
+# Test a full abstract, all stages, so leave abstract_stage unset to default value(final)
 orfs_flow(
     name = "lb_32x128",
-    abstract_stage = "floorplan",
     arguments = LB_ARGS,
-    mock_area = 1.0,
+    mock_area = 0.5,
     stage_sources = LB_STAGE_SOURCES,
     verilog_files = LB_VERILOG_FILES,
+)
+
+orfs_flow(
+    name = "lb_32x128_top",
+    arguments = LB_ARGS | {
+        "CORE_UTILIZATION": "5",
+        "PLACE_DENSITY": "0.10",
+        "RTLMP_FLOW": "1",
+    },
+    macros = ["lb_32x128_generate_abstract"],
+    stage_sources = LB_STAGE_SOURCES,
+    verilog_files = ["test/rtl/lb_32x128_top.v"],
 )
 
 # buildifier: disable=duplicated-name

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -1462,7 +1462,7 @@ def orfs_flow(
             src = "{}_{}".format(name_variant, step.stage),
         )
 
-    if mock_area:
+    if mock_area != None:
         if variant == "mock_area":
             fail("'mock_area' variant is used by mock_area targets, please choose different one")
         _mock_area_targets(

--- a/test/constraints-sram.sdc
+++ b/test/constraints-sram.sdc
@@ -1,9 +1,40 @@
-set clk_name clock
-set clk_port_name clock
-set clk_period 400
+set sdc_version 2.0
 
-if { [llength [all_registers]] > 0} {
-  source $env(PLATFORM_DIR)/constraints.sdc
-} else {
-  puts "The design is gutted when mocking floorplan"
+#
+# SDC file used during SRAM abstract generation
+#
+
+# Run at 666 MHz
+set clk_period 1500
+
+# Covers all clock naming types in SRAMs and reg files
+set clock_ports [concat [get_ports -quiet *clk] [get_ports -quiet *clock]]
+
+if {[llength $clock_ports] == 0} {
+  error "No clock ports found"
+}
+
+foreach clk_port $clock_ports {
+  set clk_name [get_name $clk_port]
+  create_clock -period $clk_period -name $clk_name $clk_port
+}
+
+set non_clk_inputs {}
+foreach input [all_inputs] {
+  if {[lsearch -exact $clock_ports $input] == -1} {
+    lappend non_clk_inputs $input
+  }
+}
+
+set_max_delay [expr {[info exists in2out_max] ? $in2out_max : 80}] -from $non_clk_inputs -to [all_outputs]
+group_path -name in2out -from $non_clk_inputs -to [all_outputs]
+
+if {[llength [all_registers]] > 0} {
+  set all_register_outputs [get_pins -of_objects [all_registers] -filter {direction == output}]
+  set_max_delay [expr {[info exists in2reg_max] ? $in2reg_max : 80}] -from $non_clk_inputs -to [all_registers]
+  set_max_delay [expr {[info exists reg2out_max] ? $reg2out_max : 80}] -from $all_register_outputs -to [all_outputs]
+
+  group_path -name in2reg -from $non_clk_inputs -to [all_registers]
+  group_path -name reg2out -from [all_registers] -to [all_outputs]
+  group_path -name reg2reg -from [all_registers] -to [all_registers]
 }

--- a/test/rtl/lb_32x128_top.v
+++ b/test/rtl/lb_32x128_top.v
@@ -1,0 +1,23 @@
+// mock version for fast builds
+module lb_32x128_top(
+  input  [4:0]   R0_addr,
+  input          R0_en,
+                 R0_clk,
+  output [127:0] R0_data,
+  input  [4:0]   W0_addr,
+  input          W0_en,
+                 W0_clk,
+  input  [127:0] W0_data
+);
+    lb_32x128 lb_32x128_inst (
+        .R0_addr(R0_addr),
+        .R0_en(R0_en),
+        .R0_clk(R0_clk),
+        .R0_data(R0_data),
+        .W0_addr(W0_addr),
+        .W0_en(W0_en),
+        .W0_clk(W0_clk),
+        .W0_data(W0_data)
+    );
+endmodule
+


### PR DESCRIPTION
run through final when generating mock abstract to check that correct .lib and .lef files are used.

mock_area is broken.

mock_area should use the mock_area .lef from floorplan and the regular .lib file when generating an abstract.

Bug 1: there should be no cts, final, place, route, grt below.

```
$ bazel query //:* | grep lb_32x128 | grep mock
Loading: 0 packages loaded
//:lb_32x128_cts_mock_area
//:lb_32x128_cts_mock_area_deps
//:lb_32x128_final_mock_area
//:lb_32x128_final_mock_area_deps
//:lb_32x128_floorplan_mock_area
//:lb_32x128_floorplan_mock_area_deps
//:lb_32x128_grt_mock_area
//:lb_32x128_grt_mock_area_deps
//:lb_32x128_mock_area
//:lb_32x128_place_mock_area
//:lb_32x128_place_mock_area_deps
//:lb_32x128_route_mock_area
//:lb_32x128_route_mock_area_deps
//:lb_32x128_synth_mock_area
//:lb_32x128_synth_mock_area_deps
```


Bug 2: run ```bazel run lb_32x128_top_route `pwd`/build gui_route```

actual, missing path groups since the mock .lib file is used:

![image](https://github.com/user-attachments/assets/0f9b25e0-0a49-46b7-9c14-7d7bcc5370e8)

expected, there should be more path groups with the real .lib file usd:

![image](https://github.com/user-attachments/assets/0b57f0cb-895b-41b1-b002-df3ae2181433)



