### PR TITLE
feat: add OrfsInfo.arguments and orfs_arguments rule for computed flow args

### DIFF
--- a/docs/orfs_arguments.md
+++ b/docs/orfs_arguments.md
@@ -1,0 +1,137 @@
+# `orfs_arguments` — Computed Flow Arguments
+
+## Overview
+
+`orfs_arguments` is a Bazel rule that runs a Tcl script to compute ORFS
+flow arguments (e.g., `CORE_UTILIZATION`, `PLACE_DENSITY`) from stage
+outputs. The computed arguments are stored as a `.json` file and flow
+through `OrfsInfo.arguments` to subsequent stages.
+
+## OrfsInfo.arguments
+
+`OrfsInfo.arguments` is a depset of `.json` files that accumulates as
+stages run. Each `.json` file is a flat dictionary:
+
+```json
+{"CORE_UTILIZATION": "40", "PLACE_DENSITY": "0.65"}
+```
+
+When a stage generates its `.mk` config, it merges all inherited `.json`
+files into a Makefile-style include. The `.mk` format is an implementation
+detail — the interface is always `.json`.
+
+### Precedence
+
+Arguments are merged in this order (first set wins with `?=`):
+
+1. **Inherited `.json` files** from `OrfsInfo.arguments` (included first)
+2. **Stage's own arguments** from the `arguments` attr (written as `export VAR?=`)
+3. **`extra_configs`** included last (can use `export VAR=` to force override)
+
+## `orfs_arguments` Rule
+
+### Usage
+
+```python
+load("//:openroad.bzl", "orfs_arguments")
+
+orfs_arguments(
+    name = "auto_utilization",
+    src = ":my_design_synth",
+    script = ":auto_utilization.tcl",
+)
+```
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `src` | label | Previous stage target providing `OrfsInfo` |
+| `script` | label | Tcl script that computes arguments |
+| `arguments` | dict | Environment variables passed to the Tcl script |
+| `data` | label_list | Additional input files for the Tcl script |
+
+### Tcl Script Contract
+
+The script receives:
+
+- `$::env(SCRIPTS_DIR)` — ORFS scripts directory
+- `$::env(RESULTS_DIR)` — results directory with stage outputs
+- `$::env(WORK_HOME)` — working directory for outputs
+- `$::env(OUTPUT)` — output filename (auto-generated `.json`)
+- All entries from the `arguments` attr as environment variables
+
+The script must write a JSON dictionary to `$WORK_HOME/$OUTPUT`:
+
+```tcl
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_synth.odb 1_synth.sdc
+
+# ... compute values from the design ...
+
+set out [file join $::env(WORK_HOME) $::env(OUTPUT)]
+set f [open $out w]
+puts $f "\{\"CORE_UTILIZATION\": \"40\", \"PLACE_DENSITY\": \"0.65\"\}"
+close $f
+```
+
+### Output
+
+The rule outputs `OrfsInfo` identical to the input, except:
+
+- `OrfsInfo.arguments` has the computed `.json` appended to the depset
+
+All other fields (`odb`, `gds`, `config`, etc.) pass through unchanged.
+
+## `extra_arguments` in `orfs_flow`
+
+Inject `.json` argument files at specific stages:
+
+```python
+orfs_flow(
+    name = "my_design",
+    extra_arguments = {
+        "floorplan": [":auto_utilization"],
+    },
+    previous_stage = {"floorplan": ":my_design_synth"},
+    # ...
+)
+```
+
+## Example: Auto-Utilization Flow
+
+```
+orfs_synth ──> orfs_arguments(auto_util.tcl) ──> orfs_flow(floorplan+)
+                     │                                    │
+                     │ reads synth ODB                    │ inherits .json
+                     │ computes CORE_UTILIZATION           │ via OrfsInfo.arguments
+                     │ writes .json                       │
+                     └────────────────────────────────────┘
+```
+
+```python
+orfs_synth(
+    name = "my_design_synth",
+    verilog_files = ["rtl/my_design.sv"],
+    # ...
+)
+
+orfs_arguments(
+    name = "my_design_auto_util",
+    src = ":my_design_synth",
+    script = ":auto_utilization.tcl",
+)
+
+orfs_flow(
+    name = "my_design",
+    arguments = {/* other args */},
+    previous_stage = {"floorplan": ":my_design_auto_util"},
+    verilog_files = ["rtl/my_design.sv"],
+    # ...
+)
+```
+
+The floorplan stage inherits `CORE_UTILIZATION` and `PLACE_DENSITY` from
+the `.json` computed by `auto_utilization.tcl`. These values take
+precedence over defaults in the `arguments` dict because inherited `.json`
+files are included before the stage's own `export VAR?=` lines.

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -39,6 +39,7 @@ load(
     _TEST_STAGE_IMPL = "TEST_STAGE_IMPL",
     _UPDATE_RULES_IMPL = "UPDATE_RULES_IMPL",
     _orfs_abstract = "orfs_abstract",
+    _orfs_arguments = "orfs_arguments",
     _orfs_cts = "orfs_cts",
     _orfs_final = "orfs_final",
     _orfs_floorplan = "orfs_floorplan",
@@ -99,6 +100,7 @@ flow_provides = _flow_provides
 # Rules
 orfs_pdk = _orfs_pdk
 orfs_macro = _orfs_macro
+orfs_arguments = _orfs_arguments
 orfs_run = _orfs_run
 orfs_test = _orfs_test
 orfs_floorplan = _orfs_floorplan

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -2,3 +2,5 @@ package(default_visibility = [
     "//:__pkg__",
     "//private:__subpackages__",
 ])
+
+exports_files(["merge_arguments.py"])

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -49,6 +49,11 @@ def orfs_attrs():
             doc = "Arguments with build settings.",
             providers = [BuildSettingInfo],
         ),
