### PR TITLE
Add orfs_genrule: a genrule variant with cfg=exec on srcs

### DIFF
--- a/.github/scripts/smoketests.sh
+++ b/.github/scripts/smoketests.sh
@@ -8,6 +8,13 @@ bazelisk query //:* | grep -q -v lb_32x128_3_place
 echo This target should exist
 bazelisk query //:* | grep -q -v lb_32x128_4_synth
 
+# orfs_genrule: verify srcs use exec config (not target config)
+# Native genrule forces srcs into target config, rebuilding ORFS outputs.
+# orfs_genrule keeps srcs in exec config, avoiding the duplicate build.
+target_config=$(bazelisk cquery //:gatelist_wc_orfs_genrule 2>&1 | grep "^//" | sed 's/.*(\(.*\))/\1/')
+srcs_config=$(bazelisk cquery 'deps(//:gatelist_wc_orfs_genrule, 1)' 2>&1 | grep "gatelist " | sed 's/.*(\(.*\))/\1/')
+test "$target_config" != "$srcs_config"
+
 bazelisk test ... \
    --keep_going \
    --test_output=errors \

--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,7 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 # load("//:eqy.bzl", "eqy_test")
 load("//:netlistsvg.bzl", "netlistsvg")
 load("//:openroad.bzl", "get_stage_args", "orfs_floorplan", "orfs_flow", "orfs_macro", "orfs_run", "orfs_synth")
+load("//:orfs_genrule.bzl", "orfs_genrule")
 load("//:ppa.bzl", "orfs_ppa")
 load("//:sweep.bzl", "orfs_sweep")
 load("//:yosys.bzl", "yosys")
@@ -419,6 +420,21 @@ genrule(
     ],
     outs = [
         "gatelist_wc.txt",
+    ],
+    cmd = "wc -l $(locations :gatelist) $(locations :spef) > $@",
+)
+
+# Same as gatelist_wc but using orfs_genrule to keep srcs in exec config.
+# Native genrule forces srcs into target config, causing ORFS outputs to
+# be rebuilt in a second configuration.
+orfs_genrule(
+    name = "gatelist_wc_orfs_genrule",
+    srcs = [
+        ":gatelist",
+        ":spef",
+    ],
+    outs = [
+        "gatelist_wc_orfs_genrule.txt",
     ],
     cmd = "wc -l $(locations :gatelist) $(locations :spef) > $@",
 )

--- a/orfs_genrule.bzl
+++ b/orfs_genrule.bzl
@@ -1,0 +1,65 @@
+"""orfs_genrule: a genrule variant where srcs use cfg = "exec".
+
+Native genrule forces srcs into the target configuration. When srcs
+come from ORFS rules (which build in the exec configuration), this
+causes the entire ORFS pipeline to be rebuilt in a second configuration.
+
+orfs_genrule avoids that by keeping srcs in exec configuration,
+matching where ORFS outputs already live.
+
+Supports the same cmd substitutions as native genrule:
+  $(location label), $(locations label),
+  $(execpath label), $(execpaths label),
+  $(SRCS), $(OUTS), $<, $@, $$
+"""
+
+def _orfs_genrule_impl(ctx):
+    outs = ctx.outputs.outs
+
+    # Expand $(location ...), $(execpath ...), etc.
+    targets = ctx.attr.srcs + ctx.attr.tools
+    cmd = ctx.expand_location(ctx.attr.cmd, targets)
+
+    # Substitute make-style variables
+    srcs_paths = " ".join([f.path for f in ctx.files.srcs])
+    outs_paths = " ".join([f.path for f in outs])
+    first_src = ctx.files.srcs[0].path if ctx.files.srcs else ""
+    first_out = outs[0].path if outs else ""
+
+    _PLACEHOLDER = "ORFS_GENRULE_DOLLAR_LITERAL"
+    cmd = cmd.replace("$$", _PLACEHOLDER)
+    cmd = cmd.replace("$(SRCS)", srcs_paths)
+    cmd = cmd.replace("$(OUTS)", outs_paths)
+    cmd = cmd.replace("$<", first_src)
+    cmd = cmd.replace("$@", first_out)
+    cmd = cmd.replace("$(RULEDIR)", outs[0].dirname if outs else "")
+    cmd = cmd.replace(_PLACEHOLDER, "$")
+
+    ctx.actions.run_shell(
+        command = cmd,
+        inputs = ctx.files.srcs,
+        outputs = outs,
+        tools = ctx.files.tools,
+        mnemonic = "OrfsGenrule",
+        progress_message = "OrfsGenrule %s" % ctx.label,
+    )
+
+    return [DefaultInfo(files = depset(outs))]
+
+orfs_genrule = rule(
+    implementation = _orfs_genrule_impl,
+    attrs = {
+        "cmd": attr.string(mandatory = True),
+        "outs": attr.output_list(mandatory = True),
+        "srcs": attr.label_list(
+            cfg = "exec",
+            allow_files = True,
+            default = [],
+        ),
+        "tools": attr.label_list(
+            cfg = "exec",
+            allow_files = True,
+            default = [],
+        ),
+    },
+)


### PR DESCRIPTION
Native genrule forces srcs into the target configuration. When srcs come from ORFS rules (which build in the exec configuration), this causes the entire ORFS pipeline to be rebuilt in a second configuration, roughly doubling build time.

orfs_genrule keeps srcs in exec configuration, matching where ORFS outputs already live. Supports the same cmd substitutions as native genrule: $(location), $(execpath), $(SRCS), $(OUTS), $<, $@, $$.

Includes a smoke test that verifies srcs are in a different (exec) config than the rule itself (target config).