### PR TITLE
fix: make sby tool labels configurable, fix parallel synth SDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           key: bazel-repo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             bazel-repo-${{ runner.os }}-
+          save-always: true
 
       - name: Disk cache
         uses: actions/cache@v4
@@ -56,6 +57,7 @@ jobs:
           key: bazel-disk-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             bazel-disk-${{ runner.os }}-
+          save-always: true
 
       - name: Configure caches
         run: |

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -738,12 +738,12 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                     deps_inputs(ctx),
                 ],
             ),
-            outputs = [synth_outputs["1_synth.odb"]],
+            outputs = [synth_outputs["1_synth.odb"], synth_outputs["1_synth.sdc"]],
             tools = yosys_and_flow_tools,
         )
 
     # Stub outputs that the serial path produces but parallel does not
-    for name in ["1_synth.sdc", "mem.json"]:
+    for name in ["mem.json"]:
         ctx.actions.write(output = synth_outputs[name], content = "")
     for f in synth_logs + synth_reports:
         ctx.actions.write(output = f, content = "")

--- a/sby/sby.bzl
+++ b/sby/sby.bzl
@@ -102,12 +102,12 @@ exit $rc
                         ctx.files.includes,
                 transitive_files = depset(
                     transitive = [
-                        ctx.attr._sby[DefaultInfo].default_runfiles.files,
-                        ctx.attr._sby[DefaultInfo].default_runfiles.symlinks,
-                        ctx.attr._yosys[DefaultInfo].default_runfiles.files,
-                        ctx.attr._yosys[DefaultInfo].default_runfiles.symlinks,
-                        ctx.attr._yosys_abc[DefaultInfo].default_runfiles.files,
-                        ctx.attr._yosys_abc[DefaultInfo].default_runfiles.symlinks,
+                        ctx.attr.sby[DefaultInfo].default_runfiles.files,
+                        ctx.attr.sby[DefaultInfo].default_runfiles.symlinks,
+                        ctx.attr.yosys[DefaultInfo].default_runfiles.files,
+                        ctx.attr.yosys[DefaultInfo].default_runfiles.symlinks,
+                        ctx.attr.yosys_abc[DefaultInfo].default_runfiles.files,
+                        ctx.attr.yosys_abc[DefaultInfo].default_runfiles.symlinks,
                     ],
                 ),
             ),

--- a/sby/sby.bzl
+++ b/sby/sby.bzl
@@ -81,7 +81,7 @@ if [ -n "$TEST_UNDECLARED_OUTPUTS_DIR" ]; then
 fi
 exit $rc
 """.format(
-            sby = ctx.executable._sby.short_path,
+            sby = ctx.executable.sby.short_path,
             sby_file = sby.short_path,
         ),
         is_executable = True,
@@ -94,9 +94,9 @@ exit $rc
             runfiles = ctx.runfiles(
                 files = [
                             sby,
-                            ctx.executable._sby,
-                            ctx.executable._yosys,
-                            ctx.executable._yosys_abc,
+                            ctx.executable.sby,
+                            ctx.executable.yosys,
+                            ctx.executable.yosys_abc,
                         ] +
                         ctx.files.verilog_files +
                         ctx.files.includes,
@@ -133,30 +133,30 @@ _sby_test = rule(
             allow_files = True,
             providers = [DefaultInfo],
         ),
-        "_sby": attr.label(
+        "sby": attr.label(
             doc = "sby binary.",
             executable = True,
             allow_files = True,
             cfg = "exec",
-            default = Label("@oss_cad_suite//:sby"),
+            mandatory = True,
         ),
         "_sby_template": attr.label(
             default = "sby.tpl",
             allow_single_file = True,
         ),
-        "_yosys": attr.label(
+        "yosys": attr.label(
             doc = "Yosys binary.",
             executable = True,
             allow_files = True,
             cfg = "exec",
-            default = Label("@oss_cad_suite//:yosys"),
+            mandatory = True,
         ),
-        "_yosys_abc": attr.label(
+        "yosys_abc": attr.label(
             doc = "yosys-abc binary (needed for abc pdr engine).",
             executable = True,
             allow_files = True,
             cfg = "exec",
-            default = Label("@oss_cad_suite//:yosys-abc"),
+            mandatory = True,
         ),
     },
     test = True,
@@ -172,6 +172,9 @@ def sby_test(
         firtool_options = None,
         verilog_files = [],
         includes = [],
+        sby = "@oss_cad_suite//:sby",
+        yosys = "@oss_cad_suite//:yosys",
+        yosys_abc = "@oss_cad_suite//:yosys-abc",
         **kwargs):
     """Run SymbiYosys formal verification on a Chisel-generated design.
 
@@ -242,5 +245,8 @@ def sby_test(
         module_top = module_top,
         verilog_files = verilog_files + [":{name}.sv".format(name = name)],
         includes = includes,
+        sby = sby,
+        yosys = yosys,
+        yosys_abc = yosys_abc,
         **kwargs
     )


### PR DESCRIPTION
Two fixes:

1. sby/sby.bzl: Make sby, yosys, yosys_abc attrs public and mandatory on the rule, with string defaults in the sby_test macro. This moves Label resolution from bazel-orfs's repo mapping (where @oss_cad_suite is not visible) to the caller's BUILD file context.

2. private/rules.bzl: Fix parallel synthesis stubbing 1_synth.sdc with an empty file. Move it to the ODB generation action outputs so synth_odb.tcl produces the real canonicalized SDC.