+        "extra_arguments": attr.label_list(
+            doc = "List of .json argument files to merge into stage config.",
+            allow_files = [".json"],
+            default = [],
+        ),
         "extra_configs": attr.label_list(
             doc = "List of additional flow configuration files.",
             allow_files = True,
@@ -87,6 +92,11 @@ def orfs_attrs():
             doc = "Tcl library.",
             allow_files = True,
             default = Label("@docker_orfs//:tcl8.6"),
+        ),
+        "_merge_arguments": attr.label(
+            doc = "Python script for merging .json argument files into .mk config.",
+            allow_single_file = True,
+            default = Label("@bazel-orfs//private:merge_arguments.py"),
         ),
         "_package_stage": attr.label(
             doc = "Python script for creating portable stage tarballs.",

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -278,7 +278,7 @@ def required_arguments(ctx):
         "WORK_HOME": "./" + ctx.label.package,
     }
 
-def orfs_arguments(*args, short = False):
+def orfs_additional_arguments(*args, short = False):
     """Returns ADDITIONAL_GDS/LEFS/LIBS arguments from OrfsInfo providers.
 
     Args:
@@ -410,13 +410,16 @@ def _prefix_include_dirs(dirs_value, prefix):
         if p.strip()
     ])
 
-def config_content(ctx, arguments, paths):
+def config_content(ctx, arguments, paths, pre_paths = []):
     """Generate Makefile-style config content for an ORFS stage.
 
     Args:
       ctx: The rule context.
       arguments: Dictionary of config variables.
-      paths: List of additional config file paths to include.
+      paths: List of additional config file paths to include at the end.
+      pre_paths: List of config file paths to include at the top, before
+        the export lines. Included files set with ?= take precedence over
+        the export lines that follow.
 
     Returns:
       A string with export VAR?=value lines and include directives.
