### PR TITLE
bazel: forward more kwargs

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -1582,10 +1582,12 @@ def _orfs_pass(
             variant = variant,
             verilog_files = verilog_files,
             pdk = pdk,
+            **kwargs
         )
         orfs_deps(
             name = "{}_deps".format(_step_name(name, variant, synth_step.stage)),
             src = _step_name(name, variant, synth_step.stage),
+            **kwargs
         )
 
     if start_stage == 0:

--- a/sweep.bzl
+++ b/sweep.bzl
@@ -57,6 +57,7 @@ def orfs_sweep(
     write_binary(
         name = name + "_sweep.json",
         data = str(sweep_json),
+        tags = tags,
     )
 
     all_variants = sweep | other_variants


### PR DESCRIPTION
Check for targets that should have, but don't, have the tags = ["manual"] set:

	bazel query 'kind(rule, ...) - attr(tags, manual, ...)'