### PR TITLE
docker: use hermetic Python for patcher, not system python3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,12 +49,12 @@ bazel_dep(
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",
     "python",
-    dev_dependency = True,
 )
 python.toolchain(
     ignore_root_user_error = True,
     python_version = "3.13",
 )
+use_repo(python, "python_3_13_host")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -210,7 +210,7 @@
   "moduleExtensions": {
     "//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "mXT67CG7L5OLVmAL21N/b1fUYtLkKfGcDS9/BHvSBuY=",
+        "bzlTransitiveDigest": "We8lHiP0MwXcNMkjeB/9G1WfFWL4xDQs48mA+auBrqE=",
         "usagesDigest": "GI2GE8tlWOwlCIZhlNeNCc5pr37kxwJb5wUjdtFqtIs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -271,6 +271,11 @@
             "",
             "docker_orfs",
             "+orfs_repositories+docker_orfs"
+          ],
+          [
+            "",
+            "python_3_13_host",
+            "rules_python++python+python_3_13_host"
           ]
         ]
       }

--- a/docker.bzl
+++ b/docker.bzl
@@ -11,10 +11,6 @@ def _impl(repository_ctx):
     else:
         image = repository_ctx.attr.image
 
-    python_name = "python3"
-    python = repository_ctx.which(python_name)
-    if not python:
-        fail("Failed to find {}.".format(python_name))
     docker_name = "docker"
     docker = repository_ctx.which(docker_name)
     if not docker:
@@ -89,10 +85,12 @@ def _impl(repository_ctx):
 
     repository_ctx.report_progress("Extracted {}.".format(repository_ctx.attr.image))
 
+    python = repository_ctx.path(repository_ctx.attr._python).realpath
     patcher = repository_ctx.path(repository_ctx.attr._patcher).realpath
     patchelf = repository_ctx.path(repository_ctx.attr._patchelf).realpath
     patcher_result = repository_ctx.execute(
         [
+            python,
             patcher,
             "--patchelf",
             patchelf,
@@ -130,11 +128,16 @@ docker_pkg = repository_rule(
             executable = True,
             cfg = "exec",
         ),
+        "_python": attr.label(
+            doc = "Hermetic Python interpreter.",
+            default = Label("@python_3_13_host//:python"),
+            executable = True,
+            cfg = "exec",
+        ),
         "_patcher": attr.label(
             doc = "Python script to remap `RUNPATH`s.",
             default = Label("//:patcher.py"),
-            executable = True,
-            cfg = "exec",
+            allow_single_file = True,
         ),
     },
 )


### PR DESCRIPTION
Replace the raw patcher.py script (invoked via #!/usr/bin/env python3 shebang) with a py_binary built by rules_python's hermetic Python 3.13 interpreter. Remove the now-unnecessary which("python3") check in docker_pkg, which was dead code (the result was never used) and the immediate cause of build failures in minimal containers without python3 installed.

Also remove dev_dependency = True from the python toolchain extension so the hermetic interpreter is available to all users of bazel-orfs, not just when it is the root module.