@@ -436,6 +439,7 @@ def config_content(ctx, arguments, paths):
         )
 
     return "".join(
+        ["include {}\n".format(path) for path in pre_paths] +
         sorted(
             [
                 "export {}?={}\n".format(*pair)

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -34,6 +34,7 @@ def _filter_stage_args(stage, **kwargs):
     arguments = kwargs.pop("arguments", {})
     data = kwargs.pop("data", [])
     settings = kwargs.pop("settings", {})
+    extra_arguments = kwargs.pop("extra_arguments", {})
     extra_configs = kwargs.pop("extra_configs", {})
     sources = kwargs.pop("sources", {})
     stage_arguments = kwargs.pop("stage_arguments", {})
@@ -58,6 +59,7 @@ def _filter_stage_args(stage, **kwargs):
         data = get_sources(stage, stage_sources, sources) +
                stage_data.get(stage, []) +
                data,
+        extra_arguments = extra_arguments.get(stage, []),
         extra_configs = extra_configs.get(stage, []),
         settings = get_stage_args(
             stage,
@@ -114,6 +116,7 @@ def orfs_flow(
         stage_arguments = {},
         renamed_inputs = {},
         arguments = {},
+        extra_arguments = {},
         extra_configs = {},
         abstract_stage = None,
         last_stage = None,
@@ -143,6 +146,9 @@ def orfs_flow(
         Use stage_arguments only to override the automatic stage assignment.
       renamed_inputs: dictionary keyed by ORFS stages to rename inputs
       arguments: dictionary of additional arguments to the flow, automatically assigned to stages
+      extra_arguments: dictionary keyed by ORFS stages with lists of .json argument file labels.
+        These .json files are merged into the stage config, providing computed arguments
+        that flow through OrfsInfo to subsequent stages.
       extra_configs: dictionary keyed by ORFS stages with list of additional configuration files
       abstract_stage: string with physical design flow stage name which controls the name of the files generated in _generate_abstract stage
       last_stage: string with the last stage to run, stops the flow early without generating an abstract. Mutually exclusive with abstract_stage. Useful for fast testing.
@@ -181,6 +187,7 @@ def orfs_flow(
         stage_arguments = stage_arguments,
         renamed_inputs = renamed_inputs,
         arguments = arguments,
+        extra_arguments = extra_arguments,
         extra_configs = extra_configs,
         abstract_stage = abstract_stage,
         last_stage = last_stage,
@@ -216,6 +223,7 @@ def orfs_flow(
         stage_arguments = stage_arguments,
         renamed_inputs = {},
         arguments = arguments | {"SYNTH_GUT": "1"},
+        extra_arguments = extra_arguments,
         extra_configs = extra_configs | mock_configs,
         abstract_stage = "place",
         variant = mock_variant,
@@ -309,6 +317,7 @@ def _orfs_pass(
         stage_arguments,
         renamed_inputs,
         arguments,
+        extra_arguments,
         extra_configs,
         abstract_stage,
         variant,
@@ -380,6 +389,7 @@ def _orfs_pass(
                 pdk = pdk,
                 stage_sources = stage_sources,
                 settings = settings,
+                extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
                 stage_data = stage_data,
                 save_odb = save_odb,
@@ -411,6 +421,7 @@ def _orfs_pass(
             all_drc_names = []
             all_arguments = {}
             all_data = []
+            all_extra_arguments = []
             all_extra_configs = []
             all_settings = {}
             for s in squash_steps:
@@ -430,6 +441,7 @@ def _orfs_pass(
                     sources = dict(sources),
                     stage_sources = dict(stage_sources),
                     settings = dict(settings),
+                    extra_arguments = dict(extra_arguments),
                     extra_configs = dict(extra_configs),
                     stage_data = dict(stage_data),
                 )
@@ -437,6 +449,9 @@ def _orfs_pass(
                 for d in stage_filtered.get("data", []):
                     if d not in all_data:
                         all_data.append(d)
+                for ea in stage_filtered.get("extra_arguments", []):
+                    if ea not in all_extra_arguments:
+                        all_extra_arguments.append(ea)
                 for c in stage_filtered.get("extra_configs", []):
                     if c not in all_extra_configs:
                         all_extra_configs.append(c)
@@ -455,6 +470,7 @@ def _orfs_pass(
                 variant = variant,
                 arguments = all_arguments,
                 data = all_data,
+                extra_arguments = all_extra_arguments,
                 extra_configs = all_extra_configs,
                 settings = all_settings,
                 **kwargs
@@ -478,6 +494,7 @@ def _orfs_pass(
                         sources = sources,
                         stage_sources = stage_sources,
                         settings = settings,
+                        extra_arguments = extra_arguments,
                         extra_configs = extra_configs,
                         src = squash_name,
                         variant = variant,
@@ -502,6 +519,7 @@ def _orfs_pass(
                 sources = sources,
                 stage_sources = stage_sources,
                 settings = settings,
+                extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
                 src = src,
                 variant = variant,

--- a/private/merge_arguments.py
+++ b/private/merge_arguments.py
@@ -1,0 +1,22 @@
+"""Merge .json argument files into a Makefile-style config."""
+
+import json
+import sys
+
+
+def main():
+    output_path = sys.argv[1]
+    json_paths = sys.argv[2:]
+
+    result = {}
+    for path in json_paths:
+        with open(path) as f:
+            result.update(json.load(f))
+
+    with open(output_path, "w") as out:
+        for k, v in sorted(result.items()):
+            out.write("export {}?={}\n".format(k, v))
+
+
+if __name__ == "__main__":
+    main()

--- a/private/providers.bzl
+++ b/private/providers.bzl
@@ -13,6 +13,7 @@ OrfsInfo = provider(
         "additional_gds",
         "additional_lefs",
         "additional_libs",
+        "arguments",
     ],
 )
 PdkInfo = provider(

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -32,7 +32,7 @@ load(
     "input_commands",
     "merge_arguments",
     "odb_arguments",
-    "orfs_arguments",
+    "orfs_additional_arguments",
     "pdk_inputs",
     "rename_inputs",
     "renames",
@@ -248,6 +248,7 @@ def _macro_impl(ctx):
             additional_gds = depset([]),
             additional_lefs = depset([]),
             additional_libs = depset([]),
+            arguments = depset([]),
         ),
         TopInfo(
             module_top = ctx.attr.module_top,
@@ -430,6 +431,87 @@ orfs_run = rule(
                     mandatory = True,
                     allow_empty = False,
                 ),
+                "script": attr.label(
+                    mandatory = True,
+                    allow_single_file = ["tcl"],
+                ),
+            },
+)
+
+# --- Arguments rule ---
+
+def _arguments_impl(ctx):
+    """Runs a Tcl script to compute flow arguments, outputs OrfsInfo with modified arguments."""
+    src_info = ctx.attr.src[OrfsInfo]
+    computed_json = ctx.actions.declare_file(ctx.attr.name + ".json")
+
+    ctx.actions.run_shell(
+        arguments = [
+            "--file",
+            ctx.file._makefile.path,
+        ],
+        command = " ".join(
+            [
+                ctx.executable._make.path,
+                "run",
+                "$@",
+            ],
+        ),
+        env = config_overrides(
+            ctx,
+            flow_environment(ctx) |
+            yosys_environment(ctx) |
+            config_environment(src_info.config) |
+            odb_arguments(ctx) |
+            data_arguments(ctx) |
+            run_arguments(ctx) |
+            {"OUTPUT": computed_json.basename},
+        ),
+        inputs = depset(
+            [src_info.config, ctx.file.script],
+            transitive = [
+                data_inputs(ctx),
+                source_inputs(ctx),
+            ],
+        ),
+        outputs = [computed_json],
+        tools = depset(
+            transitive = [
+                flow_inputs(ctx),
+                yosys_inputs(ctx),
+            ],
+        ),
+    )
+
+    return [
+        DefaultInfo(files = depset([computed_json])),
+        OrfsInfo(
+            stage = src_info.stage,
+            config = src_info.config,
+            variant = src_info.variant,
+            odb = src_info.odb,
+            gds = src_info.gds,
+            lef = src_info.lef,
+            lib = src_info.lib,
+            additional_gds = src_info.additional_gds,
+            additional_lefs = src_info.additional_lefs,
+            additional_libs = src_info.additional_libs,
+            arguments = depset(
+                [computed_json],
+                transitive = [src_info.arguments],
+            ),
+        ),
+        ctx.attr.src[PdkInfo],
+        ctx.attr.src[TopInfo],
+        ctx.attr.src[LoggingInfo],
+        ctx.attr.src[OrfsDepInfo],
+    ]
+
+orfs_arguments = rule(
+    implementation = _arguments_impl,
+    attrs = yosys_attrs() |
+            openroad_attrs() |
+            {
                 "script": attr.label(
                     mandatory = True,
                     allow_single_file = ["tcl"],
@@ -752,7 +834,7 @@ def _yosys_impl(ctx):
     all_arguments = merge_arguments(
         data_arguments(ctx) |
         required_arguments(ctx),
-        orfs_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps]),
+        orfs_additional_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps]),
     )
     config = declare_artifact(ctx, "results", "1_synth.mk")
     ctx.actions.write(
@@ -898,7 +980,7 @@ def _yosys_impl(ctx):
                 arguments = merge_arguments(
                     data_arguments(ctx) |
                     required_arguments(ctx),
-                    orfs_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps]),
+                    orfs_additional_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps]),
                 ) | verilog_arguments(ctx.files.verilog_files),
                 prefix = config_short.root.path,
             ),
@@ -1005,6 +1087,7 @@ def _yosys_impl(ctx):
             additional_libs = depset(
                 [dep[OrfsInfo].lib for dep in ctx.attr.deps if dep[OrfsInfo].lib],
             ),
+            arguments = depset([]),
         ),
         ctx.attr.pdk[PdkInfo],
         TopInfo(
@@ -1106,14 +1189,36 @@ def _make_impl(
         extra_arguments |
         data_arguments(ctx) |
         required_arguments(ctx),
-        orfs_arguments(ctx.attr.src[OrfsInfo]),
+        orfs_additional_arguments(ctx.attr.src[OrfsInfo]),
     )
+
+    # Write this stage's arguments to .json for downstream stages
+    stage_json = declare_artifact(ctx, "results", stage + ".args.json")
+    ctx.actions.write(
+        output = stage_json,
+        content = json.encode(data_arguments(ctx)),
+    )
+
+    # Merge inherited + extra + stage .json files into .mk at build time
+    inherited_jsons = ctx.attr.src[OrfsInfo].arguments.to_list()
+    extra_arg_files = ctx.files.extra_arguments
+    all_jsons = inherited_jsons + extra_arg_files + [stage_json]
+    args_mk = declare_artifact(ctx, "results", stage + ".args.mk")
+    ctx.actions.run(
+        executable = ctx.executable._python,
+        arguments = [ctx.file._merge_arguments.path, args_mk.path] +
+                    [f.path for f in all_jsons],
+        inputs = all_jsons + [ctx.file._merge_arguments],
+        outputs = [args_mk],
+    )
+
     config = declare_artifact(ctx, "results", stage + ".mk")
     ctx.actions.write(
         output = config,
         content = config_content(
             ctx,
             arguments = all_arguments,
+            pre_paths = [args_mk.path],
             paths = [file.path for file in ctx.files.extra_configs],
         ),
     )
@@ -1155,7 +1260,7 @@ def _make_impl(
             command = " && ".join(commands),
             env = config_overrides(ctx, flow_environment(ctx) | config_environment(config)),
             inputs = depset(
-                [config] + ctx.files.extra_configs,
+                [config, args_mk] + ctx.files.extra_configs + all_jsons,
                 transitive = [
                     data_inputs(ctx),
                     source_inputs(ctx),
@@ -1176,10 +1281,11 @@ def _make_impl(
                     extra_arguments |
                     data_arguments(ctx) |
                     required_arguments(ctx),
-                    orfs_arguments(ctx.attr.src[OrfsInfo]),
+                    orfs_additional_arguments(ctx.attr.src[OrfsInfo]),
                 ),
                 prefix = config_short.root.path,
             ),
+            pre_paths = [args_mk.short_path],
             paths = [file.short_path for file in ctx.files.extra_configs],
         ),
     )
@@ -1201,7 +1307,7 @@ def _make_impl(
     # Collect all files needed for deployment.
     stage_renames = renames(ctx, ctx.files.src, short = True)
     deploy_files = depset(
-        [config_short, make] + ctx.files.src + ctx.files.extra_configs,
+        [config_short, make, args_mk] + ctx.files.src + ctx.files.extra_configs + all_jsons,
         transitive = [
             flow_inputs(ctx),
             data_inputs(ctx),
@@ -1297,6 +1403,11 @@ def _make_impl(
             additional_gds = ctx.attr.src[OrfsInfo].additional_gds,
             additional_lefs = ctx.attr.src[OrfsInfo].additional_lefs,
             additional_libs = ctx.attr.src[OrfsInfo].additional_libs,
+            arguments = depset(
+                [stage_json],
+                transitive = [ctx.attr.src[OrfsInfo].arguments] +
+                             ([depset(extra_arg_files)] if extra_arg_files else []),
+            ),
         ),
         LoggingInfo(
             logs = depset(logs, transitive = [ctx.attr.src[LoggingInfo].logs]),

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,7 +2,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load("//:openroad.bzl", "get_stage_args", "orfs_floorplan", "orfs_flow", "orfs_gds", "orfs_macro", "orfs_run", "orfs_synth")
+load("//:openroad.bzl", "get_stage_args", "orfs_arguments", "orfs_floorplan", "orfs_flow", "orfs_gds", "orfs_macro", "orfs_run", "orfs_synth")
 load("//:orfs_genrule.bzl", "orfs_genrule")
 load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
@@ -340,6 +340,27 @@ sh_binary(
     ],
     data = [":lb_32x128_write_pin_placement"],
     tags = ["manual"],
+)
+
+# Auto-utilization: computes CORE_UTILIZATION and PLACE_DENSITY from synthesis
+# results via a Tcl heuristic, injecting them into OrfsInfo.arguments as .json.
+orfs_arguments(
+    name = "lb_32x128_auto_utilization",
+    src = ":lb_32x128_synth",
+    script = ":auto_utilization.tcl",
+    tags = ["manual"],
+)
+
+# buildifier: disable=duplicated-name
+orfs_flow(
+    name = "lb_32x128",
+    arguments = LB_ARGS,
+    last_stage = "floorplan",
+    previous_stage = {"floorplan": ":lb_32x128_auto_utilization"},
+    stage_sources = LB_STAGE_SOURCES,
+    tags = ["manual"],
+    variant = "auto_util",
+    verilog_files = LB_VERILOG_FILES,
 )
 
 orfs_run(

--- a/test/auto_utilization.tcl
+++ b/test/auto_utilization.tcl
@@ -1,0 +1,22 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_synth.odb 1_synth.sdc
+
+set block [ord::get_db_block]
+set num_cells [llength [$block getInsts]]
+
+if {$num_cells < 500} {
+    set util 50
+} elseif {$num_cells < 5000} {
+    set util 40
+} else {
+    set util 30
+}
+set density [format "%.2f" [expr {$util / 100.0 + 0.15}]]
+
+set out [file join $::env(WORK_HOME) $::env(OUTPUT)]
+set f [open $out w]
+puts $f "\{\"CORE_UTILIZATION\": \"$util\", \"PLACE_DENSITY\": \"$density\"\}"
+close $f
+
+puts "Cell count: $num_cells"
+puts "Computed CORE_UTILIZATION=$util PLACE_DENSITY=$density"


### PR DESCRIPTION
Add a mechanism for flow arguments to accumulate as .json files through OrfsInfo.arguments (depset) and flow from stage to stage. Each stage merges inherited .json files into a .mk config at build time, keeping the .mk format as an internal implementation detail.

The new orfs_arguments rule runs a Tcl script to compute arguments (e.g., CORE_UTILIZATION, PLACE_DENSITY) from stage outputs, storing the result as .json in OrfsInfo.arguments. orfs_flow gains an extra_arguments parameter for per-stage .json injection.

Includes a test variant (lb_32x128 auto_util) demonstrating the pattern: synth → orfs_arguments(auto_utilization.tcl) → floorplan.