### PR TITLE
Fix synthesis make target: replace do-1_synth with do-synth

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -983,7 +983,9 @@ def _yosys_impl(ctx):
             ctx.file._makefile_yosys.path,
             "yosys-dependencies",
             "do-yosys",
-            "do-1_synth",
+            "do-synth",
+            # convert to .odb using OpenROAD
+            "do-1_3_synth",
         ],
         command = " && ".join(commands),
         env = _verilog_arguments([]) |


### PR DESCRIPTION
The make target 'do-1_synth' does not exist in OpenROAD-flow-scripts Makefile. This causes synthesis to fail with 'No rule to make target'.

Replace 'do-1_synth' with the correct targets:
- 'do-synth' for synthesis
- 'do-1_3_synth' to convert result to .odb format

This makes synthesis work correctly and consistent with other stages.