### PR TITLE
bump: update orfs, openroad, qt-bazel and fix stale patch

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ local_path_override(
 
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 
-bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "mock-klayout", version = "0.0.1")
 local_path_override(
@@ -36,13 +36,12 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "f40d2f346e67ffe309a4f49b1897a560cf20c747",
+    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
     patch_strip = 1,
     # Minimal patches: only what's needed for extension.bzl flow targets
     # (PDK definitions, variables.yaml export). Design-specific patches
     # are only applied in the orfs/ integration workspace.
     patches = [
-        "//patches:0001-build-remove-stale-merge_lib.py-preprocessLib.py-fro.patch",
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
         "//patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
     ],
@@ -52,11 +51,12 @@ git_override(
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "df79404cd806cc435b3c3b53678ebf2441c31313",
+    commit = "d22045c978d037f7a5788c08f359aec471800c01",
     init_submodules = True,
     patch_strip = 1,
     patches = [
         "//:openroad-visibility.patch",
+        "//:openroad-remove-initrunfiles.patch",
     ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )
@@ -64,7 +64,7 @@ git_override(
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/chisel/MODULE.bazel
+++ b/chisel/MODULE.bazel
@@ -36,10 +36,9 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "f40d2f346e67ffe309a4f49b1897a560cf20c747",
+    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
     patch_strip = 1,
     patches = [
-        "//patches:0001-build-remove-stale-merge_lib.py-preprocessLib.py-fro.patch",
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
         "//patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
     ],
@@ -57,17 +56,20 @@ use_repo(orfs, "gnumake")
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "df79404cd806cc435b3c3b53678ebf2441c31313",
+    commit = "d22045c978d037f7a5788c08f359aec471800c01",
     init_submodules = True,
     patch_strip = 1,
-    patches = ["//:openroad-visibility.patch"],
+    patches = [
+        "//:openroad-visibility.patch",
+        "//:openroad-remove-initrunfiles.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )
 
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/chisel/openroad-remove-initrunfiles.patch
+++ b/chisel/openroad-remove-initrunfiles.patch
@@ -1,0 +1,140 @@
+diff --git a/bazel/BUILD b/bazel/BUILD
+index a15adee..66f99d2 100644
+--- a/bazel/BUILD
++++ b/bazel/BUILD
+@@ -124,18 +124,12 @@ cc_library(
+     }),
+ )
+ 
+-# shim old library as it is still referenced in src/sta, implementing the
+-# old behavior.
++# Stub library kept for src/sta:opensta compatibility.
++# Tcl setup is now handled by //bazel:tcl_library_init.
+ cc_library(
+     name = "runfiles",
+     srcs = ["InitRunFiles.cpp"],
+-    data = [":tcl_resources_dir"],
+     visibility = ["//visibility:public"],
+-    deps = [
+-        "@rules_cc//cc/runfiles",
+-        "@tcl_lang//:tcl",
+-    ],
+-    alwayslink = True,
+ )
+ 
+ # small build test to check if "bazel build //src/sta:StaTclInitVar" works
+diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
+index 0651774..ece50b0 100644
+--- a/bazel/InitRunFiles.cpp
++++ b/bazel/InitRunFiles.cpp
+@@ -1,86 +1,3 @@
+-// SPDX-License-Identifier: BSD-3-Clause
+-// Copyright (c) 2026, The OpenROAD Authors
+-
+-// This file to go away as soon as we use the tcl_library_init initialization
+-// in OpenSTA.
+-
+-#include <unistd.h>  // readlink()
+-
+-#include <climits>
+-#include <cstdlib>
+-#include <filesystem>
+-#include <iostream>
+-#include <memory>
+-#include <optional>
+-#include <string>
+-#include <system_error>
+-
+-#if defined(__APPLE__)
+-#include <mach-o/dyld.h>
+-#include <sys/param.h>
+-#endif
+-
+-#include "rules_cc/cc/runfiles/runfiles.h"
+-
+-namespace {
+-// Avoid adding any dependencies like boost.filesystem
+-// Returns path to running binary if possible, otherwise nullopt.
+-static std::optional<std::string> GetProgramLocation()
+-{
+-#if defined(_WIN32)
+-  char result[MAX_PATH + 1] = {'\0'};
+-  auto path_len = GetModuleFileNameA(NULL, result, MAX_PATH);
+-#elif defined(__APPLE__)
+-  char result[MAXPATHLEN + 1] = {'\0'};
+-  uint32_t path_len = MAXPATHLEN;
+-  if (_NSGetExecutablePath(result, &path_len) != 0) {
+-    path_len = readlink(result, result, MAXPATHLEN);
+-  }
+-#else
+-  char result[PATH_MAX + 1] = {'\0'};
+-  ssize_t path_len = readlink("/proc/self/exe", result, PATH_MAX);
+-#endif
+-  if (path_len > 0) {
+-    return result;
+-  }
+-  return std::nullopt;
+-}
+-
+-std::string GetTclLibraryBaseLocation()
+-{
+-  using rules_cc::cc::runfiles::Runfiles;
+-  std::string error;
+-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+-      *GetProgramLocation(), BAZEL_CURRENT_REPOSITORY, &error));
+-  if (!runfiles) {
+-    std::cerr << "[Warning] Failed to create bazel runfiles: " << error << "\n";
+-    return "";
+-  }
+-
+-  std::error_code ec;
+-  for (const std::string loc : {"openroad", "opensta", "_main"}) {
+-    const std::string check_loc = loc + "/bazel/tcl_resources_dir";
+-    const std::string path = runfiles->Rlocation(check_loc);
+-    if (!path.empty() && std::filesystem::exists(path, ec)) {
+-      return path;
+-    }
+-  }
+-  return "";
+-}
+-
+-class BazelInitializer
+-{
+- public:
+-  BazelInitializer()
+-  {
+-    const std::string lib_mount_point = GetTclLibraryBaseLocation();
+-    if (!lib_mount_point.empty()) {
+-      const std::string tcl_path = lib_mount_point + "/library";
+-      setenv("TCL_LIBRARY", tcl_path.c_str(), true);
+-    }
+-  }
+-};
+-
+-// Provide via global constructor.
+-static BazelInitializer bazel_initializer;
+-}  // namespace
++// Intentionally empty: tcl_library_init now handles Tcl setup.
++// This file is kept because src/sta:opensta still references
++// //bazel:runfiles in its srcs.
+diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
+index 4be9671..8306978 100644
+--- a/bazel/tcl_library_init.cc
++++ b/bazel/tcl_library_init.cc
+@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+   return Tcl_GetStringResult(interp);
+ #else
+   using rules_cc::cc::runfiles::Runfiles;
++
++  // Clear inherited RUNFILES_* env vars: when OpenROAD is invoked by
++  // a build system that previously ran another Bazel binary (e.g. a
++  // Python wrapper), those variables point to the *other* binary's
++  // runfiles tree.  Runfiles::Create() checks env vars first, so it
++  // would resolve paths in the wrong tree.  Unsetting forces it to
++  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  unsetenv("RUNFILES_DIR");
++  unsetenv("RUNFILES_MANIFEST_FILE");
++
+   std::string error;
+   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -34,10 +34,9 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "f40d2f346e67ffe309a4f49b1897a560cf20c747",
+    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
     patch_strip = 1,
     patches = [
-        "//patches:0001-build-remove-stale-merge_lib.py-preprocessLib.py-fro.patch",
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
         "//patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
     ],
