### PR TITLE
yosys: show standalone use-case

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@ load("//:eqy.bzl", "eqy_test")
 load("//:openroad.bzl", "get_stage_args", "orfs_floorplan", "orfs_flow", "orfs_macro", "orfs_run")
 load("//:ppa.bzl", "orfs_ppa")
 load("//:sweep.bzl", "orfs_sweep")
+load("//:yosys.bzl", "yosys")
 
 exports_files(["mock_area.tcl"])
 
@@ -455,4 +456,14 @@ orfs_flow(
     },
     top = "lb_32x128",
     verilog_files = LB_VERILOG_FILES,
+)
+
+yosys(
+    name = "alu",
+    srcs = ["alu.v"],
+    outs = ["alu.json"],
+    arguments = [
+        "-p",
+        "read_verilog $(location alu.v); proc; write_json $(location alu.json)",
+    ],
 )

--- a/alu.v
+++ b/alu.v
@@ -1,0 +1,26 @@
+module ALU(
+    input clk,
+    input [31:0] a,
+    input [31:0] b,
+    input [2:0] op,
+    output reg [31:0] out
+    );
+    reg [31:0] aReg;
+    reg [31:0] bReg;
+    reg [2:0] opReg;
+
+    always @*
+    begin
+        case(opReg)
+            3'b001: out = aReg + bReg;
+            3'b010: out = aReg & bReg;
+            3'b011: out = aReg | bReg;
+            default: out = 32'd0;       // Handle other cases or add a default value
+        endcase
+    end
+    always @(posedge clk) begin
+        aReg <= a;
+        bReg <= b;
+        opReg <= op;
+    end
+endmodule

--- a/yosys.bzl
+++ b/yosys.bzl
@@ -1,0 +1,51 @@
+"""Yosys rules"""
+
+def _yosys_impl(ctx):
+    outs = []
+    for k in dir(ctx.outputs):
+        outs.extend(getattr(ctx.outputs, k))
+
+    ctx.actions.run(
+        arguments = [ctx.expand_location(arg, ctx.attr.srcs) for arg in ctx.attr.arguments],
+        executable = ctx.executable._yosys,
+        inputs = depset(
+            ctx.files.srcs + [
+                ctx.executable._yosys,
+            ],
+            transitive = [
+                ctx.attr._yosys[DefaultInfo].default_runfiles.files,
+                ctx.attr._yosys[DefaultInfo].default_runfiles.symlinks,
+            ],
+        ),
+        outputs = outs,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(outs),
+        ),
+    ]
+
+yosys = rule(
+    implementation = _yosys_impl,
+    attrs = {
+        "_yosys": attr.label(
+            doc = "Yosys binary.",
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = Label("@docker_orfs//:yosys"),
+        ),
+        "arguments": attr.string_list(
+            mandatory = True,
+        ),
+        "srcs": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+        ),
+        "outs": attr.output_list(
+            mandatory = True,
+        ),
+    },
+    provides = [DefaultInfo],
+)


### PR DESCRIPTION
```
$ bazel build alu
INFO: Invocation ID: 8abc9dce-1f7a-4ffc-89fc-1405ce367437
INFO: Analyzed target //:alu (0 packages loaded, 0 targets configured).
ERROR: /home/oyvind/bazel-orfs/BUILD:460:8: Executing genrule //:alu failed: (Exit 127): bash failed: error executing Genrule command (from target //:alu) /bin/bash -c ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
+ ldd external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/tools/install/yosys/bin/yosys
+ external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/tools/install/yosys/bin/yosys -p 'read_verilog ./alu.v; write_json bazel-out/k8-fastbuild/bin/alu.json'
/bin/bash: line 4: external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/tools/install/yosys/bin/yosys: cannot execute: required file not found
	linux-vdso.so.1 (0x00007ffe55b6e000)
	libstdc++.so.6 => not found
	libm.so.6 => not found
	libreadline.so.8 => not found
	libffi.so.8 => not found
	libz.so.1 => not found
	libtcl8.6.so => not found
	libgcc_s.so.1 => not found
	libc.so.6 => not found
Target //:alu failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.328s, Critical Path: 0.24s
INFO: 2 processes: 2 internal.
ERROR: Build did NOT complete successfully
```
