### PR TITLE
Use BooleanOptionalAction for --check-bloop flag

### DIFF
--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -18,8 +18,7 @@ def main():
     parser.add_argument("--manifest")
     parser.add_argument(
         "--check-bloop",
-        action="store_true",
-        default=False,
+        action=argparse.BooleanOptionalAction,
         help="Check pre-conditions for bloop to work.",
     )
     parser.add_argument("--directory", nargs=1, default=[])


### PR DESCRIPTION
This way we can override this flag by running `bazelisk run //:bloop -- --no-check-bloop`.