### PR TITLE
CI: remove verbose debug flags from bazel commands

### DIFF
--- a/.github/scripts/build_local_target.sh
+++ b/.github/scripts/build_local_target.sh
@@ -36,11 +36,8 @@ do
   build_dir="tmp${package:+/$package}/${bare_target}_${stage}_deps"
   rm -rf "./$build_dir"
   if [[ -z $SKIP_BUILD ]] ; then
-    echo "[${target_name}] ${stage}: Query dependency target"
-    bazel query "${target_name}_${stage}_deps"
-    bazel query "${target_name}_${stage}_deps" --output=build
     echo "[${target_name}] ${stage}: Build dependency"
-    bazel run --subcommands --verbose_failures --sandbox_debug "${target_name}_${stage}_deps"
+    bazel run --verbose_failures "${target_name}_${stage}_deps"
   fi
   if [[ -z $SKIP_RUN ]] ; then
     stages=()
@@ -76,9 +73,6 @@ do
 done
 
 if [[ -z $SKIP_BUILD && -z $SKIP_ABSTRACT ]]; then
-    echo "query abstract target"
-    bazel query "${target_name}_generate_abstract"
-    bazel query "${target_name}_generate_abstract" --output=build
     echo "build abstract"
-    bazel build --subcommands --verbose_failures --sandbox_debug "${target_name}_generate_abstract"
+    bazel build --verbose_failures "${target_name}_generate_abstract"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,22 +61,18 @@ jobs:
           disk-cache: ${{ github.workflow }}-${{ matrix.STAGE_TARGET }}
           repository-cache: true
 
-      - name: query target
-        run: |
-          bazel query ${{ matrix.STAGE_TARGET }}
-          bazel query ${{ matrix.STAGE_TARGET }} --output=build
       - name: Build report
         if: ${{ endsWith(matrix.STAGE_TARGET, '_report') }}
         run: |
-          bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+          bazel build --verbose_failures ${{ matrix.STAGE_TARGET }}
       - name: Run target
         if: ${{ !endsWith(matrix.STAGE_TARGET, '_report') }}
         run: |
           if [[ ${{ matrix.STAGE_TARGET }} == "lb_32x128_generate_abstract" || ${{ matrix.STAGE_TARGET }} == *"tag_array_64x184_generate_abstract"* ]]; then
             # this is a mock area abstract, so it is not executable
-            bazel build --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+            bazel build --verbose_failures ${{ matrix.STAGE_TARGET }}
           else
-            bazel run --subcommands --verbose_failures --sandbox_debug ${{ matrix.STAGE_TARGET }}
+            bazel run --verbose_failures ${{ matrix.STAGE_TARGET }}
           fi
 
   test-open-target:


### PR DESCRIPTION
Remove --subcommands, --sandbox_debug and bazel query --output=build calls that clutter CI logs. Keep --verbose_failures which only adds output on failure.