### PR TITLE
netlist: gate netlist filegroup use-case

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -264,20 +264,14 @@ orfs_flow(
     ],
 )
 
+# Need full flow to test final gatelist extraction
 orfs_flow(
     name = "regfile_128x65",
-    abstract_stage = "cts",
-    arguments = SRAM_ARGUMENTS,
-    stage_arguments = {
-        "floorplan": BLOCK_FLOORPLAN | {
-            "DIE_AREA": "0 0 400 400",
-            "CORE_AREA": "2 2 298 298",
-            "IO_CONSTRAINTS": "$(location :io-sram)",
-        },
-        "place": {
-            "PLACE_DENSITY": "0.3",
-            "IO_CONSTRAINTS": "$(location :io-sram)",
-        },
+    arguments = SRAM_ARGUMENTS | BLOCK_FLOORPLAN | {
+        "DIE_AREA": "0 0 400 400",
+        "CORE_AREA": "2 2 298 298",
+        "IO_CONSTRAINTS": "$(location :io-sram)",
+        "PLACE_DENSITY": "0.20"
     },
     stage_sources = {
         "synth": [":constraints-sram"],
@@ -361,4 +355,37 @@ py_binary(
     ],
     main = "plot-retiming.py",
     deps = [requirement("matplotlib")],
+)
+
+filegroup(
+    name = "gatelist",
+    srcs = [
+        "lb_32x128_final",
+        "regfile_128x65_final",
+    ],
+    output_group = "6_final.v",
+)
+
+filegroup(
+    name = "spef",
+    srcs = [
+        "lb_32x128_final",
+        "regfile_128x65_final",
+    ],
+    output_group = "6_final.spef",
+)
+
+# gate netlists can be build by e.g. Verilator, mock
+# usage of the gate netlists here to demonstrate the
+# usecase
+genrule(
+    name = "gatelist_wc",
+    srcs = [
+        ":gatelist",
+        ":spef",
+    ],
+    outs = [
+        "gatelist_wc.txt",
+    ],
+    cmd = "wc -l $(locations :gatelist) $(locations :spef) > $@",
 )

--- a/test/rtl/regfile_128x65.sv
+++ b/test/rtl/regfile_128x65.sv
@@ -53,8 +53,8 @@ module regfile_128x65(
                 R5_data
 );
 
-  // reduced from 128 to 3 to speed up tests
-  reg [64:0] Memory[0:3];
+  // reduced from 128 to 1 to speed up tests
+  reg [64:0] Memory[0:0];
   always @(posedge W0_clk) begin
     if (W0_en)
       Memory[W0_addr[3:0] ^ W0_addr[7:4]] <= W0_data;


### PR DESCRIPTION
The intention here is to document the gate netlist file group use-case.

It needs work... fails:

```
$ bazel build lb_32x128_final
INFO: Analyzed target //:lb_32x128_final (1 packages loaded, 1652 targets configured).
INFO: Found 1 target...
Target //:lb_32x128_final up-to-date:
  bazel-bin/results/asap7/lb_32x128/base/6_final.gds
  bazel-bin/results/asap7/lb_32x128/base/6_final.odb
  bazel-bin/results/asap7/lb_32x128/base/6_final.sdc
  bazel-bin/results/asap7/lb_32x128/base/6_final.spef
  bazel-bin/results/asap7/lb_32x128/base/6_final.v
  bazel-bin/reports/asap7/lb_32x128/base/6_finish.rpt
  bazel-bin/reports/asap7/lb_32x128/base/VDD.rpt
  bazel-bin/reports/asap7/lb_32x128/base/VSS.rpt
INFO: Elapsed time: 0.374s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
$ bazel build gatelist
INFO: Analyzed target //:gatelist (1 packages loaded, 2 targets configured).
ERROR: /home/oyvind/bazel-orfs/BUILD:368:10: //:gatelist: missing input file '//:results/asap7/lb_32x128/base/6_final.v'
ERROR: /home/oyvind/bazel-orfs/BUILD:368:10: 1 input file(s) do not exist
Target //:gatelist failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.088s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```
