### PR TITLE
fix: generate mock klayout in extension, remove module dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,8 @@ bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True
 
 bazel_dep(name = "rules_pkg", version = "1.2.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
-bazel_dep(name = "mock-klayout", version = "0.0.1")
+
+bazel_dep(name = "mock-klayout", version = "0.0.1", dev_dependency = True)
 local_path_override(
     module_name = "mock-klayout",
     path = "mock/klayout",

--- a/config.bzl
+++ b/config.bzl
@@ -40,9 +40,8 @@ global_config = repository_rule(
     implementation = _global_config_impl,
     attrs = {
         "klayout": attr.label(
-            mandatory = False,
+            mandatory = True,
             cfg = "exec",
-            default = Label("@mock-klayout//src/bin:klayout"),
         ),
         "make": attr.label(
             mandatory = False,

--- a/extension.bzl
+++ b/extension.bzl
@@ -15,6 +15,7 @@ satisfy any residual label references in attrs.bzl.
 load("//:config.bzl", "global_config")
 load("//:gnumake.bzl", "gnumake")
 load("//:load_json_file.bzl", "load_json_file")
+load("//:mock_klayout.bzl", "mock_klayout")
 load("//:stub.bzl", "stub_docker_orfs")
 
 _default_tag = tag_class(
@@ -30,7 +31,6 @@ _default_tag = tag_class(
         "klayout": attr.label(
             mandatory = False,
             cfg = "exec",
-            default = Label("@mock-klayout//src/bin:klayout"),
         ),
         "make": attr.label(
             mandatory = False,
@@ -87,10 +87,14 @@ def _orfs_repositories_impl(module_ctx):
     # GNU Make built from source
     gnumake(name = "gnumake")
 
+    # Mock klayout that produces dummy GDS files — used as default
+    # when no real klayout is provided by the consumer.
+    mock_klayout(name = "mock_klayout")
+
     for default in module_ctx.modules[0].tags.default:
         global_config(
             name = "config",
-            klayout = default.klayout,
+            klayout = default.klayout if default.klayout else "@mock_klayout//:klayout",
             make = default.make,
             makefile = default.makefile,
             makefile_yosys = default.makefile_yosys,

--- a/mock_klayout.bzl
+++ b/mock_klayout.bzl
@@ -1,0 +1,89 @@
+"""Repository rule that generates a mock klayout binary.
+
+Creates dummy GDS files when invoked, allowing the ORFS flow to
+complete through GDS generation without a real KLayout installation.
+Used as the default klayout when no real klayout is provided.
+"""
+
+_KLAYOUT_PY = '''\
+#!/usr/bin/env python3
+"""Mock klayout — creates dummy GDS files."""
+
+import os
+import sys
+
+# Minimal GDS II file: HEADER(v7) + BGNLIB + ENDLIB
+GDS_HEADER = (
+    b"\\x00\\x06\\x00\\x02\\x00\\x07"  # HEADER record, version 7
+    b"\\x00\\x1c\\x01\\x02"  # BGNLIB record
+    b"\\x00\\x01\\x00\\x01\\x00\\x01\\x00\\x01\\x00\\x00"  # mod time
+    b"\\x00\\x01\\x00\\x01\\x00\\x01\\x00\\x01\\x00\\x00"  # access time
+    b"\\x00\\x04\\x04\\x00"  # ENDLIB record
+)
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    if argv and argv[0] == "-v":
+        print("KLayout 0.0.0 (mock)")
+        return 0
+
+    rd_args = {}
+    i = 0
+    while i < len(argv):
+        if argv[i] == "-rd" and i + 1 < len(argv):
+            i += 1
+            if "=" in argv[i]:
+                key, value = argv[i].split("=", 1)
+                rd_args[key] = value
+        i += 1
+
+    for key in ("out", "out_file"):
+        if key in rd_args:
+            os.makedirs(os.path.dirname(rd_args[key]) or ".", exist_ok=True)
+            with open(rd_args[key], "wb") as f:
+                f.write(GDS_HEADER)
+
+    print("mock klayout (CI stub)")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+_KLAYOUT_SH = '''\
+#!/bin/sh
+dir="$(cd "$(dirname "$0")" && pwd)"
+for py in \\
+    "$dir/klayout.py" \\
+    "$dir/klayout.runfiles/_main/klayout.py" \\
+; do
+    [ -f "$py" ] && exec python3 "$py" "$@"
+done
+echo "error: cannot find klayout.py" >&2
+exit 1
+'''
+
+_BUILD = '''\
+sh_binary(
+    name = "klayout",
+    srcs = ["klayout.sh"],
+    data = ["klayout.py"],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    ["klayout.py"],
+    visibility = ["//visibility:public"],
+)
+'''
+
+def _mock_klayout_impl(repository_ctx):
+    repository_ctx.file("BUILD.bazel", _BUILD)
+    repository_ctx.file("klayout.py", _KLAYOUT_PY, executable = True)
+    repository_ctx.file("klayout.sh", _KLAYOUT_SH, executable = True)
+
+mock_klayout = repository_rule(
+    implementation = _mock_klayout_impl,
+    doc = "Creates a mock klayout repo that produces dummy GDS files.",
+)


### PR DESCRIPTION
mock-klayout used local_path_override which is root-only, causing downstream consumers to fail resolving it. Instead of requiring a separate module, generate the mock klayout (dummy GDS producer) directly in the extension via a repository rule. The extension defaults to mock_klayout when no real klayout is provided.