### PR TITLE
fix: correct assertion in LifeUniverse test

### DIFF
--- a/chisel/LifeTests.cpp
+++ b/chisel/LifeTests.cpp
@@ -85,5 +85,5 @@ TEST(LifeUniverse, DirectSignalTest) {
   harness.run_until_done();
 
   // Check done signal
-  ASSERT_EQ(harness.top.done, 0);
+  ASSERT_EQ(harness.top.done, 1);
 }


### PR DESCRIPTION
The `run_until_done()` method waits until the 'done' signal becomes true (when counter reaches 42), but the test was incorrectly asserting that done should be 0. This fixes the assertion to expect done=1 after `run_until_done()` completes.