### PR TITLE
test: reduce running times

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -207,9 +207,9 @@ orfs_macro(
     module_top = "tag_array_64x184",
 )
 
-# Run one macro through all stages
 orfs_sweep(
     name = "L1MetadataArray",
+    abstract_stage = "cts",
     arguments = FAST_SETTINGS |
                 {
                     "SYNTH_HIERARCHICAL": "1",


### PR DESCRIPTION
we do a full run elsewhere in the flow:

$ bazelisk query :* | grep final
Loading: 0 packages loaded
//:lb_32x128_final
//:lb_32x128_final_deps
//:lb_32x128_ihp-sg13g2_final
//:lb_32x128_ihp-sg13g2_final_deps
//:lb_32x128_sky130hd_final
//:lb_32x128_sky130hd_final_deps
//:regfile_128x65_final
//:regfile_128x65_final_deps