### PR TITLE
pinning: added pinning of artifacts

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,8 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
+
+# Unused in CI
+#
+# load("@bazel-orfs//tools/pin:pin.bzl", "pin_data")
 load("@bazel_orfs_rules_python//python:defs.bzl", "py_binary")
 load("@bazel_orfs_rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@npm//:defs.bzl", "npm_link_all_packages")
@@ -501,3 +505,22 @@ sh_binary(
     srcs = ["bump.sh"],
     visibility = ["//visibility:public"],
 )
+
+# Not in use in CI
+#
+# pin_data(
+#     name = "pin",
+#     srcs = [
+#         ":alu",
+#     ],
+#     artifacts_lock = "artifacts_lock.txt",
+#     bucket = "some-google-bucket",
+# )
+
+# filegroup(
+#     name = "foo",
+#     srcs = [
+#         "@pinned//alu",
+#     ],
+#     tags = ["manual"],
+# )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -83,3 +83,12 @@ orfs.default(
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")
 use_repo(orfs, "config")
+
+# Not in use in CI
+#
+# pin = use_extension("//extensions:pin.bzl", "pin")
+# pin.artifacts(
+#     artifacts_lock = "//:artifacts_lock.txt",
+#     repo_name = "pinned",
+# )
+# use_repo(pin, "pinned")