@@ -56,17 +55,20 @@ use_repo(orfs, "gnumake")
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "df79404cd806cc435b3c3b53678ebf2441c31313",
+    commit = "d22045c978d037f7a5788c08f359aec471800c01",
     init_submodules = True,
     patch_strip = 1,
-    patches = ["//:openroad-visibility.patch"],
+    patches = [
+        "//:openroad-visibility.patch",
+        "//:openroad-remove-initrunfiles.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )
 
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/gallery/openroad-remove-initrunfiles.patch
+++ b/gallery/openroad-remove-initrunfiles.patch
@@ -1,0 +1,140 @@
+diff --git a/bazel/BUILD b/bazel/BUILD
+index a15adee..66f99d2 100644
+--- a/bazel/BUILD
++++ b/bazel/BUILD
+@@ -124,18 +124,12 @@ cc_library(
+     }),
+ )
+ 
+-# shim old library as it is still referenced in src/sta, implementing the
+-# old behavior.
++# Stub library kept for src/sta:opensta compatibility.
++# Tcl setup is now handled by //bazel:tcl_library_init.
+ cc_library(
+     name = "runfiles",
+     srcs = ["InitRunFiles.cpp"],
+-    data = [":tcl_resources_dir"],
+     visibility = ["//visibility:public"],
+-    deps = [
+-        "@rules_cc//cc/runfiles",
+-        "@tcl_lang//:tcl",
+-    ],
+-    alwayslink = True,
+ )
+ 
+ # small build test to check if "bazel build //src/sta:StaTclInitVar" works
+diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
+index 0651774..ece50b0 100644
+--- a/bazel/InitRunFiles.cpp
++++ b/bazel/InitRunFiles.cpp
+@@ -1,86 +1,3 @@
+-// SPDX-License-Identifier: BSD-3-Clause
+-// Copyright (c) 2026, The OpenROAD Authors
+-
+-// This file to go away as soon as we use the tcl_library_init initialization
+-// in OpenSTA.
+-
+-#include <unistd.h>  // readlink()
+-
+-#include <climits>
+-#include <cstdlib>
+-#include <filesystem>
+-#include <iostream>
+-#include <memory>
+-#include <optional>
+-#include <string>
+-#include <system_error>
+-
+-#if defined(__APPLE__)
+-#include <mach-o/dyld.h>
+-#include <sys/param.h>
+-#endif
+-
+-#include "rules_cc/cc/runfiles/runfiles.h"
+-
+-namespace {
+-// Avoid adding any dependencies like boost.filesystem
+-// Returns path to running binary if possible, otherwise nullopt.
+-static std::optional<std::string> GetProgramLocation()
+-{
+-#if defined(_WIN32)
+-  char result[MAX_PATH + 1] = {'\0'};
+-  auto path_len = GetModuleFileNameA(NULL, result, MAX_PATH);
+-#elif defined(__APPLE__)
+-  char result[MAXPATHLEN + 1] = {'\0'};
+-  uint32_t path_len = MAXPATHLEN;
+-  if (_NSGetExecutablePath(result, &path_len) != 0) {
+-    path_len = readlink(result, result, MAXPATHLEN);
+-  }
+-#else
+-  char result[PATH_MAX + 1] = {'\0'};
+-  ssize_t path_len = readlink("/proc/self/exe", result, PATH_MAX);
+-#endif
+-  if (path_len > 0) {
+-    return result;
+-  }
+-  return std::nullopt;
+-}
+-
+-std::string GetTclLibraryBaseLocation()
+-{
+-  using rules_cc::cc::runfiles::Runfiles;
+-  std::string error;
+-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+-      *GetProgramLocation(), BAZEL_CURRENT_REPOSITORY, &error));
+-  if (!runfiles) {
+-    std::cerr << "[Warning] Failed to create bazel runfiles: " << error << "\n";
+-    return "";
+-  }
+-
+-  std::error_code ec;
+-  for (const std::string loc : {"openroad", "opensta", "_main"}) {
+-    const std::string check_loc = loc + "/bazel/tcl_resources_dir";
+-    const std::string path = runfiles->Rlocation(check_loc);
+-    if (!path.empty() && std::filesystem::exists(path, ec)) {
+-      return path;
+-    }
+-  }
+-  return "";
+-}
+-
+-class BazelInitializer
+-{
+- public:
+-  BazelInitializer()
+-  {
+-    const std::string lib_mount_point = GetTclLibraryBaseLocation();
+-    if (!lib_mount_point.empty()) {
+-      const std::string tcl_path = lib_mount_point + "/library";
+-      setenv("TCL_LIBRARY", tcl_path.c_str(), true);
+-    }
+-  }
+-};
+-
+-// Provide via global constructor.
+-static BazelInitializer bazel_initializer;
+-}  // namespace
++// Intentionally empty: tcl_library_init now handles Tcl setup.
++// This file is kept because src/sta:opensta still references
++// //bazel:runfiles in its srcs.
+diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
+index 4be9671..8306978 100644
+--- a/bazel/tcl_library_init.cc
++++ b/bazel/tcl_library_init.cc
+@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+   return Tcl_GetStringResult(interp);
+ #else
+   using rules_cc::cc::runfiles::Runfiles;
++
++  // Clear inherited RUNFILES_* env vars: when OpenROAD is invoked by
++  // a build system that previously ran another Bazel binary (e.g. a
++  // Python wrapper), those variables point to the *other* binary's
++  // runfiles tree.  Runfiles::Create() checks env vars first, so it
++  // would resolve paths in the wrong tree.  Unsetting forces it to
++  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  unsetenv("RUNFILES_DIR");
++  unsetenv("RUNFILES_MANIFEST_FILE");
++
+   std::string error;
+   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));

