### PR TITLE
example: density sweep

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -136,6 +136,30 @@ orfs_flow(
     verilog_files = LB_VERILOG_FILES,
 )
 
+# Use-case:
+#
+# bazel build --keep_going $(bazel query //:* | grep lb_32x128_density.*place\$)
+DENSITY_SWEEP = [
+    0.70,
+    0.75,
+    0.80,
+]
+
+# buildifier: disable=duplicated-name
+[
+    orfs_flow(
+        name = "lb_32x128",
+        abstract_stage = "place",
+        arguments = LB_ARGS | {
+            "PLACE_DENSITY": str(density),
+        },
+        stage_sources = LB_STAGE_SOURCES,
+        variant = "density_" + str(density),
+        verilog_files = LB_VERILOG_FILES,
+    )
+    for density in DENSITY_SWEEP
+]
+
 orfs_flow(
     name = "L1MetadataArray",
     abstract_stage = "cts",


### PR DESCRIPTION
@jeffng-or @maliberty @luarss FYI

For MegaBoom, the build times are ca. 12-24 hours, so "sweeps" of parameters will have to be planned manually. 

I'm wary of trying a million parameters with a credit card and an automatic cloud solution :-)

Bazel "property sweep at home"... "at home" here as in a mom telling the kids that "We have burgers at home" when passing by a burger resturant... Of course the "burgers at home" are not nearly as nice as that fancy burger resturant... But, it gets the job done. :-)

These tests are run in parallel:

- runs all the tests in parallel
- artifacts are produced so they can be downloaded and inspected if the build happens on a server

In this simply example, I'm only after a go/no go, but for other properties it might be interesting to run some scripts to examine the different results.


Very similiar, but not quite identical results...

![image](https://github.com/user-attachments/assets/588373b5-17cb-4cd1-8153-0660779e15b8)
