### PR TITLE
sby: parameterize depth/firtool_options, enable DUT assertions

### DIFF
--- a/generate.bzl
+++ b/generate.bzl
@@ -1,5 +1,15 @@
 """
 fir_library rule for generating FIR files from source files using a specified generator tool.
+
+WARNING: The Chisel generator binary invokes firtool internally (via
+CHISEL_FIRTOOL_PATH) during elaboration to lower CHIRRTL to FIRRTL.
+Any firtool flags passed through `opts` (e.g. -disable-layers,
+--disable-all-randomization) take effect at this stage. If the output
+.fir is later processed by verilog_directory / verilog_file, the same
+firtool flags must be passed there too, or the two passes will
+disagree on layer handling and produce broken Verilog.
+
+See sby.bzl for an example of passing consistent options to both passes.
 """
 
 # buildifier: disable=module-docstring

--- a/sby.bzl
+++ b/sby.bzl
@@ -1,7 +1,28 @@
-"""Rules for sby"""
+"""Rules for sby formal verification."""
 
 load("//:generate.bzl", "fir_library")
 load("//:verilog.bzl", "verilog_directory", "verilog_single_file_library")
+
+# Default firtool options for formal verification.
+#
+# firtool is invoked twice in this flow — first by the Chisel generator
+# (fir_library, via CHISEL_FIRTOOL_PATH) to lower CHIRRTL, then by
+# verilog_directory to produce SystemVerilog. These options must be
+# passed to both passes to stay consistent.
+#
+# Verification.Assert is kept enabled so that DUT-internal Chisel
+# assert() statements are checked by the formal solver. The layer bind
+# files use `include directives which are stripped by
+# verilog_single_file_library (see verilog.bzl).
+#
+# Assume and Cover are disabled: assumes would over-constrain the
+# solver and covers are not needed for BMC.
+DEFAULT_FIRTOOL_OPTIONS = [
+    "--disable-all-randomization",
+    "-strip-debug-info",
+    "-disable-layers=Verification.Assume",
+    "-disable-layers=Verification.Cover",
+]
 
 def _sby_test_impl(ctx):
     sby = ctx.actions.declare_file(ctx.attr.name + ".sby")
