### PR TITLE
chore: bump openroad, orfs, yosys to latest

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,7 +37,7 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
+    commit = "2453de8ea1fcdcb5c4ce97d0568a41acb97db4f4",
     patch_strip = 1,
     # Minimal patches: only what's needed for extension.bzl flow targets
     # (PDK definitions, variables.yaml export). Design-specific patches
@@ -52,7 +52,7 @@ git_override(
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "d22045c978d037f7a5788c08f359aec471800c01",
+    commit = "33c72bf7b8ce8a2dd81e2f6fbf0199a547b4f6a8",
     init_submodules = True,
     patch_strip = 1,
     patches = [

--- a/chisel/MODULE.bazel
+++ b/chisel/MODULE.bazel
@@ -36,7 +36,7 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
+    commit = "2453de8ea1fcdcb5c4ce97d0568a41acb97db4f4",
     patch_strip = 1,
     patches = [
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
@@ -56,7 +56,7 @@ use_repo(orfs, "gnumake")
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "d22045c978d037f7a5788c08f359aec471800c01",
+    commit = "33c72bf7b8ce8a2dd81e2f6fbf0199a547b4f6a8",
     init_submodules = True,
     patch_strip = 1,
     patches = [

--- a/chisel/openroad-remove-initrunfiles.patch
+++ b/chisel/openroad-remove-initrunfiles.patch
@@ -5,7 +5,7 @@ index a15adee..66f99d2 100644
 @@ -124,18 +124,12 @@ cc_library(
      }),
  )
- 
+
 -# shim old library as it is still referenced in src/sta, implementing the
 -# old behavior.
 +# Stub library kept for src/sta:opensta compatibility.
@@ -21,7 +21,7 @@ index a15adee..66f99d2 100644
 -    ],
 -    alwayslink = True,
  )
- 
+
  # small build test to check if "bazel build //src/sta:StaTclInitVar" works
 diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
 index 0651774..ece50b0 100644
@@ -118,10 +118,9 @@ index 0651774..ece50b0 100644
 +// This file is kept because src/sta:opensta still references
 +// //bazel:runfiles in its srcs.
 diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
-index 4be9671..8306978 100644
 --- a/bazel/tcl_library_init.cc
 +++ b/bazel/tcl_library_init.cc
-@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+@@ -40,6 +40,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
    return Tcl_GetStringResult(interp);
  #else
    using rules_cc::cc::runfiles::Runfiles;
@@ -131,10 +130,10 @@ index 4be9671..8306978 100644
 +  // Python wrapper), those variables point to the *other* binary's
 +  // runfiles tree.  Runfiles::Create() checks env vars first, so it
 +  // would resolve paths in the wrong tree.  Unsetting forces it to
-+  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  // fall back to the exe_path derived from /proc/self/exe.
 +  unsetenv("RUNFILES_DIR");
 +  unsetenv("RUNFILES_MANIFEST_FILE");
 +
    std::string error;
-   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
-       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));
+   // Use /proc/self/exe to resolve the real binary path, as argv[0] may
+   // point into a sandbox where the .runfiles tree does not exist.

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -34,7 +34,7 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
+    commit = "2453de8ea1fcdcb5c4ce97d0568a41acb97db4f4",
     patch_strip = 1,
     patches = [
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
@@ -55,7 +55,7 @@ use_repo(orfs, "gnumake")
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "d22045c978d037f7a5788c08f359aec471800c01",
+    commit = "33c72bf7b8ce8a2dd81e2f6fbf0199a547b4f6a8",
     init_submodules = True,
     patch_strip = 1,
     patches = [

--- a/gallery/openroad-remove-initrunfiles.patch
+++ b/gallery/openroad-remove-initrunfiles.patch
@@ -5,7 +5,7 @@ index a15adee..66f99d2 100644
 @@ -124,18 +124,12 @@ cc_library(
      }),
  )
- 
+
 -# shim old library as it is still referenced in src/sta, implementing the
 -# old behavior.
 +# Stub library kept for src/sta:opensta compatibility.
