### PR TITLE
ci: speed up free-disk-space action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,10 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
           docker-images: true
-          swap-storage: true
+          # Set false for speed (~4min -> ~47s); ~20GB savings remain sufficient.
+          large-packages: false
+          swap-storage: false
       - name: Checkout bazel-orfs
         uses: actions/checkout@v4
 


### PR DESCRIPTION
It can reduce time from ~4min to 47s :rocket: which can still save ~20GB which is enough for us.
I think it is a good trade off.