### PR TITLE
LoggingInfo: typo, drcs and jsons were mixed up with reports

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -240,6 +240,7 @@ def source_inputs(ctx):
             ctx.attr.src[PdkInfo].files,
             ctx.attr.src[LoggingInfo].jsons,
             ctx.attr.src[LoggingInfo].logs,
+            ctx.attr.src[LoggingInfo].reports,
         ],
     )
 


### PR DESCRIPTION
forgot reports.