### PR TITLE
open: fixes e.g. FASTROUTE_TCL error in open.tcl

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -451,6 +451,7 @@ orfs_flow(
     pdk = "@docker_orfs//:sky130hd",
     sources = {
         "SDC_FILE": [":constraints-sram-sky130hd.sdc"],
+        "FASTROUTE_TCL": [":fastroute.tcl"],
     },
     top = "lb_32x128",
     verilog_files = LB_VERILOG_FILES,

--- a/fastroute.tcl
+++ b/fastroute.tcl
@@ -1,0 +1,7 @@
+# Test FASTROUTE_TCL 
+set_global_routing_layer_adjustment $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) $::env(ROUTING_LAYER_ADJUSTMENT)
+set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)
+if {[env_var_exists_and_non_empty MACRO_EXTENSION]} {
+  set_macro_extension $::env(MACRO_EXTENSION)
+}
+  

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -1016,7 +1016,9 @@ def _make_impl(
             runfiles = ctx.runfiles(
                 [config_short, make] +
                 forwards + results + logs + reports + ctx.files.extra_configs +
-                drcs + jsons,
+                drcs + jsons +
+                # Some of these files might be read by open.tcl
+                ctx.files.data,
                 transitive_files = depset(transitive = [
                     flow_inputs(ctx),
                     ctx.attr.src[PdkInfo].files,


### PR DESCRIPTION
Fixes:

```
$ rm -rf /tmp/foo && bazel run lb_32x128_sky130hd_grt /tmp/foo gui_grt [ERROR STA-0340] cannot open './fastroute.tcl'.
[ERROR GUI-0070] Error: open.tcl, 74 STA-0340
```