--- a/openroad-remove-initrunfiles.patch
+++ b/openroad-remove-initrunfiles.patch
@@ -1,0 +1,140 @@
+diff --git a/bazel/BUILD b/bazel/BUILD
+index a15adee..66f99d2 100644
+--- a/bazel/BUILD
++++ b/bazel/BUILD
+@@ -124,18 +124,12 @@ cc_library(
+     }),
+ )
+ 
+-# shim old library as it is still referenced in src/sta, implementing the
+-# old behavior.
++# Stub library kept for src/sta:opensta compatibility.
++# Tcl setup is now handled by //bazel:tcl_library_init.
+ cc_library(
+     name = "runfiles",
+     srcs = ["InitRunFiles.cpp"],
+-    data = [":tcl_resources_dir"],
+     visibility = ["//visibility:public"],
+-    deps = [
+-        "@rules_cc//cc/runfiles",
+-        "@tcl_lang//:tcl",
+-    ],
+-    alwayslink = True,
+ )
+ 
+ # small build test to check if "bazel build //src/sta:StaTclInitVar" works
+diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
+index 0651774..ece50b0 100644
+--- a/bazel/InitRunFiles.cpp
++++ b/bazel/InitRunFiles.cpp
+@@ -1,86 +1,3 @@
+-// SPDX-License-Identifier: BSD-3-Clause
+-// Copyright (c) 2026, The OpenROAD Authors
+-
+-// This file to go away as soon as we use the tcl_library_init initialization
+-// in OpenSTA.
+-
+-#include <unistd.h>  // readlink()
+-
+-#include <climits>
+-#include <cstdlib>
+-#include <filesystem>
+-#include <iostream>
+-#include <memory>
+-#include <optional>
+-#include <string>
+-#include <system_error>
+-
+-#if defined(__APPLE__)
+-#include <mach-o/dyld.h>
+-#include <sys/param.h>
+-#endif
+-
+-#include "rules_cc/cc/runfiles/runfiles.h"
+-
+-namespace {
+-// Avoid adding any dependencies like boost.filesystem
+-// Returns path to running binary if possible, otherwise nullopt.
+-static std::optional<std::string> GetProgramLocation()
+-{
+-#if defined(_WIN32)
+-  char result[MAX_PATH + 1] = {'\0'};
+-  auto path_len = GetModuleFileNameA(NULL, result, MAX_PATH);
+-#elif defined(__APPLE__)
+-  char result[MAXPATHLEN + 1] = {'\0'};
+-  uint32_t path_len = MAXPATHLEN;
+-  if (_NSGetExecutablePath(result, &path_len) != 0) {
+-    path_len = readlink(result, result, MAXPATHLEN);
+-  }
+-#else
+-  char result[PATH_MAX + 1] = {'\0'};
+-  ssize_t path_len = readlink("/proc/self/exe", result, PATH_MAX);
+-#endif
+-  if (path_len > 0) {
+-    return result;
+-  }
+-  return std::nullopt;
+-}
+-
+-std::string GetTclLibraryBaseLocation()
+-{
+-  using rules_cc::cc::runfiles::Runfiles;
+-  std::string error;
+-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+-      *GetProgramLocation(), BAZEL_CURRENT_REPOSITORY, &error));
+-  if (!runfiles) {
+-    std::cerr << "[Warning] Failed to create bazel runfiles: " << error << "\n";
+-    return "";
+-  }
+-
+-  std::error_code ec;
+-  for (const std::string loc : {"openroad", "opensta", "_main"}) {
+-    const std::string check_loc = loc + "/bazel/tcl_resources_dir";
+-    const std::string path = runfiles->Rlocation(check_loc);
+-    if (!path.empty() && std::filesystem::exists(path, ec)) {
+-      return path;
+-    }
+-  }
+-  return "";
+-}
+-
+-class BazelInitializer
+-{
+- public:
+-  BazelInitializer()
+-  {
+-    const std::string lib_mount_point = GetTclLibraryBaseLocation();
+-    if (!lib_mount_point.empty()) {
+-      const std::string tcl_path = lib_mount_point + "/library";
+-      setenv("TCL_LIBRARY", tcl_path.c_str(), true);
+-    }
+-  }
+-};
+-
+-// Provide via global constructor.
+-static BazelInitializer bazel_initializer;
+-}  // namespace
++// Intentionally empty: tcl_library_init now handles Tcl setup.
++// This file is kept because src/sta:opensta still references
++// //bazel:runfiles in its srcs.
+diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
+index 4be9671..8306978 100644
+--- a/bazel/tcl_library_init.cc
++++ b/bazel/tcl_library_init.cc
+@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+   return Tcl_GetStringResult(interp);
+ #else
+   using rules_cc::cc::runfiles::Runfiles;
++
++  // Clear inherited RUNFILES_* env vars: when OpenROAD is invoked by
++  // a build system that previously ran another Bazel binary (e.g. a
++  // Python wrapper), those variables point to the *other* binary's
++  // runfiles tree.  Runfiles::Create() checks env vars first, so it
++  // would resolve paths in the wrong tree.  Unsetting forces it to
++  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  unsetenv("RUNFILES_DIR");
++  unsetenv("RUNFILES_MANIFEST_FILE");
++
+   std::string error;
+   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));

