### PR TITLE
orfs: bump

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -96,11 +96,11 @@ orfs = use_extension("//:extension.bzl", "orfs_repositories")
 orfs.default(
     # a local only or remote docker image. Local docker images do not
     # have a sha256.
-    image = "docker.io/openroad/orfs:v3.0-4072-g2a1832971",
+    image = "docker.io/openroad/orfs:v3.0-4123-g30da7ceff",
     # Smoketest, this is the default value
     makefile = "@docker_orfs//:makefile",
     # Comment out line below for local only docker images
-    sha256 = "d5ac8b165ebab339eb98beb63a463eab5ed78364335fb1455c2e1d75eb757c3d",
+    sha256 = "974844d2c888227a07f4d6a4e1c7b969a61723f3ecb7eb72c5e1145d8d33a7d0",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -173,7 +173,7 @@
     "//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "W2FcgOTim8eocKPV5zKBqUWCMCrRjVK8KK28G/2fPTE=",
-        "usagesDigest": "3lVbpK65W75DmGcmhC3Ih1kyZ8sVamfBSwXTxhmN/hQ=",
+        "usagesDigest": "uVSqw39av8X/AJB7oz3WyE+jGLc7btbNBmAsRDhn6IQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -191,8 +191,8 @@
           "docker_orfs": {
             "repoRuleId": "@@//:docker.bzl%docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-4072-g2a1832971",
-              "sha256": "d5ac8b165ebab339eb98beb63a463eab5ed78364335fb1455c2e1d75eb757c3d",
+              "image": "docker.io/openroad/orfs:v3.0-4123-g30da7ceff",
+              "sha256": "974844d2c888227a07f4d6a4e1c7b969a61723f3ecb7eb72c5e1145d8d33a7d0",
               "build_file": "@@//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [


### PR DESCRIPTION
[#8735](https://github.com/The-OpenROAD-Project/OpenROAD/pull/8375) is failing in bazel, because the current test/orfs version doesn't have the changes in [#3504](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3504).

AFAIU, we need to first bump here and then on OR.