### PR TITLE
firtool: belt and suspenders args

### DIFF
--- a/sby/BUILD
+++ b/sby/BUILD
@@ -29,6 +29,12 @@ fir_library(
     generator = ":generate_counter",
     opts = [
         "TestCounter",
+        "--disable-all-randomization",
+        "-strip-debug-info",
+        "-disable-layers=Verification",
+        "-disable-layers=Verification.Assert",
+        "-disable-layers=Verification.Assume",
+        "-disable-layers=Verification.Cover",
     ],
     tags = ["manual"],
 )

--- a/verilog.bzl
+++ b/verilog.bzl
@@ -80,7 +80,7 @@ def _only_sv(f):
 
     # FIXME ideally we could use verilog_file directly on the fir target
     # https://github.com/llvm/circt/issues/9020
-    if f.extension in ["v", "sv"] and not "/verification/" in f.path:
+    if f.extension in ["v", "sv"]:
         return f.path
     return None
 


### PR DESCRIPTION
firtool converts from .fir to .mlir, from .mlir to .sv, pass in firtool options both times

```
$ bazelisk test //sby:counter_test
INFO: Analyzed target //sby:counter_test (1 packages loaded, 7 targets configured).
INFO: Found 1 test target...
Target //sby:counter_test up-to-date:
  bazel-bin/sby/counter_test.run.sh
INFO: Elapsed time: 0.553s, Critical Path: 0.38s
INFO: 2 processes: 16 action cache hit, 2 processwrapper-sandbox.
INFO: Build completed successfully, 2 total actions
//sby:counter_test                                                       PASSED in 0.2s
```