--- a/patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
+++ b/patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
@@ -26,10 +26,10 @@ diff --git a/MODULE.bazel b/MODULE.bazel
 -    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 -)
 -
- bazel_dep(name = "rules_python", version = "1.2.0")
+ bazel_dep(name = "rules_python", version = "1.8.5")
  bazel_dep(name = "rules_shell", version = "0.6.1")
 
-@@ -33,15 +26,3 @@
+@@ -36,15 +29,3 @@
  use_repo(pip, "orfs-pip")
 
  orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")

--- a/sby/MODULE.bazel
+++ b/sby/MODULE.bazel
@@ -40,10 +40,9 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "f40d2f346e67ffe309a4f49b1897a560cf20c747",
+    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
     patch_strip = 1,
     patches = [
-        "//patches:0001-build-remove-stale-merge_lib.py-preprocessLib.py-fro.patch",
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
         "//patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
     ],
@@ -53,17 +52,20 @@ git_override(
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "df79404cd806cc435b3c3b53678ebf2441c31313",
+    commit = "d22045c978d037f7a5788c08f359aec471800c01",
     init_submodules = True,
     patch_strip = 1,
-    patches = ["//:openroad-visibility.patch"],
+    patches = [
+        "//:openroad-visibility.patch",
+        "//:openroad-remove-initrunfiles.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )
 
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/sby/openroad-remove-initrunfiles.patch
+++ b/sby/openroad-remove-initrunfiles.patch
@@ -1,0 +1,140 @@
+diff --git a/bazel/BUILD b/bazel/BUILD
+index a15adee..66f99d2 100644
+--- a/bazel/BUILD
++++ b/bazel/BUILD
+@@ -124,18 +124,12 @@ cc_library(
+     }),
+ )
+ 
+-# shim old library as it is still referenced in src/sta, implementing the
+-# old behavior.
++# Stub library kept for src/sta:opensta compatibility.
++# Tcl setup is now handled by //bazel:tcl_library_init.
+ cc_library(
+     name = "runfiles",
+     srcs = ["InitRunFiles.cpp"],
+-    data = [":tcl_resources_dir"],
+     visibility = ["//visibility:public"],
+-    deps = [
+-        "@rules_cc//cc/runfiles",
+-        "@tcl_lang//:tcl",
+-    ],
+-    alwayslink = True,
+ )
+ 
+ # small build test to check if "bazel build //src/sta:StaTclInitVar" works
+diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
+index 0651774..ece50b0 100644
+--- a/bazel/InitRunFiles.cpp
++++ b/bazel/InitRunFiles.cpp
+@@ -1,86 +1,3 @@
+-// SPDX-License-Identifier: BSD-3-Clause
+-// Copyright (c) 2026, The OpenROAD Authors
+-
+-// This file to go away as soon as we use the tcl_library_init initialization
+-// in OpenSTA.
+-
+-#include <unistd.h>  // readlink()
+-
+-#include <climits>
+-#include <cstdlib>
+-#include <filesystem>
+-#include <iostream>
+-#include <memory>
+-#include <optional>
+-#include <string>
+-#include <system_error>
+-
+-#if defined(__APPLE__)
+-#include <mach-o/dyld.h>
+-#include <sys/param.h>
+-#endif
+-
+-#include "rules_cc/cc/runfiles/runfiles.h"
+-
+-namespace {
+-// Avoid adding any dependencies like boost.filesystem
+-// Returns path to running binary if possible, otherwise nullopt.
+-static std::optional<std::string> GetProgramLocation()
+-{
+-#if defined(_WIN32)
+-  char result[MAX_PATH + 1] = {'\0'};
+-  auto path_len = GetModuleFileNameA(NULL, result, MAX_PATH);
+-#elif defined(__APPLE__)
+-  char result[MAXPATHLEN + 1] = {'\0'};
+-  uint32_t path_len = MAXPATHLEN;
+-  if (_NSGetExecutablePath(result, &path_len) != 0) {
+-    path_len = readlink(result, result, MAXPATHLEN);
+-  }
+-#else
+-  char result[PATH_MAX + 1] = {'\0'};
+-  ssize_t path_len = readlink("/proc/self/exe", result, PATH_MAX);
+-#endif
+-  if (path_len > 0) {
+-    return result;
+-  }
+-  return std::nullopt;
+-}
+-
+-std::string GetTclLibraryBaseLocation()
+-{
+-  using rules_cc::cc::runfiles::Runfiles;
+-  std::string error;
+-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+-      *GetProgramLocation(), BAZEL_CURRENT_REPOSITORY, &error));
+-  if (!runfiles) {
+-    std::cerr << "[Warning] Failed to create bazel runfiles: " << error << "\n";
+-    return "";
+-  }
+-
+-  std::error_code ec;
+-  for (const std::string loc : {"openroad", "opensta", "_main"}) {
+-    const std::string check_loc = loc + "/bazel/tcl_resources_dir";
+-    const std::string path = runfiles->Rlocation(check_loc);
+-    if (!path.empty() && std::filesystem::exists(path, ec)) {
+-      return path;
+-    }
+-  }
+-  return "";
+-}
+-
+-class BazelInitializer
+-{
+- public:
+-  BazelInitializer()
+-  {
+-    const std::string lib_mount_point = GetTclLibraryBaseLocation();
+-    if (!lib_mount_point.empty()) {
+-      const std::string tcl_path = lib_mount_point + "/library";
+-      setenv("TCL_LIBRARY", tcl_path.c_str(), true);
+-    }
+-  }
+-};
+-
+-// Provide via global constructor.
+-static BazelInitializer bazel_initializer;
+-}  // namespace
++// Intentionally empty: tcl_library_init now handles Tcl setup.
++// This file is kept because src/sta:opensta still references
++// //bazel:runfiles in its srcs.
+diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
+index 4be9671..8306978 100644
+--- a/bazel/tcl_library_init.cc
++++ b/bazel/tcl_library_init.cc
+@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+   return Tcl_GetStringResult(interp);
+ #else
+   using rules_cc::cc::runfiles::Runfiles;
++
++  // Clear inherited RUNFILES_* env vars: when OpenROAD is invoked by
++  // a build system that previously ran another Bazel binary (e.g. a
++  // Python wrapper), those variables point to the *other* binary's
++  // runfiles tree.  Runfiles::Create() checks env vars first, so it
++  // would resolve paths in the wrong tree.  Unsetting forces it to
++  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  unsetenv("RUNFILES_DIR");
++  unsetenv("RUNFILES_MANIFEST_FILE");
++
+   std::string error;
+   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
+       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));


### PR DESCRIPTION
- orfs -> b6ff3eb63dac (drop patch 0001 merged upstream)
- openroad -> d34d035725c3
- qt-bazel -> 886104974c2f
- rules_shell 0.6.1 -> 0.7.1 (fix version mismatch warning)
- Regenerate patch 0035 for new upstream MODULE.bazel