### PR TITLE
[DRAFT] optuna: switch to mock-cpu

### DIFF
--- a/optuna/BUILD
+++ b/optuna/BUILD
@@ -10,14 +10,12 @@ exports_files([
 
 # DSE-specific flow configuration with tighter constraints
 orfs_flow(
-    name = "lb_32x128",
+    name = "mock-cpu",
     abstract_stage = "cts",
     arguments = {
-        # Tight timing constraints for meaningful DSE
         "CORE_ASPECT_RATIO": "0.5",
         "CORE_UTILIZATION": "50",  # Higher utilization
         "PLACE_DENSITY": "0.20",
-        "PLACE_PINS_ARGS": "-min_distance 1 -min_distance_in_tracks",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
         # Enable timing-driven optimization for DSE
         "GPL_TIMING_DRIVEN": "1",  # Enable timing-driven placement
@@ -31,31 +29,34 @@ orfs_flow(
         "SKIP_INCREMENTAL_REPAIR": "1",
         "SKIP_REPORT_METRICS": "1",
         "TAPCELL_TCL": "",
+        # Tight timing constraints for meaningful DSE
+        "ABC_CLOCK_PERIOD_IN_PS": "1000",
+        # Synthesis
+        "SYNTH_HDL_FRONTEND": "slang",
     },
-    mock_area = 0.7,
+    top = "mock_cpu",
     sources = {
         "SDC_FILE": [":constraints-dse.sdc"],
-        "IO_CONSTRAINTS": ["//:io-sram"],
     },
     tags = ["manual"],
-    verilog_files = ["//:test/mock/lb_32x128.sv"],
+    verilog_files = [":mock-cpu.sv"],
 )
 
 # Extract timing information from CTS
 orfs_run(
-    name = "lb_32x128_timing",
-    src = ":lb_32x128_cts",
-    outs = ["lb_32x128_timing.txt"],
-    arguments = {"OUTFILE": "$(location lb_32x128_timing.txt)"},
+    name = "mock-cpu_timing",
+    src = ":mock-cpu_cts",
+    outs = ["mock-cpu_timing.txt"],
+    arguments = {"OUTFILE": "$(location mock-cpu_timing.txt)"},
     script = ":extract_timing.tcl",
 )
 
 # Extract PPA (Performance, Power, Area) metrics from CTS
 orfs_run(
-    name = "lb_32x128_ppa",
-    src = ":lb_32x128_cts",
-    outs = ["lb_32x128_ppa.txt"],
-    arguments = {"OUTFILE": "$(location lb_32x128_ppa.txt)"},
+    name = "mock-cpu_ppa",
+    src = ":mock-cpu_cts",
+    outs = ["mock-cpu_ppa.txt"],
+    arguments = {"OUTFILE": "$(location mock-cpu_ppa.txt)"},
     script = ":extract_ppa.tcl",
 )
 

--- a/optuna/constraints-dse.sdc
+++ b/optuna/constraints-dse.sdc
@@ -5,9 +5,7 @@ set sdc_version 2.0
 # Tighter constraints than default to make PLACE_DENSITY optimization meaningful
 #
 
-# Run at ~13.9 GHz (72 ps period - challenging but achievable)
-# With timing-driven optimization, some PLACE_DENSITY values should meet this
-set clk_period 72
+set clk_period $::env(ABC_CLOCK_PERIOD_IN_PS)
 
 # Covers all clock naming types in SRAMs and reg files
 set clock_ports [concat [get_ports -quiet *clk] [get_ports -quiet *clock]]

--- a/optuna/mock-cpu.sv
+++ b/optuna/mock-cpu.sv
@@ -1,0 +1,67 @@
+module mock_cpu #(
+    parameter int NUM_CORES      = 2,   // Parallelism
+    parameter int PIPELINE_DEPTH = 4,   // Latency
+    parameter int WORK_PER_STAGE = 8,   // Logic Depth
+    parameter int DATA_WIDTH     = 32   
+)(
+    input  logic                    clk,
+    input  logic [DATA_WIDTH-1:0]   data_in,
+    output logic [DATA_WIDTH-1:0]   data_out
+);
+
+    // 1. Input Registration (Isolates timing from external input delay)
+    logic [DATA_WIDTH-1:0] data_in_reg;
+    
+    always_ff @(posedge clk) begin
+        data_in_reg <= data_in;
+    end
+
+    // Aggregate outputs from all cores
+    logic [DATA_WIDTH-1:0] core_results [NUM_CORES];
+
+    genvar c, s, w;
+    generate
+        for (c = 0; c < NUM_CORES; c++) begin : g_cores
+            
+            // Pipeline stages (+1 for the initial stage coming from input reg)
+            logic [DATA_WIDTH-1:0] stage_regs [PIPELINE_DEPTH+1];
+            
+            // Connect input register to first stage with unique core seed
+            assign stage_regs[0] = data_in_reg + c; 
+
+            for (s = 0; s < PIPELINE_DEPTH; s++) begin : g_pipeline
+                logic [DATA_WIDTH-1:0] stage_logic;
+
+                always_comb begin
+                    stage_logic = stage_regs[s];
+                    // "Mock Compute": Chains of XOR/ADD to create logic depth
+                    for (int w = 0; w < WORK_PER_STAGE; w++) begin
+                        stage_logic = (stage_logic ^ (stage_logic << 1)) + (w * s);
+                    end
+                end
+
+                // Pipeline Register (No Reset)
+                always_ff @(posedge clk) begin
+                    stage_regs[s+1] <= stage_logic;
+                end
+            end
+
+            assign core_results[c] = stage_regs[PIPELINE_DEPTH];
+        end
+    endgenerate
+
+    // 2. Output Reduction (Combinational)
+    logic [DATA_WIDTH-1:0] data_out_comb;
+    always_comb begin
+        data_out_comb = '0;
+        for (int i = 0; i < NUM_CORES; i++) begin
+            data_out_comb ^= core_results[i];
+        end
+    end
+
+    // 3. Output Registration (Isolates timing from external output load)
+    always_ff @(posedge clk) begin
+        data_out <= data_out_comb;
+    end
+
+endmodule

--- a/optuna/optimize_dse.py
+++ b/optuna/optimize_dse.py
@@ -49,8 +49,8 @@ def build_design(core_util: int, place_density: float, workspace_root: str) -> d
             "build",
             f"--define=CORE_UTILIZATION={core_util}",
             f"--define=PLACE_DENSITY={place_density:.4f}",
-            "//optuna:lb_32x128_cts",
-            "//optuna:lb_32x128_ppa",
+            "//optuna:mock-cpu_cts",
+            "//optuna:mock-cpu_ppa",
         ],
         capture_output=True,
         text=True,
@@ -70,7 +70,7 @@ def build_design(core_util: int, place_density: float, workspace_root: str) -> d
         }
 
     # Parse PPA metrics - use absolute path from workspace root
-    ppa_file = os.path.join(workspace_root, "bazel-bin/optuna/lb_32x128_ppa.txt")
+    ppa_file = os.path.join(workspace_root, "bazel-bin/optuna/mock-cpu_ppa.txt")
     metrics = {}
     try:
         with open(ppa_file) as f:


### PR DESCRIPTION
A mock multicore CPU in SystemVerilog to keep the Chisel concern out of the bazel-orfs scaling for Optuna issues at first.

@MrAMS Thoughts?

Needs `VERILOG_TOP_PARAMS` + some study work.

My thinking is that bazel-orfs needs to demonstrate that it can solve the compute scaling of these studies and that this will require some collaboration and fixes in bazel-orfs itself...