### PR TITLE
orfs_flow: support ADDITIONAL_LIBS/LEFS/GDS/FILES

### DIFF
--- a/sweep.bzl
+++ b/sweep.bzl
@@ -61,7 +61,17 @@ def orfs_sweep(
 
     for variant in all_variants:
         for key in all_variants[variant].keys():
-            if key not in ["arguments", "dissolve", "macros", "previous_stage", "renamed_inputs", "stage_arguments", "stage_sources", "description"]:
+            if key not in [
+                "arguments",
+                "dissolve",
+                "macros",
+                "previous_stage",
+                "renamed_inputs",
+                "stage_arguments",
+                "stage_sources",
+                "description",
+                "sources",
+            ]:
                 fail("Unknown orfs_sweep() key \"" + key + "\" in " + variant)
 
         orfs_flow(
@@ -83,7 +93,7 @@ def orfs_sweep(
             },
             variant = variant,
             verilog_files = verilog_files,
-            sources = sources,
+            sources = sources | all_variants[variant].get("sources", {}),
             abstract_stage = abstract_stage,
             visibility = visibility,
         )


### PR DESCRIPTION
Doesn't work yet unless `bazel run L1MetadataArray_1_floorplan_deps /tmp/foo` is run first:


```
bazel run L1MetadataArray_1_floorplan /tmp/foo open_floorplan
INFO: Invocation ID: fdd7f97c-d361-4ec4-a8f1-de43c3bba8da
INFO: Analyzed target //:L1MetadataArray_1_floorplan (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:L1MetadataArray_1_floorplan up-to-date:
  bazel-bin/results/asap7/L1MetadataArray/1/2_floorplan.odb
  bazel-bin/results/asap7/L1MetadataArray/1/2_floorplan.sdc
  bazel-bin/reports/asap7/L1MetadataArray/1/2_floorplan_final.rpt
INFO: Elapsed time: 0.106s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/L1MetadataArray_1_floorplan.sh /tmp/foo open_floorplan
ODB_FILE=.//results/asap7/L1MetadataArray/1/2_floorplan.odb external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -no_init -threads 12  external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/scripts/open.tcl
OpenROAD HEAD-HASH-NOTFOUND 
Features included (+) or not (-): +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 12 thread(s).
Error: read_liberty.tcl, 25 cannot read file results/asap7/tag_array_64x184/base/tag_array_64x184.lib.
openroad> 
```
