### PR TITLE
Fix yosys deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,11 +74,11 @@ orfs = use_extension("//:extension.bzl", "orfs_repositories")
 orfs.default(
     # a local only or remote docker image. Local docker images do not
     # have a sha256.
-    image = "docker.io/openroad/orfs:v3.0-3060-gaa611ef7",
+    image = "docker.io/openroad/orfs:v3.0-3081-g0c7a7a98",
     # Smoketest, this is the default value
     makefile = "@docker_orfs//:makefile",
     # Comment out line below for local only docker images
-    sha256 = "d7b08fd04206a66afc34a4df17e727eff18cfb9aaf0f5f74198057a9dd9a346f",
+    sha256 = "e81b1540dfbbbd86f1558044a9d35dfc388cd971ae67936a9655efbf1abdeb0e",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -143,7 +143,7 @@
     "//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "opZMguyG+UPmDQ6vhzXe/u0WnKyao2m9IAQt+JWkhcA=",
-        "usagesDigest": "bzMHzV/yHNETG/j3ohC6Y3RU8Ql31n1bb0Sq6Y0qY6c=",
+        "usagesDigest": "bNFMnK4V6ifMlsipqo+bCUvtuw1uDyYmmwZQT0NGgBY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -163,8 +163,8 @@
             "bzlFile": "@@//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-3060-gaa611ef7",
-              "sha256": "d7b08fd04206a66afc34a4df17e727eff18cfb9aaf0f5f74198057a9dd9a346f",
+              "image": "docker.io/openroad/orfs:v3.0-3081-g0c7a7a98",
+              "sha256": "e81b1540dfbbbd86f1558044a9d35dfc388cd971ae67936a9655efbf1abdeb0e",
               "build_file": "@@//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [

--- a/docker.BUILD.bazel
+++ b/docker.BUILD.bazel
@@ -44,7 +44,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-sh_binary(
+filegroup(
     name = "yosys",
     data = [
         ":ld.so",


### PR DESCRIPTION
Before this fix:

```
$ bazel run tag_array_64x184_synth_deps /tmp/xxx do-yosys
INFO: Invocation ID: b7a692b2-3fa4-46b2-bc4b-7ea82cd6e1da
INFO: Analyzed target //:tag_array_64x184_synth_deps (1 packages loaded, 1644 targets configured).
INFO: Found 1 target...
Target //:tag_array_64x184_synth_deps up-to-date:
  bazel-bin/results/asap7/tag_array_64x184/base/1_synth.short.mk
INFO: Elapsed time: 36.496s, Critical Path: 0.08s
INFO: 5 processes: 5 internal.
INFO: Build completed successfully, 5 total actions
INFO: Running command line: bazel-bin/results/asap7/tag_array_64x184/base/tag_array_64x184_synth_deps.sh /tmp/xxx do-yosys
external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/scripts/synth.sh external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/scripts/synth.tcl .//logs/asap7/tag_array_64x184/base/1_1_yosys.log
time: cannot run bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/_main~orfs_repositories~docker_orfs/yosys: No such file or directory
Command exited with non-zero status 127
Elapsed time: 0:00.00[h:]min:sec. CPU time: user 0.00 sys 0.00 (80%). Peak memory: 1024KB.
make: *** [external/_main~orfs_repositories~docker_orfs/OpenROAD-flow-scripts/flow/Makefile:287: do-yosys] Error 1
```
