### PR TITLE
fix: update verilator, rules_verilator, and add rules_verilog

### DIFF
--- a/EXTERNAL_API.md
+++ b/EXTERNAL_API.md
@@ -15,7 +15,7 @@ consumers.
 | `openroad.bzl` | `orfs_flow`, `orfs_synth`, `orfs_update`, `orfs_run`, `orfs_test`, `orfs_macro`, `orfs_pdk`, `orfs_deps`, `orfs_floorplan`, `orfs_place`, `orfs_cts`, `orfs_grt`, `orfs_route`, `orfs_final`, `orfs_gds`, `orfs_abstract`, `orfs_generate_metadata`, `orfs_update_rules`, providers (`OrfsInfo`, `PdkInfo`, `TopInfo`, `OrfsDepInfo`, `LoggingInfo`) | `bazel_skylib` |
 | `extension.bzl` | `orfs_repositories` module extension | built-in only |
 | `ppa.bzl` | `orfs_ppa` | `rules_shell` |
-| `verilog.bzl` | `verilog_directory`, `verilog_file`, `verilog_single_file_library` | `rules_verilator` |
+| `verilog.bzl` | `verilog_directory`, `verilog_file`, `verilog_single_file_library` | `rules_verilog` |
 | `generate.bzl` | `fir_library` | none (`@circt` http_archive) |
 | `sby/sby.bzl` | `sby_test` | `bazel-orfs-verilog`, `oss_cad_suite` (in `bazel-orfs-sby` submodule) |
 | `eqy.bzl` | `eqy_test` | none |
@@ -29,7 +29,8 @@ downstream consumers may transitively evaluate:
 
 - `bazel_skylib` — `BuildSettingInfo` in private/attrs.bzl, private/environment.bzl
 - `rules_shell` — `sh_binary` in ppa.bzl, root BUILD
-- `rules_verilator` — verilog providers in verilog.bzl
+- `rules_verilog` — verilog providers in verilog.bzl
+- `rules_verilator` — verilator toolchain, verilator_cc_library
 - `verilator` — required by rules_verilator
 - `rules_python` — `py_binary` in root BUILD, pythonwrapper/BUILD
 

--- a/chisel/MODULE.bazel
+++ b/chisel/MODULE.bazel
@@ -103,8 +103,9 @@ register_toolchains(
 
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_shell", version = "0.3.0")
-bazel_dep(name = "rules_verilator", version = "0.1.0")
-bazel_dep(name = "verilator", version = "5.036.bcr.3")
+bazel_dep(name = "rules_verilator", version = "0.3.1")
+bazel_dep(name = "rules_verilog", version = "1.1.1")
+bazel_dep(name = "verilator", version = "5.046.bcr.2")
 bazel_dep(name = "googletest", version = "1.17.0")
 
 # --- Chisel / Scala toolchain ---

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -104,7 +104,8 @@ register_toolchains(
 # --- rules_scala + Chisel: for building Chisel projects (Gemmini, etc.) ---
 
 bazel_dep(name = "rules_chisel", version = "0.3.0")
-bazel_dep(name = "rules_verilator", version = "0.1.0")
+bazel_dep(name = "rules_verilator", version = "0.3.1")
+bazel_dep(name = "rules_verilog", version = "1.1.1")
 bazel_dep(name = "bazel-orfs-verilog")
 local_path_override(
     module_name = "bazel-orfs-verilog",

--- a/verilog/MODULE.bazel
+++ b/verilog/MODULE.bazel
@@ -3,8 +3,9 @@ module(
     version = "0.0.1",
 )
 
-bazel_dep(name = "rules_verilator", version = "0.1.0")
-bazel_dep(name = "verilator", version = "5.036.bcr.3")
+bazel_dep(name = "rules_verilator", version = "0.3.1")
+bazel_dep(name = "rules_verilog", version = "1.1.1")
+bazel_dep(name = "verilator", version = "5.046.bcr.2")
 
 http_archive = use_repo_rule(
     "@bazel_tools//tools/build_defs/repo:http.bzl",

--- a/verilog/verilog.bzl
+++ b/verilog/verilog.bzl
@@ -11,7 +11,7 @@ constructs in the .fir won't match what this pass expects.
 See sby.bzl for an example of passing consistent options to both passes.
 """
 
-load("@rules_verilator//verilog:providers.bzl", "make_dag_entry", "make_verilog_info")
+load("@rules_verilog//verilog:defs.bzl", "VerilogInfo")
 
 def _verilog_impl(ctx, split):
     if split:
@@ -37,26 +37,21 @@ def _verilog_impl(ctx, split):
     )
 
     # TODO: Figure out how to get the directories w/o hardcoding
-    verilog_info = make_verilog_info(
-        new_entries = [
-            make_dag_entry(
-                srcs = [sv],
-                hdrs = [],
-                includes = [
-                    sv.path,
-                    sv.path + "/Simulation",
-                    sv.path + "/verification",
-                    sv.path + "/verification/assume",
-                    sv.path + "/verification/cover",
-                    sv.path + "/verification/assert",
-                ],
-                data = [],
-                deps = [],
-                label = ctx.label,
-                tags = [],
-            ),
-        ],
-        old_infos = [],
+    verilog_info = VerilogInfo(
+        srcs = depset([sv]),
+        hdrs = depset(),
+        includes = depset([
+            sv.path,
+            sv.path + "/Simulation",
+            sv.path + "/verification",
+            sv.path + "/verification/assume",
+            sv.path + "/verification/cover",
+            sv.path + "/verification/assert",
+        ]),
+        data = depset(),
+        deps = depset(),
+        standard = "",
+        top_module = "",
     )
 
     return [


### PR DESCRIPTION
Upgrade to hermetic-compatible versions and use the new rules_verilog package for verilog providers (VerilogInfo), which was extracted from rules_verilator into its own module.

- verilator 5.036.bcr.3 → 5.046.bcr.2
- rules_verilator 0.1.0 → 0.3.1
- rules_verilog 1.1.1 (new dependency)

The older verilator had non-hermetic Python scripts in its build; 5.046.bcr.2 fixes this. The newer rules_verilator depends on rules_verilog for verilog providers, so verilog.bzl now loads VerilogInfo from @rules_verilog instead of the removed @rules_verilator//verilog:providers.bzl.

Fixes https://github.com/The-OpenROAD-Project/bazel-orfs/issues/654