### PR TITLE
Stage outputs arguments used to support for instance naja

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -294,6 +294,9 @@ def _deps_impl(ctx):
         ),
     ]
 
+def flow_provides():
+    return [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo]
+
 def flow_attrs():
     return {
         "arguments": attr.string_dict(
@@ -398,6 +401,13 @@ def yosys_only_attrs():
         ),
     }
 
+def output_attrs(outputs):
+    return {
+        "outputs": attr.string_dict(
+            default = {out: out for out in outputs},
+        ),
+    }
+
 def synth_attrs():
     return {
         "verilog_files": attr.label_list(
@@ -472,30 +482,37 @@ def _config_content(arguments, paths):
 def _data_arguments(ctx):
     return {k: ctx.expand_location(v, ctx.attr.data) for k, v in ctx.attr.arguments.items()}
 
-def _add_optional_generation_to_command(command, optional_files):
+def _generation_commands(optional_files):
     if optional_files:
-        return " && ".join([
+        return [
             "mkdir -p " + " ".join(sorted([result.dirname for result in optional_files])),
             "touch " + " ".join(sorted([result.path for result in optional_files])),
-            command,
-        ])
-    return command
+        ]
+    return []
+
+def _output_commands(ctx, results):
+    reverse = {v: k for k, v in ctx.attr.outputs.items()}
+    return ["mv {} {}".format(
+        "/".join([result.dirname, reverse[result.basename]]),
+        result.path,
+    ) for result in results if result.basename in reverse]
 
 def _work_home(ctx):
     if ctx.label.package:
         return "/".join([ctx.genfiles_dir.path, ctx.label.package])
     return ctx.genfiles_dir.path
 
-def _artifact_dir(ctx, category):
+def _artifact_name(ctx, category, name):
     return "/".join([
         category,
         _platform(ctx),
         _module_top(ctx),
         ctx.attr.variant,
+        name,
     ])
 
 def _declare_artifact(ctx, category, name):
-    return ctx.actions.declare_file("/".join([_artifact_dir(ctx, category), name]))
+    return ctx.actions.declare_file(_artifact_name(ctx, category, name))
 
 def _run_impl(ctx):
     config = ctx.attr.src[OrfsInfo].config
@@ -548,6 +565,9 @@ orfs_run = rule(
     },
 )
 
+CANON_OUTPUT = "1_synth.rtlil"
+SYNTH_OUTPUTS = ["1_synth.v", "1_synth.sdc", "mem.json"]
+
 def _yosys_impl(ctx):
     all_arguments = _data_arguments(ctx) | _required_arguments(ctx) | _orfs_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps])
     config = _declare_artifact(ctx, "results", "1_synth.mk")
@@ -560,13 +580,13 @@ def _yosys_impl(ctx):
     for log in ["1_1_yosys_canonicalize.log"]:
         canon_logs.append(_declare_artifact(ctx, "logs", log))
 
-    canon_output = _declare_artifact(ctx, "results", "1_synth.rtlil")
+    canon_output = _declare_artifact(ctx, "results", CANON_OUTPUT)
 
-    command = _add_optional_generation_to_command(ctx.executable._make.path + " $@", canon_logs)
+    commands = [ctx.executable._make.path + " $@"] + _generation_commands(canon_logs)
 
     ctx.actions.run_shell(
         arguments = ["--file", ctx.file._makefile.path, canon_output.path],
-        command = command,
+        command = " && ".join(commands),
         env = _verilog_arguments(ctx.files.verilog_files) |
               flow_environment(ctx) |
               yosys_environment(ctx) |
@@ -591,14 +611,16 @@ def _yosys_impl(ctx):
         synth_logs.append(_declare_artifact(ctx, "logs", log))
 
     synth_outputs = []
-    for output in ["1_synth.v", "1_synth.sdc", "mem.json"]:
+    for output in SYNTH_OUTPUTS:
+        if output in ctx.attr.outputs:
+            output = ctx.attr.outputs[output]
         synth_outputs.append(_declare_artifact(ctx, "results", output))
 
-    command = _add_optional_generation_to_command(ctx.executable._make.path + " $@", synth_logs)
+    commands = [ctx.executable._make.path + " $@"] + _generation_commands(synth_logs) + _output_commands(ctx, synth_outputs)
     ctx.actions.run_shell(
         arguments = ["--file", ctx.file._makefile.path, "--old-file", canon_output.path, "yosys-dependencies"] +
-                    [f.path for f in synth_outputs],
-        command = command,
+                    ["/".join([_work_home(ctx), _artifact_name(ctx, "results", name)]) for name in SYNTH_OUTPUTS],
+        command = " && ".join(commands),
         env = _verilog_arguments([]) |
               flow_environment(ctx) |
               yosys_environment(ctx) |
@@ -616,6 +638,8 @@ def _yosys_impl(ctx):
         ),
         outputs = synth_outputs + synth_logs,
     )
