### PR TITLE
fix: auto-detect SSL CA bundle for NixOS and non-FHS systems

### DIFF
--- a/docs/oci-extraction.md
+++ b/docs/oci-extraction.md
@@ -105,6 +105,35 @@ not a problem because:
 ls $(bazel info repository_cache)/content_addressable/sha256/
 ```
 
+### SSL certificates (NixOS, non-FHS systems)
+
+`oci_extract.py` auto-detects the system CA certificate bundle at startup.
+The detection order is:
+
+1. `SSL_CERT_FILE` environment variable (if already set, used as-is)
+2. `NIX_SSL_CERT_FILE` environment variable (NixOS)
+3. Common distro paths: `/etc/ssl/certs/ca-certificates.crt` (Debian),
+   `/etc/pki/tls/certs/ca-bundle.crt` (RHEL), etc.
+
+This is needed because rules_python's hermetic Python bundles its own
+OpenSSL, which looks for certificates at a compiled-in FHS path that
+may not exist on NixOS or other non-standard layouts.
+
+To override, set `SSL_CERT_FILE` in your environment before running Bazel.
+
+### Diagnostic toggles
+
+Environment variables to disable specific features for troubleshooting.
+All default to `1` (enabled); set to `0` to disable.
+
+| Variable | Effect when `=0` |
+|---|---|
+| `OCI_EXTRACT_SSL_SETUP` | Skip CA bundle auto-detection |
+| `OCI_EXTRACT_PIGZ` | Use Python gzip instead of pigz |
+| `OCI_EXTRACT_PARALLEL` | Sequential URL resolution (no threads) |
+
+Example: `OCI_EXTRACT_PARALLEL=0 bazelisk fetch @docker_orfs//...`
+
 ### Standalone mode
 
 `oci_extract.py extract` still works as a standalone one-step command

