### PR TITLE
optuna: avoid python language servers from locking up with 100% cpu when discovering bazel folders

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,5 +7,6 @@
         "**/__pycache__",
         "**/node_modules",
         "**/__pycache__",
+        "optuna/trial_runs/**/*",
     ],
 }


### PR DESCRIPTION
@MrAMS FYI