### PR TITLE
orfs: keep up, 1_2_yosys.v is now the synthesis output

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -907,7 +907,7 @@ orfs_test = rule(
 )
 
 CANON_OUTPUT = "1_1_yosys_canonicalize.rtlil"
-SYNTH_OUTPUTS = ["1_synth.v", "1_synth.sdc", "mem.json", "1_synth.odb"]
+SYNTH_OUTPUTS = ["1_2_yosys.v", "1_synth.sdc", "mem.json", "1_synth.odb"]
 SYNTH_REPORTS = ["synth_stat.txt"]
 
 def _yosys_impl(ctx):


### PR DESCRIPTION
@MrAMS FYI, for very large designs, it is possible do use bazel-orfs to do abc in parallel using bazel-orfs, which speeds up synthesis from hours to minutes, hence synthesis output .v is needed.

No test/demo in CI of this though...