### PR TITLE
feat: extract yosys + plugins from ORFS image (yosys-latest)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,11 +5,16 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
-# OpenROAD and OpenSTA binaries from the latest ORFS Docker image.
-# Downstream projects use these labels to skip building OpenROAD from source:
+# OpenROAD, OpenSTA, and yosys binaries from the latest ORFS Docker image.
+# Downstream projects use these labels to skip building these tools from source:
 #   orfs.default(
 #       openroad = "@bazel-orfs//:openroad-latest",
 #       opensta = "@bazel-orfs//:opensta-latest",
+#       # Optional: when the design needs yosys plugins (e.g. slang) that
+#       # the BCR @yosys package doesn't ship.
+#       yosys = "@bazel-orfs//:yosys-latest",
+#       yosys_abc = "@bazel-orfs//:yosys-abc-latest",
+#       yosys_share = "@bazel-orfs//:yosys-share-latest",
 #   )
 # The Docker image is only downloaded when these targets are actually built.
 alias(
@@ -21,6 +26,24 @@ alias(
 alias(
     name = "opensta-latest",
     actual = "@docker_orfs_image//:sta",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "yosys-latest",
+    actual = "@docker_orfs_yosys_image//:yosys",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "yosys-abc-latest",
+    actual = "@docker_orfs_yosys_image//:yosys-abc",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "yosys-share-latest",
+    actual = "@docker_orfs_yosys_image//:yosys_share",
     visibility = ["//visibility:public"],
 )
 

--- a/docker_yosys.BUILD.bazel
+++ b/docker_yosys.BUILD.bazel
@@ -1,0 +1,57 @@
+"""BUILD file for extracting yosys + plugins from an ORFS Docker image.
+
+Complements docker_openroad.BUILD.bazel: that file extracts only the
+OpenROAD binary and its runtime dependencies, while this one extracts
+yosys, yosys-abc, and the yosys share tree (including plugins/slang.so
+for native SystemVerilog parsing).
+
+This repo is materialized lazily — downloaded only when a target under
+@docker_orfs_yosys_image is built, or via the @bazel-orfs//:yosys-latest
+alias. Downstream projects that don't need image-sourced yosys pay
+nothing.
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "ld.so",
+    srcs = ["_lib/ld-linux-x86-64.so.2"],
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(
+        [
+            "lib/x86_64-linux-gnu/**/*.so*",
+            "usr/lib/x86_64-linux-gnu/*.so*",
+            "OpenROAD-flow-scripts/tools/install/yosys/lib/*.so*",
+        ],
+        allow_empty = True,
+    ),
+)
+
+# All files under share/yosys: techlib cells, plugin .so files
+# (including slang.so), scripts, and cell mappings.
+filegroup(
+    name = "yosys_share",
+    srcs = glob(["OpenROAD-flow-scripts/tools/install/yosys/share/yosys/**"]),
+)
+
+filegroup(
+    name = "yosys",
+    srcs = ["OpenROAD-flow-scripts/tools/install/yosys/bin/yosys"],
+    data = [
+        ":ld.so",
+        ":lib",
+        ":yosys_share",
+    ],
+)
+
+filegroup(
+    name = "yosys-abc",
+    srcs = ["OpenROAD-flow-scripts/tools/install/yosys/bin/yosys-abc"],
+    data = [
+        ":ld.so",
+        ":lib",
+    ],
+)

--- a/extension.bzl
+++ b/extension.bzl
@@ -15,6 +15,13 @@ A docker_orfs_image repo is also created, providing the OpenROAD binary
 from the latest ORFS Docker image.  It is lazily fetched — the multi-GB
 download only happens when a target from @docker_orfs_image is built
 (e.g. via @bazel-orfs//:openroad-latest).
+
+A parallel docker_orfs_yosys_image repo extracts yosys + plugins from
+the same image for designs that need the slang frontend or other
+plugins not shipped by the BCR @yosys module.  Lazily fetched, and
+shares layer downloads with docker_orfs_image via the content-
+addressed repository cache.  Access via @bazel-orfs//:yosys-latest,
+@bazel-orfs//:yosys-abc-latest, and @bazel-orfs//:yosys-share-latest.
 """
 
 load("//:config.bzl", "global_config")
@@ -109,6 +116,28 @@ def _orfs_repositories_impl(module_ctx):
         patch_cmds = [
             "find OpenROAD-flow-scripts -name BUILD -delete -o -name BUILD.bazel -delete",
             "ln -sf ../../../x86_64-linux-gnu/libtclreadline-2.3.8.so usr/lib/tcltk/x86_64-linux-gnu/tclreadline2.3.8/libtclreadline.so || true",
+        ],
+    )
+
+    # Separate lazy extraction of yosys from the same ORFS image.
+    # Kept as its own repo so users who don't need yosys+plugins don't
+    # pay the share-tree extraction cost. Bazel's content-addressed
+    # repository cache dedupes the layer downloads with docker_orfs_image,
+    # so using both pulls the image only once.
+    #
+    # Motivation: the yosys shipped in the ORFS image has extra plugins
+    # (notably yosys-slang for native SystemVerilog parsing) that are
+    # not available from the BCR @yosys module. Designs that set
+    # SYNTH_HDL_FRONTEND=slang can route orfs.default(yosys=...,
+    # yosys_abc=..., yosys_share=...) at @bazel-orfs//:yosys-latest
+    # et al. to pick up the image build.
+    docker_pkg(
+        name = "docker_orfs_yosys_image",
+        build_file = Label("//:docker_yosys.BUILD.bazel"),
+        image = LATEST_ORFS_IMAGE,
+        sha256 = LATEST_ORFS_SHA256,
+        patch_cmds = [
+            "find OpenROAD-flow-scripts -name BUILD -delete -o -name BUILD.bazel -delete",
         ],
     )
 

--- a/test/docker/MODULE.bazel
+++ b/test/docker/MODULE.bazel
@@ -72,7 +72,7 @@ python.toolchain(
     python_version = "3.13",
 )
 
-# --- ORFS extension: use Docker image OpenROAD ---
+# --- ORFS extension: use Docker image OpenROAD + yosys ---
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
 orfs.default(
     # Use OpenROAD and OpenSTA from the latest ORFS Docker image instead
@@ -80,6 +80,13 @@ orfs.default(
     # @openroad//:openroad and @openroad//src/sta:opensta.
     openroad = "@bazel-orfs//:openroad-latest",
     opensta = "@bazel-orfs//:opensta-latest",
+    # Also take yosys from the image so the slang frontend and other
+    # plugins shipped in the ORFS yosys build are available. BCR
+    # @yosys doesn't ship the plugins directory.
+    yosys = "@bazel-orfs//:yosys-latest",
+    yosys_abc = "@bazel-orfs//:yosys-abc-latest",
+    yosys_share = "@bazel-orfs//:yosys-share-latest",
 )
 use_repo(orfs, "docker_orfs")
 use_repo(orfs, "docker_orfs_image")
+use_repo(orfs, "docker_orfs_yosys_image")


### PR DESCRIPTION
## Summary

Add a parallel lazy extraction of yosys from the ORFS Docker image, so downstream projects that need yosys plugins (notably `yosys-slang` for native SystemVerilog parsing via `SYNTH_HDL_FRONTEND=slang`) can get them without rebuilding yosys from source. The BCR ``@yosys`` package doesn't ship the plugins directory, so today there is no way to use ``@bazel-orfs//:openroad-latest`` alongside a plugin-enabled yosys without extracting it yourself.

## What's added

- **``docker_orfs_yosys_image``** — new repo in ``extension.bzl``, uses the existing ``docker_pkg`` rule with the same image/sha256 as ``docker_orfs_image``. Bazel's content-addressed repository cache dedupes layer downloads, so enabling both repos adds no net bandwidth.
- **``docker_yosys.BUILD.bazel``** — exposes three targets extracted from ``OpenROAD-flow-scripts/tools/install/yosys``: ``yosys``, ``yosys-abc``, and ``yosys_share`` (including ``plugins/slang.so``).
- **Three aliases in ``//:BUILD``** — ``yosys-latest``, ``yosys-abc-latest``, ``yosys-share-latest`` — mirroring the existing ``openroad-latest``/``opensta-latest`` public surface.
- **``test/docker/MODULE.bazel``** — demonstrates routing ``orfs.default(yosys=..., yosys_abc=..., yosys_share=...)`` at the new aliases.

## Design choice: separate repo, not extended ``docker_openroad.BUILD.bazel``

Kept the yosys extraction in its own repo (``docker_orfs_yosys_image``) rather than adding targets to ``docker_openroad.BUILD.bazel`` so that users who don't need image-sourced yosys pay nothing — the yosys share tree is extracted only when one of the new aliases is actually referenced.

## Test plan

- [x] ``test/docker`` workspace MODULE updated to use the new aliases
- [ ] CI green on the docker-test workspace