### PR TITLE
bazel: bazelisk run :bloop now works without hack

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,12 +2,4 @@ build --incompatible_strict_action_env
 
 common --incompatible_disallow_empty_glob
 
-# Stamping the manifest changes the name of `scala-compiler-2.13.17.jar` to
-# `processed_scala-compiler-2.13.17.jar`, which keeps `bloop` from recognizing
-# it.
-# Read more:
-# https://web.archive.org/web/20250624074624/https://github.com/scalacenter/bloop/blob/b90aaa82e0799b8783b1812f4c07961d4c47ec30/backend/src/main/scala/bloop/ScalaInstance.scala#L73-L75
-# https://web.archive.org/web/20250624074941/https://github.com/bazel-contrib/rules_jvm_external/issues/786
-common --@rules_jvm_external//settings:stamp_manifest=false
-
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
@MrAMS FYI, cleanup.

Did you try out the following to set up Chisel editing .bloop files for e.g. vscode?

    bazelisk run :bloop