### PR TITLE
fix: install libxcb-cursor0 for GUI-enabled OpenROAD in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
           large-packages: false
           swap-storage: false
 
+      - name: Install runtime dependencies
+        run: sudo apt-get update && sudo apt-get install -y libxcb-cursor0
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The previous commit enabled --@openroad//:platform=gui unconditionally, which links OpenROAD against libxcb-cursor. The CI runner (ubuntu-22.04) does not have this library installed, causing all real-OpenROAD synth actions to fail with "error while loading shared libraries: libxcb-cursor.so.0: cannot open shared object file".