### PR TITLE
yosys: avoid resynthesis on ORFS upgrade when yosys doesn't change

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,9 +8,9 @@ orfs = use_extension("//:extension.bzl", "orfs_repositories")
 orfs.default(
     # a local only or remote docker image. Local docker images do not
     # have a sha256.
-    image = "docker.io/openroad/orfs:v3.0-1696-g6927a54e",
+    image = "docker.io/openroad/orfs:v3.0-1694-g0a5008b6",
     # Comment out line below for local only docker images
-    sha256 = "81ca0709ab96939b05c15beae22e191dc281a303716d9d37a42c20b858e65088",
+    sha256 = "4ef9b95551629ff00217188eb68198873ed709c09671e3c40a184ad14e88df19",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,9 +8,9 @@ orfs = use_extension("//:extension.bzl", "orfs_repositories")
 orfs.default(
     # a local only or remote docker image. Local docker images do not
     # have a sha256.
-    image = "docker.io/openroad/orfs:v3.0-1679-g980de246",
+    image = "docker.io/openroad/orfs:v3.0-1696-g6927a54e",
     # Comment out line below for local only docker images
-    sha256 = "e3c30971e63d4748fde1ddbec63f9680bda53be5a50319d67db9279dd51d2945",
+    sha256 = "81ca0709ab96939b05c15beae22e191dc281a303716d9d37a42c20b858e65088",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -64,7 +64,7 @@
     "//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "vmcGR7h5VgEPebKSKqrF0UgcqrgFTr0lE5jdk/LXXdg=",
-        "usagesDigest": "MSaAP2iGR0nHxZjmvhxVBds6slaLwkB6DkkmilkHWHg=",
+        "usagesDigest": "8wjxrMMLnKMy/+x6a55upa0S8rMnjUxmRQu84oUoPxI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -84,8 +84,8 @@
             "bzlFile": "@@//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-1679-g980de246",
-              "sha256": "e3c30971e63d4748fde1ddbec63f9680bda53be5a50319d67db9279dd51d2945",
+              "image": "docker.io/openroad/orfs:v3.0-1696-g6927a54e",
+              "sha256": "81ca0709ab96939b05c15beae22e191dc281a303716d9d37a42c20b858e65088",
               "build_file": "@@//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -64,7 +64,7 @@
     "//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "vmcGR7h5VgEPebKSKqrF0UgcqrgFTr0lE5jdk/LXXdg=",
-        "usagesDigest": "8wjxrMMLnKMy/+x6a55upa0S8rMnjUxmRQu84oUoPxI=",
+        "usagesDigest": "eyPZu0buMJOhNwkJZlCG4dRhFwS6TAlv5YaUVuWRltk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -84,8 +84,8 @@
             "bzlFile": "@@//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-1696-g6927a54e",
-              "sha256": "81ca0709ab96939b05c15beae22e191dc281a303716d9d37a42c20b858e65088",
+              "image": "docker.io/openroad/orfs:v3.0-1694-g0a5008b6",
+              "sha256": "4ef9b95551629ff00217188eb68198873ed709c09671e3c40a184ad14e88df19",
               "build_file": "@@//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [

--- a/docker.BUILD.bazel
+++ b/docker.BUILD.bazel
@@ -104,19 +104,37 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+MAKEFILE_SHARED = [
+        "OpenROAD-flow-scripts/flow/util/utils.mk",
+        "OpenROAD-flow-scripts/flow/scripts/*.py",
+        "OpenROAD-flow-scripts/flow/scripts/*.sh",
+        "OpenROAD-flow-scripts/flow/scripts/*.yaml",
+
+]
+
+# Narrowly define yosys dependencies to avoid hours of resynthesis
+# upon upgrading ORFS since yosys hardly ever changes
+filegroup(
+    name = "makefile_yosys",
+    srcs = ["OpenROAD-flow-scripts/flow/Makefile"],
+    data = glob(MAKEFILE_SHARED + [
+        "OpenROAD-flow-scripts/flow/scripts/*.script",
+        "OpenROAD-flow-scripts/flow/scripts/util.tcl",
+        "OpenROAD-flow-scripts/flow/scripts/synth*.tcl",
+        "OpenROAD-flow-scripts/flow/util/preprocessLib.py",
+        "OpenROAD-flow-scripts/flow/util/mergeLib.pl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "makefile",
     srcs = ["OpenROAD-flow-scripts/flow/Makefile"],
-    data = glob([
-        "OpenROAD-flow-scripts/flow/util/utils.mk",
+    data = glob(MAKEFILE_SHARED + [
         "OpenROAD-flow-scripts/flow/util/*.pl",
         "OpenROAD-flow-scripts/flow/util/*.py",
         "OpenROAD-flow-scripts/flow/util/*.sh",
-        "OpenROAD-flow-scripts/flow/scripts/*.py",
-        "OpenROAD-flow-scripts/flow/scripts/*.script",
-        "OpenROAD-flow-scripts/flow/scripts/*.sh",
         "OpenROAD-flow-scripts/flow/scripts/*.tcl",
-        "OpenROAD-flow-scripts/flow/scripts/*.yaml",
     ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This still works:

bazel run //sram:sdq_17x64_synth $(pwd)/tmp open_synth

Consider these two ORFS versions, there should be no need for resynthesis:

```
$ git diff v3.0-1696-g6927a54e v3.0-1694-g0a5008b6
diff --git a/flow/designs/sky130hd/microwatt/config.mk b/flow/designs/sky130hd/microwatt/config.mk
index 07bdd1cf1..243db9eb3 100644
--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -31,7 +31,7 @@ export MACRO_PLACE_CHANNEL = 200 200
 export CTS_BUF_DISTANCE = 600
 export SKIP_GATE_CLONING = 1
 
-export SETUP_SLACK_MARGIN = 0.2
+export export SETUP_SLACK_MARGIN = 0.2
 
 # This is high, some SRAMs should probably be converted
 # to real SRAMs and not instantiated as flops
$
``