--- a/oci_extract.py
+++ b/oci_extract.py
@@ -53,6 +53,46 @@ MANIFEST_TYPES = ", ".join(
 CHUNK_SIZE = 1 << 20  # 1 MiB
 
 
+def _setup_ssl():
+    """Configure SSL certificate bundle for hermetic Python interpreters.
+
+    rules_python's hermetic Python bundles its own OpenSSL, which looks
+    for CA certificates at a compiled-in FHS path (e.g. /usr/lib/ssl/certs/).
+    On NixOS and other non-FHS systems, the CA bundle is elsewhere.
+
+    This function detects the correct CA bundle path and sets SSL_CERT_FILE
+    so that OpenSSL (and thus urllib) finds it.  Does nothing if SSL_CERT_FILE
+    is already set.
+
+    Disable with OCI_EXTRACT_SSL_SETUP=0 for diagnostics.
+    """
+    if os.environ.get("OCI_EXTRACT_SSL_SETUP", "1") == "0":
+        return
+
+    if os.environ.get("SSL_CERT_FILE"):
+        return
+
+    for var in ("NIX_SSL_CERT_FILE", "CURL_CA_BUNDLE"):
+        path = os.environ.get(var)
+        if path and os.path.isfile(path):
+            os.environ["SSL_CERT_FILE"] = path
+            return
+
+    for path in (
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/etc/pki/tls/certs/ca-bundle.crt",
+        "/etc/ssl/ca-bundle.pem",
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        "/etc/ssl/cert.pem",
+    ):
+        if os.path.isfile(path):
+            os.environ["SSL_CERT_FILE"] = path
+            return
+
+
+_setup_ssl()
+
+
 def parse_image(image_str):
     """Parse an image string into (registry, repository).
 
@@ -277,8 +317,11 @@ def resolve_layers(image, reference):
         url = resolve_blob_url(registry, repository, digest, token)
         return {"digest": digest, "size": size, "url": url}
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
-        result = list(pool.map(_resolve, layers))
+    if os.environ.get("OCI_EXTRACT_PARALLEL", "1") == "0":
+        result = [_resolve(layer) for layer in layers]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            result = list(pool.map(_resolve, layers))
 
     return result
 
@@ -312,8 +355,12 @@ def extract_layers(layer_paths, output_dir):
 
     Layers must be provided in order (bottom to top).  Handles Docker
     whiteout files (.wh.*) for proper layer stacking.
+
+    Disable pigz with OCI_EXTRACT_PIGZ=0 for diagnostics.
     """
-    pigz = shutil.which("pigz")
+    pigz = (
+        shutil.which("pigz") if os.environ.get("OCI_EXTRACT_PIGZ", "1") != "0" else None
+    )
     os.makedirs(output_dir, exist_ok=True)
     if pigz:
         print(f"Using pigz: {pigz}", file=sys.stderr)
@@ -360,7 +407,7 @@ def extract_layer(tar_path, output_dir, pigz=None):
         proc.wait()
 
 
-_PIGZ = shutil.which("pigz")
+_PIGZ = shutil.which("pigz") if os.environ.get("OCI_EXTRACT_PIGZ", "1") != "0" else None
 
 
 def _extract_tar_members(tar, output_dir):

--- a/oci_extract_test.py
+++ b/oci_extract_test.py
@@ -731,5 +731,132 @@ class TestExtractLayers(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(output, "old.txt")))
 
 
+class TestSetupSsl(unittest.TestCase):
+    """Test _setup_ssl() certificate bundle detection."""
+
+    def setUp(self):
+        self.orig_env = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.orig_env)
+
+    def test_respects_existing_ssl_cert_file(self):
+        os.environ["SSL_CERT_FILE"] = "/custom/ca.pem"
+        os.environ.pop("NIX_SSL_CERT_FILE", None)
+        oci_extract._setup_ssl()
+        self.assertEqual(os.environ["SSL_CERT_FILE"], "/custom/ca.pem")
+
+    @patch("os.path.isfile", return_value=True)
+    def test_nix_ssl_cert_file(self, _mock_isfile):
+        os.environ.pop("SSL_CERT_FILE", None)
+        os.environ["NIX_SSL_CERT_FILE"] = "/nix/store/xxx/ca-bundle.crt"
+        oci_extract._setup_ssl()
+        self.assertEqual(
+            os.environ.get("SSL_CERT_FILE"),
+            "/nix/store/xxx/ca-bundle.crt",
+        )
+
+    @patch("os.path.isfile")
+    def test_fallback_candidates(self, mock_isfile):
+        os.environ.pop("SSL_CERT_FILE", None)
+        os.environ.pop("NIX_SSL_CERT_FILE", None)
+        mock_isfile.side_effect = (
+            lambda path: path == "/etc/pki/tls/certs/ca-bundle.crt"
+        )
+        oci_extract._setup_ssl()
+        self.assertEqual(
+            os.environ.get("SSL_CERT_FILE"),
+            "/etc/pki/tls/certs/ca-bundle.crt",
+        )
+
+    @patch("os.path.isfile", return_value=False)
+    def test_no_cert_found(self, _mock_isfile):
+        os.environ.pop("SSL_CERT_FILE", None)
+        os.environ.pop("NIX_SSL_CERT_FILE", None)
+        oci_extract._setup_ssl()
+        self.assertNotIn("SSL_CERT_FILE", os.environ)
+
+    def test_disabled_by_toggle(self):
+        os.environ.pop("SSL_CERT_FILE", None)
+        os.environ["NIX_SSL_CERT_FILE"] = "/nix/store/xxx/ca-bundle.crt"
+        os.environ["OCI_EXTRACT_SSL_SETUP"] = "0"
+        oci_extract._setup_ssl()
+        self.assertNotIn("SSL_CERT_FILE", os.environ)
+
+
+class TestDiagnosticToggles(unittest.TestCase):
+    """Test OCI_EXTRACT_* diagnostic toggles."""
+
+    def setUp(self):
+        self.orig_env = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.orig_env)
+
+    @patch("oci_extract.shutil.which", return_value="/usr/bin/pigz")
+    def test_pigz_enabled_by_default(self, _mock_which):
+        os.environ.pop("OCI_EXTRACT_PIGZ", None)
+        # extract_layers reads the toggle; check via _PIGZ-like logic
+        pigz = (
+            shutil.which("pigz")
+            if os.environ.get("OCI_EXTRACT_PIGZ", "1") != "0"
+            else None
+        )
+        self.assertIsNotNone(pigz)
+
+    def test_pigz_disabled(self):
+        os.environ["OCI_EXTRACT_PIGZ"] = "0"
+        pigz = (
+            shutil.which("pigz")
+            if os.environ.get("OCI_EXTRACT_PIGZ", "1") != "0"
+            else None
+        )
+        self.assertIsNone(pigz)
+
+    @patch("oci_extract.resolve_blob_url", return_value="https://cdn/blob")
+    @patch(
+        "oci_extract.fetch_manifest",
+        return_value={
+            "layers": [
+                {"digest": "sha256:aaa", "size": 100},
+                {"digest": "sha256:bbb", "size": 200},
+            ]
+        },
+    )
+    @patch("oci_extract.get_token", return_value="tok")
+    def test_parallel_disabled(self, _tok, _manifest, mock_resolve):
+        os.environ["OCI_EXTRACT_PARALLEL"] = "0"
+        with patch("concurrent.futures.ThreadPoolExecutor") as mock_pool:
+            oci_extract.resolve_layers("docker.io/test/img", "sha256:abc")
+            mock_pool.assert_not_called()
+
+    @patch("oci_extract.resolve_blob_url", return_value="https://cdn/blob")
+    @patch(
+        "oci_extract.fetch_manifest",
+        return_value={
+            "layers": [
+                {"digest": "sha256:aaa", "size": 100},
+                {"digest": "sha256:bbb", "size": 200},
+            ]
+        },
+    )
+    @patch("oci_extract.get_token", return_value="tok")
+    def test_parallel_enabled_by_default(self, _tok, _manifest, _resolve):
+        os.environ.pop("OCI_EXTRACT_PARALLEL", None)
+        with patch("concurrent.futures.ThreadPoolExecutor") as mock_pool:
+            mock_pool.return_value.__enter__ = MagicMock()
+            mock_pool.return_value.__exit__ = MagicMock(return_value=False)
+            mock_pool.return_value.__enter__.return_value.map = MagicMock(
+                return_value=[
+                    {"digest": "sha256:aaa", "size": 100, "url": "https://cdn/blob"},
+                    {"digest": "sha256:bbb", "size": 200, "url": "https://cdn/blob"},
+                ]
+            )
+            oci_extract.resolve_layers("docker.io/test/img", "sha256:abc")
+            mock_pool.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
rules_python's hermetic Python bundles its own OpenSSL, which looks for CA certificates at a compiled-in FHS path. On NixOS the CA bundle lives in /nix/store/ and is exposed via NIX_SSL_CERT_FILE, but Python's urllib doesn't check that variable.

Add _setup_ssl() that auto-detects the CA bundle at startup:
1. Respects existing SSL_CERT_FILE (no-op)
2. Checks NIX_SSL_CERT_FILE and CURL_CA_BUNDLE env vars
3. Falls back to common distro paths

Also add diagnostic toggles (default=1, set =0 to disable):
- OCI_EXTRACT_SSL_SETUP: skip CA bundle auto-detection
- OCI_EXTRACT_PIGZ: skip pigz, use Python gzip
- OCI_EXTRACT_PARALLEL: sequential URL resolution

Test procedure for reviewers:

## OCI extraction (exercises SSL + all phases)

    bazelisk fetch @docker_orfs//...

## Full build with real OpenROAD (macro through generate_abstract)

    bazelisk test //test/smoketest:lb_32x128_asap7_build_test

## Diagnose: disable features one at a time

    OCI_EXTRACT_PARALLEL=0 bazelisk fetch @docker_orfs//...
    OCI_EXTRACT_PIGZ=0 bazelisk fetch @docker_orfs//...

## NixOS: confirm the SSL fix is what helps

    OCI_EXTRACT_SSL_SETUP=0 bazelisk fetch @docker_orfs//...
