### PR TITLE
build: add resource_set to prevent CPU oversubscription

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,6 +56,13 @@ python.toolchain(
 )
 use_repo(python, "python_3_13_host")
 
+detect_cpus = use_repo_rule("//:detect_cpus.bzl", "detect_cpus")
+
+detect_cpus(
+    name = "host_cpus",
+    python_interpreter = "@python_3_13_host//:python",
+)
+
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "bazel-orfs-pip",

--- a/detect_cpus.bzl
+++ b/detect_cpus.bzl
@@ -1,0 +1,32 @@
+"""Repository rule to detect the number of CPUs available on the host.
+
+This runs once during workspace setup and writes a .bzl file with the
+CPU count, which openroad.bzl uses for resource_set scheduling.
+"""
+
+def _detect_cpus_impl(repository_ctx):
+    python = repository_ctx.path(repository_ctx.attr.python_interpreter)
+    result = repository_ctx.execute([
+        str(python),
+        "-c",
+        "import os; print(os.cpu_count() or 1)",
+    ])
+    if result.return_code == 0:
+        cpus = int(result.stdout.strip())
+    else:
+        cpus = 8
+    repository_ctx.file("BUILD.bazel", "")
+    repository_ctx.file("cpus.bzl", "NUM_CPUS = %d\n" % cpus)
+
+detect_cpus = repository_rule(
+    implementation = _detect_cpus_impl,
+    attrs = {
+        "python_interpreter": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "Hermetic Python interpreter used to detect CPU count.",
+        ),
+    },
+    local = True,
+    configure = True,
+)