@@ -21,7 +21,7 @@ index a15adee..66f99d2 100644
 -    ],
 -    alwayslink = True,
  )
- 
+
  # small build test to check if "bazel build //src/sta:StaTclInitVar" works
 diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
 index 0651774..ece50b0 100644
@@ -118,10 +118,9 @@ index 0651774..ece50b0 100644
 +// This file is kept because src/sta:opensta still references
 +// //bazel:runfiles in its srcs.
 diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
-index 4be9671..8306978 100644
 --- a/bazel/tcl_library_init.cc
 +++ b/bazel/tcl_library_init.cc
-@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+@@ -40,6 +40,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
    return Tcl_GetStringResult(interp);
  #else
    using rules_cc::cc::runfiles::Runfiles;
@@ -131,10 +130,10 @@ index 4be9671..8306978 100644
 +  // Python wrapper), those variables point to the *other* binary's
 +  // runfiles tree.  Runfiles::Create() checks env vars first, so it
 +  // would resolve paths in the wrong tree.  Unsetting forces it to
-+  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  // fall back to the exe_path derived from /proc/self/exe.
 +  unsetenv("RUNFILES_DIR");
 +  unsetenv("RUNFILES_MANIFEST_FILE");
 +
    std::string error;
-   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
-       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));
+   // Use /proc/self/exe to resolve the real binary path, as argv[0] may
+   // point into a sandbox where the .runfiles tree does not exist.

--- a/openroad-remove-initrunfiles.patch
+++ b/openroad-remove-initrunfiles.patch
@@ -5,7 +5,7 @@ index a15adee..66f99d2 100644
 @@ -124,18 +124,12 @@ cc_library(
      }),
  )
- 
+
 -# shim old library as it is still referenced in src/sta, implementing the
 -# old behavior.
 +# Stub library kept for src/sta:opensta compatibility.
@@ -21,7 +21,7 @@ index a15adee..66f99d2 100644
 -    ],
 -    alwayslink = True,
  )
- 
+
  # small build test to check if "bazel build //src/sta:StaTclInitVar" works
 diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
 index 0651774..ece50b0 100644
@@ -117,24 +117,3 @@ index 0651774..ece50b0 100644
 +// Intentionally empty: tcl_library_init now handles Tcl setup.
 +// This file is kept because src/sta:opensta still references
 +// //bazel:runfiles in its srcs.
-diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
-index 4be9671..8306978 100644
---- a/bazel/tcl_library_init.cc
-+++ b/bazel/tcl_library_init.cc
-@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
-   return Tcl_GetStringResult(interp);
- #else
-   using rules_cc::cc::runfiles::Runfiles;
-+
-+  // Clear inherited RUNFILES_* env vars: when OpenROAD is invoked by
-+  // a build system that previously ran another Bazel binary (e.g. a
-+  // Python wrapper), those variables point to the *other* binary's
-+  // runfiles tree.  Runfiles::Create() checks env vars first, so it
-+  // would resolve paths in the wrong tree.  Unsetting forces it to
-+  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
-+  unsetenv("RUNFILES_DIR");
-+  unsetenv("RUNFILES_MANIFEST_FILE");
-+
-   std::string error;
-   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
-       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));

--- a/openroad-remove-initrunfiles.patch
+++ b/openroad-remove-initrunfiles.patch
@@ -117,3 +117,23 @@ index 0651774..ece50b0 100644
 +// Intentionally empty: tcl_library_init now handles Tcl setup.
 +// This file is kept because src/sta:opensta still references
 +// //bazel:runfiles in its srcs.
+diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
+--- a/bazel/tcl_library_init.cc
++++ b/bazel/tcl_library_init.cc
+@@ -40,6 +40,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+   return Tcl_GetStringResult(interp);
+ #else
+   using rules_cc::cc::runfiles::Runfiles;
++
++  // Clear inherited RUNFILES_* env vars: when OpenROAD is invoked by
++  // a build system that previously ran another Bazel binary (e.g. a
++  // Python wrapper), those variables point to the *other* binary's
++  // runfiles tree.  Runfiles::Create() checks env vars first, so it
++  // would resolve paths in the wrong tree.  Unsetting forces it to
++  // fall back to the exe_path derived from /proc/self/exe.
++  unsetenv("RUNFILES_DIR");
++  unsetenv("RUNFILES_MANIFEST_FILE");
++
+   std::string error;
+   // Use /proc/self/exe to resolve the real binary path, as argv[0] may
+   // point into a sandbox where the .runfiles tree does not exist.

--- a/sby/MODULE.bazel
+++ b/sby/MODULE.bazel
@@ -40,7 +40,7 @@ single_version_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "74271e42b301df0b3b84fb14d42282f9e8491cee",
+    commit = "2453de8ea1fcdcb5c4ce97d0568a41acb97db4f4",
     patch_strip = 1,
     patches = [
         "//patches:0002-build-add-all-PDKs-and-export-variables.yaml.patch",
@@ -52,7 +52,7 @@ git_override(
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "d22045c978d037f7a5788c08f359aec471800c01",
+    commit = "33c72bf7b8ce8a2dd81e2f6fbf0199a547b4f6a8",
     init_submodules = True,
     patch_strip = 1,
     patches = [

--- a/sby/openroad-remove-initrunfiles.patch
+++ b/sby/openroad-remove-initrunfiles.patch
@@ -5,7 +5,7 @@ index a15adee..66f99d2 100644
 @@ -124,18 +124,12 @@ cc_library(
      }),
  )
- 
+
 -# shim old library as it is still referenced in src/sta, implementing the
 -# old behavior.
 +# Stub library kept for src/sta:opensta compatibility.
@@ -21,7 +21,7 @@ index a15adee..66f99d2 100644
 -    ],
 -    alwayslink = True,
  )
- 
+
  # small build test to check if "bazel build //src/sta:StaTclInitVar" works
 diff --git a/bazel/InitRunFiles.cpp b/bazel/InitRunFiles.cpp
 index 0651774..ece50b0 100644
@@ -118,10 +118,9 @@ index 0651774..ece50b0 100644
 +// This file is kept because src/sta:opensta still references
 +// //bazel:runfiles in its srcs.
 diff --git a/bazel/tcl_library_init.cc b/bazel/tcl_library_init.cc
-index 4be9671..8306978 100644
 --- a/bazel/tcl_library_init.cc
 +++ b/bazel/tcl_library_init.cc
-@@ -35,6 +35,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
+@@ -40,6 +40,16 @@ static std::optional<std::string> TclLibraryMountPoint(Tcl_Interp* interp)
    return Tcl_GetStringResult(interp);
  #else
    using rules_cc::cc::runfiles::Runfiles;
@@ -131,10 +130,10 @@ index 4be9671..8306978 100644
 +  // Python wrapper), those variables point to the *other* binary's
 +  // runfiles tree.  Runfiles::Create() checks env vars first, so it
 +  // would resolve paths in the wrong tree.  Unsetting forces it to
-+  // fall back to Tcl_GetNameOfExecutable(), which is always correct.
++  // fall back to the exe_path derived from /proc/self/exe.
 +  unsetenv("RUNFILES_DIR");
 +  unsetenv("RUNFILES_MANIFEST_FILE");
 +
    std::string error;
-   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
-       Tcl_GetNameOfExecutable(), BAZEL_CURRENT_REPOSITORY, &error));
+   // Use /proc/self/exe to resolve the real binary path, as argv[0] may
+   // point into a sandbox where the .runfiles tree does not exist.


### PR DESCRIPTION
openroad -> 33c72bf7b8ce
orfs -> 2453de8ea1fc
yosys -> v0.64

Drop tcl_library_init.cc hunk from initrunfiles patch: upstream now uses /proc/self/exe to resolve runfiles, making the unsetenv workaround unnecessary.