### PR TITLE
python: use bazel to handle dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -356,3 +356,8 @@ orfs_flow(
         "test/rtl/regfile_128x65.sv",
     ],
 )
+
+py_binary(
+    name = "yaml_to_json",
+    srcs = ["yaml_to_json.py"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,4 @@
+"""This is a Bazel module file."""
 module(
     name = "bazel-orfs",
     version = "0.0.1",
@@ -25,6 +26,22 @@ http_archive(
     urls = ["https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2024-08-28/oss-cad-suite-linux-x64-20240828.tgz"],
 )
 
+bazel_dep(name = "rules_python", version = "0.31.0")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    ignore_root_user_error = True,
+    python_version = "3.12",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pip",
+    python_version = "3.12",
+    requirements_lock = "//:requirements_lock.txt",
+)
+use_repo(pip, "pip")
+
 load_json_file = use_repo_rule("//:load_json_file.bzl", "load_json_file")
 
 load_json_file(
@@ -32,5 +49,5 @@ load_json_file(
     src = "@docker_orfs//:OpenROAD-flow-scripts/flow/scripts/variables.yaml",
     # Dummy output file, we're not actually using it
     out = "variables.json",
-    script = "//:yaml_to_json.py",
+    script = "//:yaml_to_json",
 )

--- a/load_json_file.bzl
+++ b/load_json_file.bzl
@@ -2,19 +2,25 @@
 A repository rule to load a yaml file and convert it into a Starlark file.
 """
 
-def _load_json_file_impl(repository_ctx):
-    yaml_file = repository_ctx.path(repository_ctx.attr.src)
-    json_file = repository_ctx.path(repository_ctx.attr.out)
-    repository_ctx.execute(["python3", repository_ctx.path(repository_ctx.attr.script), yaml_file, json_file])
-    json_data = json.decode(repository_ctx.read(json_file))
-    repository_ctx.file("json.bzl", "orfs_variable_metadata = " + repr(json_data))
-    repository_ctx.file("BUILD", "")
+def _load_json_file_impl(ctx):
+    yaml_file = ctx.path(ctx.attr.src)
+    json_file = ctx.path(ctx.attr.out)
+
+    ctx.execute([ctx.path(ctx.attr.script),yaml_file, json_file])
+
+    json_data = json.decode(ctx.read(json_file))
+    ctx.file("json.bzl", "orfs_variable_metadata = " + repr(json_data))
+    ctx.file("BUILD", "")
 
 load_json_file = repository_rule(
     implementation = _load_json_file_impl,
     attrs = {
         "src": attr.label(allow_single_file = True),
-        "script": attr.label(allow_single_file = True),
+        "script": attr.label(
+            allow_files = True,
+            executable = True,
+            cfg = "exec",
+        ),
         "out": attr.string(),
     },
     local = True,

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,2 @@
+tabulate==0.8.10
+PyYAML==6.0.1


### PR DESCRIPTION
avoid dependency on locally installed python packages