--- a/docs/resource_scheduling.md
+++ b/docs/resource_scheduling.md
@@ -1,0 +1,158 @@
+# Resource Scheduling for Bazel Actions
+
+## The problem
+
+Bazel defaults to 1 CPU per action, allowing many actions to run in parallel.
+OpenROAD stages that spawn internal threads suffer severe slowdowns from this:
+context switching and cache thrashing dominate when N actions each spawn
+NUM_CORES threads on NUM_CORES physical cores.
+
+Evidence: `tag_array_64x184` global placement (379 cells) takes 1.4s alone but
+521s inside `bazelisk test ...`. Same computation, same output — 370x slower.
+
+## The fix
+
+Every `ctx.actions.run_shell()` call declares a `resource_set`. Multi-threaded
+stages request all CPUs so Bazel runs at most one at a time. Single-threaded
+stages request 1 CPU, allowing full parallelism.
+
+A `repository_rule` (`detect_cpus`) runs hermetic Python's `os.cpu_count()`
+once at workspace setup to determine the host CPU count. This is written to
+`@host_cpus//:cpus.bzl` as `NUM_CPUS` and loaded by `openroad.bzl`.
+
+## Stage threading classification
+
+OpenROAD is always invoked with `-threads NUM_CORES`, but ORFS's `load.tcl`
+immediately sets `sta::set_thread_count 1` (workaround for flaky STA in
+rel_3.0+). Only algorithms with their own internal threading (OpenMP, etc.)
+actually use multiple cores.
+
+### Multi-threaded stages (request all CPUs)
+
+| Stage   | Make target    | Multi-threaded sub-stages                                                                           |
+|---------|----------------|------------------------------------------------------------------------------------------------------|
+| place   | `do-place`     | `global_placement` (RePlAce, OpenMP), `global_placement -incremental` (resize), `detailed_placement` |
+| cts     | `do-cts`       | `clock_tree_synthesis` (TritonCTS), `detailed_placement`, `repair_timing_helper`                      |
+| grt     | `do-5_1_grt`   | `global_route` (FastRoute), `repair_design_helper`, `repair_timing_helper`, `detailed_placement`     |
+| route   | `do-5_2_route` | `detailed_route` (TritonRoute, heavily threaded)                                                     |
+
+### Single-threaded stages (request 1 CPU)
+
+| Stage             | Make target            | Sub-stages                                              |
+|-------------------|------------------------|---------------------------------------------------------|
+| synth             | `do-yosys`             | Yosys synthesis (single-threaded)                       |
+| floorplan         | `do-floorplan`         | `floorplan`, `macro_place`, `tapcell`, `pdn`            |
+| final             | `do-final`             | `density_fill`, `final_report`, KLayout GDS merge       |
+| generate_abstract | `do-generate_abstract` | `write_timing_model`, `write_abstract_lef`              |
+
+### Empirical thread counts (tag_array_64x184, ASAP7, 16-core host)
+
+Measured via `ps -eo nlwp` sampling at 200ms intervals:
+
+| TCL script              | Max threads observed | Samples |
+|-------------------------|---------------------:|--------:|
+| `global_place_skip_io`  |                   16 |     146 |
+| `global_place`          |                   16 |      16 |
+| `floorplan`             |                    1 |      18 |
+| `macro_place`           |                    1 |      16 |
+| `tapcell`               |                    1 |      18 |
+| `pdn`                   |                    1 |      16 |
+| `io_placement`          |                    1 |      14 |
+| `resize`                |                    1 |      12 |
+| `detail_place`          |                    1 |      14 |
+| `cts`                   |                    1 |      34 |
+| `generate_abstract`     |                    1 |      29 |
+| `synth_canonicalize`    |                    1 |      20 |
+| `synth_odb`             |                    1 |      16 |
+
+Note: `global_route`, `detail_route`, `density_fill`, and `final_report` were
+too fast on this small design (379 cells) to capture. For larger designs,
+`global_route` and `detail_route` are known to be heavily multi-threaded from
+OpenROAD source code (FastRoute and TritonRoute both use internal threading).
+CTS, resize, and detail_place also scale to multiple threads on larger designs.
+
+## Memory
+
+The `resource_set` also declares memory (8192 MB). Large designs can consume
+significant memory, especially during global routing (`grt`) and detailed
+routing. Bazel uses this for scheduling decisions, not as a hard limit.
+
+## Why not break stages into substage actions?
+
+A finer-grained approach would split each stage into individual Bazel actions
+per substage (e.g., 5 actions for `place` instead of 1). This would allow
+precise CPU allocation: 1 CPU for `io_placement`, all CPUs for
+`global_placement`. This has two show-stoppers:
+
+### Artifact explosion
+
+Each substage produces an intermediate ODB file. ODB files are hundreds of MB
+for real designs. Breaking `place` into 5 substage actions means 5 intermediate
+ODB files in `bazel-out` instead of 1. Across all stages this would add ~20
+extra ODB files per design, consuming significant disk space and remote cache.
+
+### White-box coupling with ORFS
+
+The ORFS Makefile provides stable `do-floorplan`, `do-place`, `do-cts`,
+`do-route`, `do-final` targets. The Makefile comments explicitly state:
+
+> *"The do- substeps of each of these stages are subject to change."*
+
+Full substage decomposition requires hard-coding every `do-2_1_floorplan`,
+`do-3_1_place_gp_skip_io`, etc. and their exact input/output ODB filenames.
+Any ORFS update could break this coupling silently.
+
+### The waste is small
+
+For `place` (the stage with the most mixed threading), the multi-threaded
+substages (`global_place_skip_io`, `global_place`) dominate runtime (~80% of
+samples). Holding all CPUs during the ~20% single-threaded portion
+(`io_placement`, `resize`, `detail_place`) is a minor inefficiency compared to
+the 370x improvement from preventing oversubscription.
+
+### Path to finer granularity
+
+If the stage-level approach proves too coarse for real workloads, the right fix
+is upstream in ORFS following the `variables.yaml` pattern:
+
+- ORFS already exports `variables.yaml` with stage-to-variable mappings.
+  `bazel-orfs` consumes this via `load_json_file` without white-boxing.
+- ORFS could similarly export a `stages.yaml` describing substages, their
+  threading profile (single/multi), and their input/output artifacts.
+- `bazel-orfs` would consume this metadata to set `resource_set` per-substage
+  or dynamically construct substage actions.
+- This keeps the contract between ORFS and `bazel-orfs` explicit and versioned.
+
+## Tuning for your environment
+
+### Overriding CPU count
+
+The detected CPU count can be verified by inspecting
+`@host_cpus//:cpus.bzl` in your Bazel output base. If this value is wrong
+(e.g., inside a container with limited cores), the `detect_cpus` repository
+rule will re-run on the next `bazel sync` or clean build.
+
+### Controlling parallelism
+
+Bazel's `--local_cpu_resources` flag controls the total CPU budget. With
+`NUM_CPUS=16` and `--local_cpu_resources=16` (default), Bazel will run at most
+one multi-threaded OpenROAD stage at a time, while allowing up to 16
+single-threaded stages in parallel.
+
+To allow two multi-threaded stages to overlap (e.g., on a 32-core machine
+detected as 16 cores due to containers):
+
+```
+bazel build --local_cpu_resources=32 //...
+```
+
+### Monitoring
+
+To see which actions are running and their resource usage:
+
+```
+bazel build --show_progress //...
+```
+
+To verify resource_set values, add `--subcommands` to see the full action
+command lines, or inspect the action graph with `bazel aquery`.

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -10,7 +10,18 @@ load(
     "CONFIG_YOSYS",
     "CONFIG_YOSYS_ABC",
 )