@@ -10,6 +31,7 @@ def _sby_test_impl(ctx):
         template = ctx.file._sby_template,
         output = sby,
         substitutions = {
+            "${DEPTH}": str(ctx.attr.depth),
             "${TOP}": ctx.attr.module_top,
             "${VERILOG_BASE_NAMES}": " ".join(
                 [file.basename for file in ctx.files.verilog_files],
@@ -66,6 +88,7 @@ exit $rc
 _sby_test = rule(
     implementation = _sby_test_impl,
     attrs = {
+        "depth": attr.int(mandatory = True),
         "module_top": attr.string(mandatory = True),
         "verilog_files": attr.label_list(
             allow_files = True,
@@ -97,29 +120,38 @@ def sby_test(
         name,
         module_top,
         generator,
+        depth = 20,
         generator_opts = [],
+        firtool_options = None,
         verilog_files = [],
         **kwargs):
-    """sby_test macro frontend to run formal verification with sby.
+    """Run SymbiYosys bounded model checking on a Chisel-generated design.
+
+    Generates Verilog from Chisel source, then runs SymbiYosys BMC with
+    the bitwuzla solver. Additional SystemVerilog files (formal wrappers
+    with SVA properties) can be included via verilog_files.
 
     Args:
-        name: Name of the test target.
-        module_top: Top module name in the verilog files.
-        generator: Label of the scala binary that generates the verilog files.
-        generator_opts: List of options passed to Generator scala app for generating the verilog.
-        verilog_files: List of additional verilog files to include in the sby test.
-        **kwargs: Additional args passed to _sby_test.
+        name: Name of the test target. The actual test will be name + "_test".
+        module_top: Top module name for formal checking (typically the
+            formal wrapper module, e.g. "FormalMyModule").
+        generator: Label of the Chisel generator binary (scala_binary that
+            calls chisel3.stage.ChiselStage).
+        depth: BMC depth — number of clock cycles to unroll. Higher values
+            find deeper bugs but take exponentially longer. Default 20.
+        generator_opts: Options passed to the Chisel generator binary
+            (e.g. ["--top-module=my.package.MyModule"]).
+        firtool_options: Options passed to firtool for both CHIRRTL lowering
+            and Verilog generation. Defaults to DEFAULT_FIRTOOL_OPTIONS which
+            disables randomization and Verification layers. Override to
+            customize layer handling or add other firtool flags.
+        verilog_files: Additional SystemVerilog files to include (e.g. formal
+            wrapper files with SVA properties using `ifdef FORMAL).
+        **kwargs: Additional args passed to the underlying test rule
+            (e.g. tags, timeout, size).
     """
-
-    # massage output for sby
-    firtool_options = [
-        "--disable-all-randomization",
-        "-strip-debug-info",
-        "-disable-layers=Verification",
-        "-disable-layers=Verification.Assert",
-        "-disable-layers=Verification.Assume",
-        "-disable-layers=Verification.Cover",
-    ]
+    if firtool_options == None:
+        firtool_options = DEFAULT_FIRTOOL_OPTIONS
 
     fir_library(
         name = "{name}_fir".format(name = name),
@@ -129,7 +161,7 @@ def sby_test(
         tags = ["manual"],
     )
 
-    # FIXME we have to split the files or we get the verification layer stubs
+    # Split into per-module files to avoid verification layer stubs
     # https://github.com/llvm/circt/issues/9020
     verilog_directory(
         name = "{name}_split".format(name = name),
@@ -138,7 +170,7 @@ def sby_test(
         tags = ["manual"],
     )
 
-    # And concat the files into one again for sby
+    # Concat back into a single file for sby
     verilog_single_file_library(
         name = "{name}.sv".format(name = name),
         srcs = [":{name}_split".format(name = name)],
@@ -148,6 +180,7 @@ def sby_test(
 
     _sby_test(
         name = name + "_test",
+        depth = depth,
         module_top = module_top,
         verilog_files = verilog_files + [":{name}.sv".format(name = name)],
         **kwargs

--- a/sby.tpl
+++ b/sby.tpl
@@ -4,6 +4,7 @@ bmc
 [options]
 bmc:
 mode bmc
+depth ${DEPTH}
 
 [engines]
 smtbmc bitwuzla

--- a/sby/README.md
+++ b/sby/README.md
@@ -1,58 +1,123 @@
-# Chisel testing with sby
+# Formal verification with SymbiYosys
 
-Test example, which should succeed:
+The `sby_test` macro runs bounded model checking (BMC) on Chisel-generated
+designs using SymbiYosys with the bitwuzla SMT solver.
+
+## Quick start
+
+```python
+load("@bazel-orfs//:sby.bzl", "sby_test")
+
+sby_test(
+    name = "counter_formal",
+    generator = ":generator",
+    generator_opts = ["--top-module=MyCounter"],
+    module_top = "FormalCounter",
+    verilog_files = ["src/main/resources/FormalCounter.sv"],
+    tags = ["manual"],
+)
+```
+
+Run:
+
+    bazelisk test :counter_formal_test
+
+(Note: the actual test target has a `_test` suffix.)
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `depth` | 20 | BMC depth (clock cycles to unroll). Higher = deeper bugs but exponentially slower. |
+| `firtool_options` | `DEFAULT_FIRTOOL_OPTIONS` | Firtool flags for both CHIRRTL lowering and Verilog generation. |
+| `generator_opts` | `[]` | Options passed to the Chisel generator (e.g. `--top-module`, `--lowering-options`). |
+| `verilog_files` | `[]` | Additional SystemVerilog files (formal wrappers with SVA properties). |
+
+## Writing formal wrappers
+
+The formal wrapper is a SystemVerilog module that instantiates the DUT and
+adds `assume` / `assert` properties inside an `` `ifdef FORMAL`` block.
+SymbiYosys reads these with `read -formal`.
+
+```systemverilog
+module FormalCounter(input clock, input reset, ...);
+
+    MyCounter dut(.clock(clock), .reset(reset), ...);
+
+`ifdef FORMAL
+    initial assume(reset == 1'b1);
+
+    // Properties go here
+    always @(posedge clock)
+        if (!reset) assert(dut_output <= MAX_VALUE);
+`endif
+
+endmodule
+```
+
+## Counterexample traces
+
+When BMC fails, counterexample traces (VCD, Verilog testbench, Yosys
+witness) are copied to `$TEST_UNDECLARED_OUTPUTS_DIR` so they survive
+Bazel sandbox cleanup. Find them at:
+
+    bazel-testlogs/<package>/<name>_test/test.outputs/
+
+## Chisel assert() and the Verification layer caveat
+
+Chisel `assert()` statements are compiled into CIRCT Verification layers
+(`Verification.Assert`). These are **disabled by default** in the firtool
+options because enabling them generates layer bind files with `` `include``
+directives that yosys cannot resolve after file concatenation
+(see [circt#9020](https://github.com/llvm/circt/issues/9020)).
+
+This means **DUT-internal Chisel assertions are not checked by the formal
+solver**. The solver can explore states that would violate internal
+invariants, potentially producing spurious counterexamples.
+
+To work around this, replicate critical DUT assertions as SVA properties
+in the formal wrapper. For example, if the Chisel source has:
+
+```scala
+assert(!evicting || !hitLine.valid, "no access during eviction")
+```
+
+Add the equivalent in your `FormalXxx.sv`:
+
+```systemverilog
+always @(posedge clock)
+    if (!reset) assert(!dut.evicting || !dut.hitLine_valid);
+```
+
+## firtool double invocation
+
+The `sby_test` flow invokes firtool **twice**:
+
+1. **fir_library** -- the Chisel generator calls firtool internally (via
+   `CHISEL_FIRTOOL_PATH`) to lower CHIRRTL to FIRRTL.
+2. **verilog_directory** -- firtool converts the `.fir` to split
+   SystemVerilog files.
+
+The `firtool_options` parameter is passed to both invocations. If you
+override it, ensure both passes see the same flags, or the `.fir` and
+`.sv` will disagree on layer handling and randomization.
+
+## Debugging a failure
+
+```bash
+# Run with streamed output to see BMC progress
+bazelisk test :my_formal_test --test_output=streamed --nocache_test_results
+
+# Inspect the counterexample VCD
+surfer bazel-testlogs/.../test.outputs/.../engine_0/trace.vcd
+```
+
+## Example with injected bug
+
+Test example which should succeed:
 
     bazelisk test //sby:counter_test
 
 Modify Counter.scala to have an error and re-run with:
 
     bazelisk test //sby:counter_test --sandbox_debug
-
-In the output look for:
-
-    Files found in /home/.../.cache/bazel/.../sby/counter_test.run.sh.runfiles/_main
-
-Run:
-
-    find /home/.../.cache/bazel/.../sby/counter_test.run.sh.runfiles/_main -printf "%P\n"
-
-Which outputs all the files sby used:
-
-    sby
-    sby/counter_test_bmc
-    sby/counter_test_bmc/logfile.txt
-    sby/counter_test_bmc/status
-    sby/counter_test_bmc/model
-    sby/counter_test_bmc/model/design.log
-    sby/counter_test_bmc/model/design_smt2.ys
-    sby/counter_test_bmc/model/design_smt2.log
-    sby/counter_test_bmc/model/design_prep.ys
-    sby/counter_test_bmc/model/design.il
-    sby/counter_test_bmc/model/design_prep.il
-    sby/counter_test_bmc/model/design.ys
-    sby/counter_test_bmc/model/design_prep.log
-    sby/counter_test_bmc/model/design_smt2.smt2
-    sby/counter_test_bmc/model/design.json
-    sby/counter_test_bmc/engine_0
-    sby/counter_test_bmc/engine_0/logfile.txt
-    sby/counter_test_bmc/engine_0/trace.smtc
-    sby/counter_test_bmc/engine_0/trace_tb.v
-    sby/counter_test_bmc/engine_0/trace.vcd
-    sby/counter_test_bmc/engine_0/trace.yw
-    sby/counter_test_bmc/src
-    sby/counter_test_bmc/src/counter.sv
-    sby/counter_test_bmc/config.sby
-    sby/counter_test_bmc/FAIL
-    sby/counter_test_bmc/counter_test_bmc.xml
-    sby/counter_test_bmc/status.path
-    sby/counter_test
-    sby/counter_test/status.sqlite
-    sby/counter.sv
-    sby/counter_test.sby
-    sby/counter_test.run.sh
-
-## vcd file in the case of a failure
-
-Of particular interest is the .vcd file seen above in the case of a failure.
-
-![vcd failure](vcd-failure.png)

--- a/verilog.bzl
+++ b/verilog.bzl
@@ -1,5 +1,14 @@
 """
-verilog library support
+Verilog library support: firtool FIRRTL-to-SystemVerilog conversion.
+
+WARNING: If the .fir input was produced by fir_library (which runs the
+Chisel generator with firtool internally), the same firtool flags
+(especially -disable-layers, --disable-all-randomization) must be
+passed to verilog_directory / verilog_file via `opts`. The two firtool
+invocations must agree, otherwise layer bind files or randomization
+constructs in the .fir won't match what this pass expects.
+
+See sby.bzl for an example of passing consistent options to both passes.
 """
 
 load("@rules_verilator//verilog:providers.bzl", "make_dag_entry", "make_verilog_info")
@@ -98,9 +107,15 @@ def _verilog_single_file_library(ctx):
 
     args = ctx.actions.args()
     args.add_all(ctx.files.srcs, map_each = _only_sv)
+
+    # Strip `include directives: when all .sv files from the split
+    # directory are concatenated, the include targets are already present
+    # in the output. Leaving include directives would cause yosys/verilator
+    # to fail because the include paths don't resolve in the flat file.
+    # This is the workaround for https://github.com/llvm/circt/issues/9020
     ctx.actions.run_shell(
         arguments = [args],
-        command = "cat $@ > {}".format(out.path),
+        command = "grep -hvF '`include' $@ > {} || true".format(out.path),
         inputs = ctx.files.srcs,
         outputs = [out],
         mnemonic = "Cat",


### PR DESCRIPTION
The sby_test macro was hardcoded with depth and firtool options that couldn't be overridden per-target. This makes formal verification impractical for designs that need different BMC depths or layer configurations.

Changes:
- Add `depth` parameter (default 20) and `firtool_options` parameter to sby_test macro, with DEFAULT_FIRTOOL_OPTIONS as module constant
- Template sby.tpl now uses ${DEPTH} substitution instead of hardcoded value
- Enable Verification.Assert layer so DUT-internal Chisel assert() statements are checked by the formal solver (catches internal invariant violations that would otherwise produce spurious counterexamples)
- Strip `include directives in verilog_single_file_library to work around circt#9020 (layer bind files generate includes that yosys cannot resolve after concatenation)
- Document the firtool double-invocation pitfall in generate.bzl, verilog.bzl, and sby/README.md