### PR TITLE
orfs_run: faster macro placement and io pin placement generation

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -340,6 +340,11 @@ def _deps_impl(ctx):
             files = ctx.attr.src[OrfsDepInfo].files,
             runfiles = ctx.attr.src[OrfsDepInfo].runfiles,
         ),
+        ctx.attr.src[OrfsInfo],
+        ctx.attr.src[PdkInfo],
+        ctx.attr.src[TopInfo],
+        ctx.attr.src[LoggingInfo],
+        ctx.attr.src[OrfsDepInfo],
     ]
 
 def flow_provides():

--- a/sram/BUILD
+++ b/sram/BUILD
@@ -183,13 +183,15 @@ orfs_macro(
 # Use the macro placement from a different flow
 orfs_run(
     name = "top_write_macro_placement",
-    src = ":top_floorplan",
+    src = ":top_floorplan_deps",
     outs = [
         ":macro_placement.tcl",
     ],
     arguments = {
         "MESSAGE": "Hello world!",
     },
+    # Run only the steps we need, faster
+    cmd = "do-2_1_floorplan do-2_2_floorplan_macro run",
     script = ":write_macros.tcl",
 )
 

--- a/sram/write_macros.tcl
+++ b/sram/write_macros.tcl
@@ -1,4 +1,5 @@
-source $::env(SCRIPTS_DIR)/open.tcl
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 2_2_floorplan_macro.odb 2_1_floorplan.sdc
 
 set f [file join $::env(WORK_HOME) "macro_placement.tcl"]
 


### PR DESCRIPTION
Generate macro placement without running entire floorplan and pin placement without running global & detailed placement.

A future experiment would be to try some shenanigans and generate macro and pin placement and skipping unneded steps like PDN