+load("@host_cpus//:cpus.bzl", "NUM_CPUS")
 load("@orfs_variable_metadata//:json.bzl", "orfs_variable_metadata")
+
+# Stages containing multi-threaded OpenROAD algorithms that benefit from
+# all available CPUs. See docs/resource_scheduling.md for sub-stage details.
+_MULTI_THREADED_STAGES = ["place", "cts", "grt", "route"]
+
+def _openroad_resource_set(_os, _inputs):
+    return {"cpu": NUM_CPUS, "memory": 8192}
+
+def _lightweight_resource_set(_os, _inputs):
+    return {"cpu": 1, "memory": 8192}
 
 def _map(function, iterable):
     return [function(x) for x in iterable]
@@ -819,6 +830,7 @@ def _run_impl(ctx):
                 yosys_inputs(ctx),
             ],
         ),
+        resource_set = _lightweight_resource_set,
     )
 
     make = ctx.actions.declare_file(
@@ -1012,6 +1024,7 @@ def _yosys_impl(ctx):
         ),
         outputs = [canon_output] + canon_logs,
         tools = yosys_inputs(ctx),
+        resource_set = _lightweight_resource_set,
     )
 
     synth_logs = []
@@ -1056,6 +1069,7 @@ def _yosys_impl(ctx):
         ),
         outputs = synth_outputs.values() + synth_logs + synth_reports,
         tools = depset(transitive = [yosys_inputs(ctx), flow_inputs(ctx)]),
+        resource_set = _lightweight_resource_set,
     )
 
     variables = _declare_artifact(ctx, "results", "1_synth.vars")
@@ -1085,6 +1099,7 @@ def _yosys_impl(ctx):
         ),
         outputs = [variables],
         tools = depset(transitive = [flow_inputs(ctx)]),
+        resource_set = _lightweight_resource_set,
     )
 
     outputs = [canon_output, variables] + synth_outputs.values()
@@ -1370,6 +1385,7 @@ def _make_impl(
         ),
         outputs = results + objects + logs + reports + jsons + drcs,
         tools = flow_inputs(ctx),
+        resource_set = _openroad_resource_set if ctx.attr._stage in _MULTI_THREADED_STAGES else _lightweight_resource_set,
     )
 
     config_short = _declare_artifact(ctx, "results", stage + ".short.mk")
@@ -1735,7 +1751,13 @@ orfs_generate_metadata = rule(
         ],
         result_names = [],
     ),
-    attrs = openroad_attrs() | renamed_inputs_attr(),
+    attrs = openroad_attrs() |
+            renamed_inputs_attr() |
+            {
+                "_stage": attr.string(
+                    default = "generate_metadata",
+                ),
+            },
     provides = flow_provides(),
     executable = True,
 )
@@ -1751,7 +1773,13 @@ orfs_update_rules = rule(
         report_names = ["rules.json"],
         result_names = [],
     ),
-    attrs = openroad_attrs() | renamed_inputs_attr(),
+    attrs = openroad_attrs() |
+            renamed_inputs_attr() |
+            {
+                "_stage": attr.string(
+                    default = "update_rules",
+                ),
+            },
     provides = flow_provides(),
     executable = True,
 )


### PR DESCRIPTION
Parallel bazel builds cause 370x slowdowns for OpenROAD actions because bazel defaults to 1 CPU per action while OpenROAD spawns threads for all cores. With 16 concurrent actions × 16 threads = 256 threads on 16 cores, context switching and cache thrashing dominate.

Evidence: tag_array_64x184 global placement (379 cells) takes 1.4s alone but 521s inside `bazelisk test ...`. Same computation, same output sha.

Fix: declare resource_set on every ctx.actions.run_shell() call. Multi-threaded stages (place, cts, grt, route) request all CPUs so bazel runs at most one at a time. Single-threaded stages (synth, floorplan, final) request 1 CPU, allowing full parallelism.

A repository_rule (detect_cpus) runs `nproc` once at workspace setup to determine the host CPU count. This is invisible to users — no .bazelrc flags, no env vars, no per-design configuration needed.