--- a/extensions/BUILD.bazel
+++ b/extensions/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(
+    ["pin.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/extensions/pin.bzl
+++ b/extensions/pin.bzl
@@ -1,0 +1,26 @@
+"""Pinning of artifacts"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _attrs(content):
+    (url, sha256) = content.split("@")
+    return {
+        "url": url,
+        "sha256": sha256,
+    }
+
+def _pin_impl(repository_ctx):
+    for mod in repository_ctx.modules:
+        for install in mod.tags.artifacts:
+            content = repository_ctx.read(install.artifacts_lock)
+            http_archive(name = install.repo_name, **_attrs(content))
+
+pin = module_extension(
+    implementation = _pin_impl,
+    tag_classes = {
+        "artifacts": tag_class(attrs = {
+            "repo_name": attr.string(),
+            "artifacts_lock": attr.label(),
+        }),
+    },
+)

--- a/tools/pin/BUILD.bazel
+++ b/tools/pin/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files([
+    "pin.py",
+    "pin.sh.tpl",
+])

--- a/tools/pin/README.md
+++ b/tools/pin/README.md
@@ -1,0 +1,48 @@
+# Pinning of artifacts
+
+Pinning artifacts can be useful with OpenROAD flows because some targets can take a very long time to run and hardly ever change:
+
+- Netlist of a large register file, multiplier, floating point unit, etc. may hardly ever change, so pin these artifacts and only re-synthesize the parts of the design that is under active development
+- Macro and pin placement is only known after placement, which can take a long time and also it may be desirable to keep macro placement and pin placement stable while other parts of the design changes.
+
+## MODULE.bazel changes
+
+Create a pinning repository:
+
+```starlark
+pin = use_extension("@bazel-orfs//:extensions/pin.bzl", "pin")
+pin.artifacts(
+    artifacts_lock = "//:artifacts_lock.txt",
+    repo_name = "pinned",
+)
+use_repo(pin, "pinned")
+```
+
+## BUILD.bazel changes to define pinned artifacts
+
+```starlark
+pin_data(
+    name = "pin",
+    srcs = [
+        ":someslowtarget",
+    ],
+    artifacts_lock = "artifacts_lock.txt",
+    bucket = "some-google-bucket",
+)
+```
+
+## Using pinned artifacts from a BUILD.bazel file
+
+```starlark
+filegroup(
+    name = "foo",
+        srcs = [
+            "@pinned//someslowtarget",
+            ..
+```
+
+## Updating pinned artifacts
+
+This will build the artifacts, upload them to the bucket and update `artifacts_locked.txt`
+
+    bazelisk run :pin

--- a/tools/pin/pin.bzl
+++ b/tools/pin/pin.bzl
@@ -1,0 +1,59 @@
+"""Pinning of artifacts"""
+
+def _serialize_file(file):
+    return "@".join([
+        file.path,
+        file.root.path,
+        file.owner.workspace_root,
+    ])
+
+def _serialize(target):
+    if len(target.files.to_list()) == 0:
+        fail("Target {} has no files to pin".format(target.label))
+
+    return repr(",".join([
+        str(target.label),
+        target.label.workspace_root,
+        ":".join([_serialize_file(file) for file in target.files.to_list()]),
+    ]))
+
+def _pin_data_impl(ctx):
+    exe = ctx.actions.declare_file(ctx.attr.name + ".sh")
+    ctx.actions.expand_template(
+        substitutions = {
+            "${PINNER}": ctx.file._pinner.short_path,
+            "${BUCKET}": ctx.attr.bucket,
+            "${PACKAGE}": ctx.label.package,
+            "${LOCK}": ctx.attr.artifacts_lock,
+            "\"$@\"": " ".join([_serialize(target) for target in ctx.attr.srcs]),
+        },
+        template = ctx.file._pin_template,
+        output = exe,
+    )
+    return [DefaultInfo(
+        executable = exe,
+        files = depset([exe]),
+        runfiles = ctx.runfiles(ctx.files._pinner + ctx.files.srcs),
+    )]
+
+pin_data = rule(
+    implementation = _pin_data_impl,
+    provides = [DefaultInfo, OutputGroupInfo],
+    attrs = {
+        "artifacts_lock": attr.string(mandatory = True),
+        "bucket": attr.string(mandatory = True),
+        "srcs": attr.label_list(
+            allow_files = True,
+            default = [],
+        ),
+        "_pin_template": attr.label(
+            default = "@bazel-orfs//tools/pin:pin.sh.tpl",
+            allow_single_file = True,
+        ),
+        "_pinner": attr.label(
+            default = "@bazel-orfs//tools/pin:pin.py",
+            allow_single_file = True,
+        ),
+    },
+    executable = True,
+)

--- a/tools/pin/pin.py
+++ b/tools/pin/pin.py
@@ -1,0 +1,193 @@
+#! /bin/env python3
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import typing
+import urllib.parse
+
+
+class Label(typing.NamedTuple):
+    repo: str
+    package: str
+    name: str
+
+
+def label(s):
+    (repo, path) = s.split("//")
+    (package, name) = path.split(":")
+    return Label(repo=repo, package=package, name=name)
+
+
+class File(typing.NamedTuple):
+    path: str
+    root: str
+    workspace_root: str
+
+    def runfile_path(self):
+        return os.path.join(
+            os.environ["RUNFILES"], os.path.relpath(self.path, self.root)
+        )
+
+    def archive_path(self):
+        return os.path.relpath(
+            os.path.relpath(self.path, self.root), self.workspace_root
+        )
+
+
+def file(s):
+    (path, root, workspace_root) = s.split("@")
+    return File(path=path, root=root, workspace_root=workspace_root)
+
+
+class Artifact(typing.NamedTuple):
+    label: Label
+    files: typing.Set[File]
+
+
+class ArtifactAction(argparse.Action):
+
+    def __init__(self, option_strings, dest, nargs, **kwargs):
+        super().__init__(option_strings, dest, nargs, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        artifacts = []
+        for artifact in values:
+            (l, root, files) = artifact.split(",")
+            artifacts.append(
+                Artifact(
+                    label=label(l), files=frozenset([file(s) for s in files.split(":")])
+                )
+            )
+        setattr(namespace, self.dest, artifacts)
+
+
+def build_write(artifacts, output):
+    for artifact in artifacts:
+        match sorted(artifact.files):
+            case [x] if (
+                os.path.relpath(x.archive_path(), artifact.label.package)
+                == artifact.label.name
+            ):
+                print("exports_files(", file=output)
+                print("  srcs = [", file=output)
+                for file in artifact.files:
+                    print(
+                        "    {},".format(
+                            repr(
+                                os.path.relpath(
+                                    file.archive_path(), artifact.label.package
+                                )
+                            )
+                        ),
+                        file=output,
+                    )
+                print("  ],".format(artifact.label), file=output)
+                print('  visibility = ["//visibility:public"],', file=output)
+                print(")", file=output)
+            case _:
+                print("filegroup(", file=output)
+                print("  name = {},".format(repr(artifact.label.name)), file=output)
+                print("  srcs = [", file=output)
+                for file in sorted(artifact.files):
+                    print(
+                        "    {},".format(
+                            repr(
+                                os.path.relpath(
+                                    file.archive_path(), artifact.label.package
+                                )
+                            )
+                        ),
+                        file=output,
+                    )
+                print("  ],".format(artifact.label), file=output)
+                print('  visibility = ["//visibility:public"],', file=output)
+                print(")", file=output)
+
+
+def gs(bucket, path):
+    return urllib.parse.urlunparse(("gs", bucket, path, None, None, None))
+
+
+def https(bucket, path):
+    return urllib.parse.urlunparse(
+        (
+            "https",
+            "storage.googleapis.com",
+            os.path.join(bucket, path),
+            None,
+            None,
+            None,
+        )
+    )
+
+
+def reset(tarinfo):
+    tarinfo.mtime = 0
+    tarinfo.uid = 0
+    tarinfo.uname = "root"
+    tarinfo.gid = 0
+    tarinfo.gname = "root"
+    return tarinfo
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", "--bucket", help="Google cloud bucket used for uploads.")
+    parser.add_argument("-l", "--lock", help="Lock file.")
+    parser.add_argument("-p", "--package", help="Bazel package.")
+    parser.add_argument("artifact", action=ArtifactAction, nargs="+")
+
+    args = parser.parse_args()
+
+    pkgs = {}
+    for artifact in args.artifact:
+        pkgs.setdefault(artifact.label.package, []).append(artifact)
+
+    path = tempfile.mkdtemp()
+    try:
+        tar_path = os.path.join(path, args.lock + ".tar")
+        with tarfile.open(tar_path, "w", dereference=True) as tar:
+            for pkg, artifacts in pkgs.items():
+                pkg_build_path = os.path.join(pkg, "BUILD")
+                build_path = os.path.join(path, pkg_build_path)
+                os.makedirs(os.path.dirname(build_path), exist_ok=True)
+
+                with open(build_path, "w") as build:
+                    build_write(artifacts, build)
+
+                tar.add(build_path, arcname=pkg_build_path, filter=reset)
+                for file in sorted(
+                    frozenset.union(*[artifact.files for artifact in artifacts])
+                ):
+                    tar.add(
+                        file.runfile_path(), arcname=file.archive_path(), filter=reset
+                    )
+
+        with open(tar_path, "rb") as f:
+            sha256 = hashlib.file_digest(f, "sha256")
+
+        dir, _ = os.path.splitext(args.lock)
+        name = os.path.join(args.package, dir, sha256.hexdigest() + ".tar")
+        subprocess.run(["gsutil", "mv", "-n", "-Z", tar_path, gs(args.bucket, name)])
+
+        with open(
+            os.path.join(
+                os.environ["BUILD_WORKSPACE_DIRECTORY"], args.package, args.lock
+            ),
+            "w",
+        ) as f:
+            f.write(https(args.bucket, name))
+            f.write("@")
+            f.write(sha256.hexdigest())
+
+    finally:
+        shutil.rmtree(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pin/pin.sh.tpl
+++ b/tools/pin/pin.sh.tpl
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+export RUNFILES="$0.runfiles/_main"
+
+exec python3 "${RUNFILES}/${PINNER}" --bucket "${BUCKET}" --lock "${LOCK}" --package "${PACKAGE}" "$@"


### PR DESCRIPTION
# Pinning of artifacts

Pinning artifacts can be useful with OpenROAD flows because some targets can take a very long time to run and hardly ever change:

- Netlist of a large register file, multiplier, floating point unit, etc. may hardly ever change, so pin these artifacts and only re-synthesize the parts of the design that is under active development
- Macro and pin placement is only known after placement, which can take a long time and also it may be desirable to keep macro placement and pin placement stable while other parts of the design changes.

## MODULE.bazel changes

Create a pinning repository:

```starlark
pin = use_extension("@bazel-orfs//:extensions/pin.bzl", "pin")
pin.artifacts(
    artifacts_lock = "//:artifacts_lock.txt",
    repo_name = "pinned",
)
use_repo(pin, "pinned")
```

## BUILD.bazel changes to define pinned artifacts

```starlark
pin_data(
    name = "pin",
    srcs = [
        ":someslowtarget",
    ],
    artifacts_lock = "artifacts_lock.txt",
    bucket = "some-google-bucket",
)
```

## Using pinned artifacts from a BUILD.bazel file

```starlark
filegroup(
    name = "foo",
        srcs = [
            "@pinned//someslowtarget",
            ..
```

## Updating pinned artifacts

This will build the artifacts, upload them to the bucket and update `artifacts_locked.txt`

    bazelisk run :pin