+
+    outputs = [canon_output] + synth_outputs
 
     config_short = _declare_artifact(ctx, "results", "1_synth.short.mk")
     ctx.actions.write(
@@ -638,7 +662,7 @@ def _yosys_impl(ctx):
         template = ctx.file._deploy_template,
         output = exe,
         substitutions = {
-            "${GENFILES}": " ".join(sorted([f.short_path for f in synth_outputs + [config_short] + canon_logs + synth_logs])),
+            "${GENFILES}": " ".join(sorted([f.short_path for f in [config_short] + outputs + canon_logs + synth_logs])),
             "${CONFIG}": config_short.short_path,
             "${MAKE}": make.short_path,
         },
@@ -647,9 +671,9 @@ def _yosys_impl(ctx):
     return [
         DefaultInfo(
             executable = exe,
-            files = depset([canon_output] + synth_outputs),
+            files = depset(outputs),
             runfiles = ctx.runfiles(
-                synth_outputs + canon_logs + synth_logs + [canon_output, config_short, make] +
+                outputs + canon_logs + synth_logs + [config_short, make] +
                 ctx.files.verilog_files + ctx.files.extra_configs,
                 transitive_files = depset(transitive = [
                     flow_inputs(ctx),
@@ -663,7 +687,7 @@ def _yosys_impl(ctx):
         OutputGroupInfo(
             logs = depset(canon_logs + synth_logs),
             reports = depset([]),
-            **{f.basename: depset([f]) for f in [canon_output, config] + synth_outputs}
+            **{f.basename: depset([f]) for f in [config] + outputs}
         ),
         OrfsDepInfo(
             make = make,
@@ -704,7 +728,7 @@ def _yosys_impl(ctx):
 
 orfs_synth = rule(
     implementation = _yosys_impl,
-    attrs = yosys_attrs() | synth_attrs(),
+    attrs = yosys_attrs() | synth_attrs() | output_attrs(SYNTH_OUTPUTS + [CANON_OUTPUT]),
     provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, PdkInfo, TopInfo, LoggingInfo],
     executable = True,
 )
@@ -739,7 +763,7 @@ def _make_impl(ctx, stage, steps, forwarded_names = [], result_names = [], objec
     )
 
     results = []
-    for result in result_names:
+    for result in ctx.attr.outputs.keys() + result_names:
         results.append(_declare_artifact(ctx, "results", result))
 
     objects = []
@@ -760,12 +784,11 @@ def _make_impl(ctx, stage, steps, forwarded_names = [], result_names = [], objec
     for file in forwards + results:
         info[file.extension] = file
 
-    command = ctx.executable._make.path + " $@"
-    command = _add_optional_generation_to_command(command, reports + logs)
+    commands = [ctx.executable._make.path + " $@"] + _generation_commands(reports + logs) + _output_commands(ctx, results)
 
     ctx.actions.run_shell(
         arguments = ["--file", ctx.file._makefile.path] + steps,
-        command = command,
+        command = " && ".join(commands),
         env = flow_environment(ctx) | config_environment(config),
         inputs = depset(
             [config] +
@@ -810,7 +833,7 @@ def _make_impl(ctx, stage, steps, forwarded_names = [], result_names = [], objec
         DefaultInfo(
             executable = exe,
             files = depset(
-                forwards + reports + results,
+                forwards + results + logs + reports,
                 transitive = [
                     ctx.attr.src[OrfsInfo].additional_gds,
                     ctx.attr.src[OrfsInfo].additional_lefs,
@@ -865,27 +888,11 @@ def _make_impl(ctx, stage, steps, forwarded_names = [], result_names = [], objec
         ctx.attr.src[TopInfo],
     ]
 
-def add_orfs_make_rule_(
-        implementation,
-        attrs = openroad_attrs(),
-        provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
-        executable = True):
-    return rule(
-        implementation = implementation,
-        attrs = attrs,
-        provides = provides,
-        executable = executable,
-    )
-
-orfs_floorplan = add_orfs_make_rule_(
+orfs_floorplan = rule(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "2_floorplan",
         steps = ["do-floorplan"],
-        result_names = [
-            "2_floorplan.odb",
-            "2_floorplan.sdc",
-        ],
         log_names = [
             "2_1_floorplan.log",
             "2_2_floorplan_io.log",
@@ -898,18 +905,19 @@ orfs_floorplan = add_orfs_make_rule_(
             "2_floorplan_final.rpt",
         ],
     ),
-    attrs = openroad_attrs(),
+    attrs = openroad_attrs() | output_attrs([
+        "2_floorplan.odb",
+        "2_floorplan.sdc",
+    ]),
+    provides = flow_provides(),
+    executable = True,
 )
 
-orfs_place = add_orfs_make_rule_(
+orfs_place = rule(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "3_place",
         steps = ["do-place"],
-        result_names = [
-            "3_place.odb",
-            "3_place.sdc",
-        ],
         log_names = [
             "3_1_place_gp_skip_io.log",
             "3_2_place_iop.log",
@@ -919,17 +927,19 @@ orfs_place = add_orfs_make_rule_(
         ],
         report_names = [],
     ),
+    attrs = openroad_attrs() | output_attrs([
+        "3_place.odb",
+        "3_place.sdc",
+    ]),
+    provides = flow_provides(),
+    executable = True,
 )
 
-orfs_cts = add_orfs_make_rule_(
+orfs_cts = rule(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "4_cts",
         steps = ["do-cts"],
-        result_names = [
-            "4_cts.odb",
-            "4_cts.sdc",
-        ],
         log_names = [
             "4_1_cts.log",
         ],
@@ -937,9 +947,15 @@ orfs_cts = add_orfs_make_rule_(
             "4_cts_final.rpt",
         ],
     ),
+    attrs = openroad_attrs() | output_attrs([
+        "4_cts.odb",
+        "4_cts.sdc",
+    ]),
+    provides = flow_provides(),
+    executable = True,
 )
 
-orfs_grt = add_orfs_make_rule_(
+orfs_grt = rule(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "5_1_grt",
@@ -949,9 +965,6 @@ orfs_grt = add_orfs_make_rule_(
         forwarded_names = [
             "4_cts.sdc",
         ],
-        result_names = [
-            "5_1_grt.odb",
-        ],
         log_names = [
             "5_1_grt.log",
         ],
@@ -960,12 +973,14 @@ orfs_grt = add_orfs_make_rule_(
             "congestion.rpt",
         ],
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, PdkInfo, TopInfo],
+    attrs = openroad_attrs() | output_attrs([
+        "5_1_grt.odb",
+    ]),
+    provides = flow_provides(),
     executable = True,
 )
 
-orfs_route = add_orfs_make_rule_(
+orfs_route = rule(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "5_2_route",
@@ -975,10 +990,6 @@ orfs_route = add_orfs_make_rule_(
             "do-5_route",
             "do-5_route.sdc",
         ],
-        result_names = [
-            "5_route.odb",
-            "5_route.sdc",
-        ],
         log_names = [
             "5_2_route.log",
             "5_3_fillcell.log",
@@ -987,19 +998,19 @@ orfs_route = add_orfs_make_rule_(
             "5_route_drc.rpt",
         ],
     ),
+    attrs = openroad_attrs() | output_attrs([
+        "5_route.odb",
+        "5_route.sdc",
+    ]),
+    provides = flow_provides(),
+    executable = True,
 )
 
-orfs_final = add_orfs_make_rule_(
+orfs_final = rule(
     implementation = lambda ctx: _make_impl(
         ctx = ctx,
         stage = "6_final",
         steps = ["do-final"],
-        result_names = [
-            "6_final.gds",
-            "6_final.odb",
-            "6_final.sdc",
-            "6_final.spef",
-        ],
         object_names = [
             "klayout.lyt",
         ],
@@ -1014,6 +1025,14 @@ orfs_final = add_orfs_make_rule_(
             "VSS.rpt",
         ],
     ),
+    attrs = openroad_attrs() | output_attrs([
+        "6_final.gds",
+        "6_final.odb",
+        "6_final.sdc",
+        "6_final.spef",
+    ]),
+    provides = flow_provides(),
+    executable = True,
 )
 
 def _extensionless_basename(file):
@@ -1037,8 +1056,8 @@ orfs_abstract = rule(
         extra_arguments =
             {"ABSTRACT_SOURCE": _extensionless_basename(ctx.attr.src[OrfsInfo].odb)},
     ),
-    attrs = openroad_attrs(),
-    provides = [DefaultInfo, OutputGroupInfo, OrfsDepInfo, OrfsInfo, LoggingInfo, PdkInfo, TopInfo],
+    attrs = openroad_attrs() | output_attrs([]),
+    provides = flow_provides(),
     executable = True,
 )
 
@@ -1246,6 +1265,7 @@ def orfs_flow(
         sources = {},
         stage_sources = {},
         stage_arguments = {},
+        stage_outputs = {},
         arguments = {},
         extra_configs = {},
         abstract_stage = None,
@@ -1262,6 +1282,7 @@ def orfs_flow(
       sources: dictionary keyed by ORFS variables with lists of sources
       stage_sources: dictionary keyed by ORFS stages with lists of stage-specific sources
       stage_arguments: dictionary keyed by ORFS stages with lists of stage-specific arguments
+      stage_outputs: dictionary keyed by ORFS stages to rename outputs
       arguments: dictionary of additional arguments to the flow, automatically assigned to stages
       extra_configs: dictionary keyed by ORFS stages with list of additional configuration files
       abstract_stage: string with physical design flow stage name which controls the name of the files generated in _generate_abstract stage
@@ -1277,6 +1298,7 @@ def orfs_flow(
         sources = sources,
         stage_sources = stage_sources,
         stage_arguments = stage_arguments,
+        stage_outputs = stage_outputs,
         arguments = arguments,
         extra_configs = extra_configs,
         abstract_stage = abstract_stage,
@@ -1308,6 +1330,7 @@ def orfs_flow(
         sources = sources,
         stage_sources = stage_sources,
         stage_arguments = mock_stage_arguments,
+        stage_outputs = stage_outputs,
         arguments = {},
         extra_configs = extra_configs | mock_configs,
         abstract_stage = "floorplan",
@@ -1334,6 +1357,9 @@ def orfs_flow(
         module_top = name,
     )
 
+def _kwargs(stage, **kwargs):
+    return {k: v[stage] for k, v in kwargs.items() if stage in v and v[stage]}
+
 def _orfs_pass(
         name,
         verilog_files,
@@ -1341,6 +1367,7 @@ def _orfs_pass(
         sources,
         stage_sources,
         stage_arguments,
+        stage_outputs,
         arguments,
         extra_configs,
         abstract_stage,
@@ -1366,6 +1393,10 @@ def _orfs_pass(
         variant = variant,
         verilog_files = verilog_files,
         visibility = visibility,
+        **_kwargs(
+            synth_step.stage,
+            outputs = stage_outputs,
+        )
     )
     orfs_deps(
         name = "{}_deps".format(_step_name(name, variant, synth_step.stage)),
@@ -1383,6 +1414,10 @@ def _orfs_pass(
             extra_configs = extra_configs.get(step.stage, []),
             variant = variant,
             visibility = visibility,
+            **_kwargs(
+                step.stage,
+                outputs = stage_outputs,
+            )
         )
         orfs_deps(
             name = "{}_deps".format(step_name),

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -491,7 +491,7 @@ def _generation_commands(optional_files):
     return []
 
 def _output_commands(ctx, results):
-    reverse = {v: k for k, v in ctx.attr.outputs.items()}
+    reverse = {v: k for k, v in ctx.attr.outputs.items() if k != v}
     return ["mv {} {}".format(
         "/".join([result.dirname, reverse[result.basename]]),
         result.path,

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -1339,7 +1339,7 @@ def orfs_flow(
         sources = sources,
         stage_sources = stage_sources,
         stage_arguments = mock_stage_arguments,
-        stage_outputs = stage_outputs,
+        stage_outputs = {},
         arguments = {},
         extra_configs = extra_configs | mock_configs,
         abstract_stage = "floorplan",

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -618,8 +618,17 @@ def _yosys_impl(ctx):
 
     commands = [ctx.executable._make.path + " $@"] + _generation_commands(synth_logs) + _output_commands(ctx, synth_outputs)
     ctx.actions.run_shell(
-        arguments = ["--file", ctx.file._makefile.path, "--old-file", canon_output.path, "yosys-dependencies"] +
-                    ["/".join([_work_home(ctx), _artifact_name(ctx, "results", name)]) for name in SYNTH_OUTPUTS],
+        arguments = [
+            "--file",
+            ctx.file._makefile.path,
+            "--old-file",
+            canon_output.path,
+            "yosys-dependencies",
+            "do-yosys-keep-hierarchy",
+            "do-yosys",
+            "do-synth",
+            "/".join([_work_home(ctx), _artifact_name(ctx, "results", "1_synth.sdc")]),
+        ],
         command = " && ".join(commands),
         env = _verilog_arguments([]) |
               flow_environment(ctx) |

--- a/sram/BUILD
+++ b/sram/BUILD
@@ -18,10 +18,27 @@ orfs_flow(
         "PLACE_DENSITY": "0.25",
     },
     mock_area = 0.95,
+    stage_outputs = {
+        "synth": {"1_synth.v": "1_synth_unedited.v"},
+    },
     stage_sources = {
         "synth": [":fakeram/constraints-sram.sdc"],
+        "floorplan": [":naja"],
     },
     verilog_files = [":fakeram/sdq_17x64.sv"],
+)
+
+filegroup(
+    name = "sdq_17x64_synth_unedited",
+    srcs = ["sdq_17x64_synth"],
+    output_group = "1_synth_unedited.v",
+)
+
+genrule(
+    name = "naja",
+    srcs = [":sdq_17x64_synth_unedited"],
+    outs = ["results/asap7/sdq_17x64/base/1_synth.v"],
+    cmd = "mkdir -p `dirname $@`; cp $< $@",
 )
 
 orfs_flow(

--- a/sram/BUILD
+++ b/sram/BUILD
@@ -19,6 +19,7 @@ orfs_flow(
     },
     mock_area = 0.95,
     stage_outputs = {
+        # the "naja" rule below will use the synthesis output
         "synth": {"1_synth.v": "1_synth_unedited.v"},
     },
     stage_sources = {
@@ -28,17 +29,21 @@ orfs_flow(
     verilog_files = [":fakeram/sdq_17x64.sv"],
 )
 
+# fish out the file that we want as input to the "naja" rule
+# below.
 filegroup(
     name = "sdq_17x64_synth_unedited",
     srcs = ["sdq_17x64_synth"],
     output_group = "1_synth_unedited.v",
 )
 
+# Read in the renamed synthesis output from above and provide
+# the original name to the next stage
 genrule(
     name = "naja",
     srcs = [":sdq_17x64_synth_unedited"],
     outs = ["results/asap7/sdq_17x64/base/1_synth.v"],
-    cmd = "mkdir -p `dirname $@`; cp $< $@",
+    cmd = "mkdir -p `dirname $@`; echo \"// imagine naja edits in this file\" > $@ && cat $< >> $@",
 )
 
 orfs_flow(


### PR DESCRIPTION
```
$ bazel build //sram:sdq_17x64_floorplan_deps
INFO: Invocation ID: 9348e0e3-8b53-4151-a142-2c83b7e12d7d
INFO: Analyzed target //sram:sdq_17x64_floorplan_deps (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //sram:sdq_17x64_floorplan_deps up-to-date:
  bazel-bin/sram/results/asap7/sdq_17x64/base/2_floorplan.short.mk
  bazel-bin/sram/results/asap7/sdq_17x64/base/1_synth.rtlil
  bazel-bin/sram/results/asap7/sdq_17x64/base/1_synth_unedited.v
  bazel-bin/sram/results/asap7/sdq_17x64/base/1_synth.sdc
  bazel-bin/sram/results/asap7/sdq_17x64/base/mem.json
  bazel-bin/sram/results/asap7/sdq_17x64/base/1_synth.v
INFO: Elapsed time: 0.068s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
$ diff bazel-bin/sram/results/asap7/sdq_17x64/base/1_synth.v bazel-bin/sram/results/asap7/sdq_17x64/base/1_synth_unedited.v 
1d0
< imagine naja edits in this file
```
