### PR TITLE
build: stub libxml2.so.2 in the LLVM toolchain to drop host libxml2-dev

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,6 +81,28 @@ bazel_dep(name = "glpk", version = "5.0.bcr.4")
 
 bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 
+# Stub libxml2.so.2 — boarding up a broken window.
+# ld.lld from the LLVM release links libxml2 dynamically but only calls into
+# it for Windows manifest merging (lld/COFF). On Linux we get a useless
+# "no version information available" warning on every link and a hidden
+# host libxml2-dev requirement. We inject an abort-on-call stub into the
+# toolchain's lib/, which ld.lld's RUNPATH=$ORIGIN/../lib resolves before
+# the system library. See tools/xml-hack/README.md for deletion conditions.
+# toolchains_llvm has no patch_cmds hook, so we bring our own LLVM tarball
+# via an http_archive and point llvm.toolchain_root at it.
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "llvm_toolchain_llvm",
+    build_file = "//tools/xml-hack:BUILD.llvm_repo",
+    patch_cmds = [
+        """printf '%s\\n' 'extern void abort(void);' 'void *xmlFree=0;' 'void *xmlAddChild(void*p,void*c){abort();}' 'void *xmlCopyNamespace(void*n){abort();}' 'void xmlDocDumpFormatMemoryEnc(void*d,void*b,void*s,const char*e,int f){abort();}' 'void *xmlDocGetRootElement(void*d){abort();}' 'void *xmlDocSetRootElement(void*d,void*r){abort();}' 'void xmlFreeDoc(void*d){abort();}' 'void xmlFreeNode(void*n){abort();}' 'void xmlFreeNs(void*n){abort();}' 'void *xmlNewDoc(const void*v){abort();}' 'void *xmlNewNs(void*n,const void*h,const void*p){abort();}' 'void *xmlNewProp(void*n,const void*a,const void*v){abort();}' 'void *xmlReadMemory(const char*b,int sz,const char*u,const char*e,int o){abort();}' 'void xmlSetGenericErrorFunc(void*c,void*h){abort();}' 'void *xmlStrdup(const void*s){abort();}' 'void xmlUnlinkNode(void*n){abort();}' > _stub.c && printf '%s\\n' 'LIBXML2_2.4.30 { global: xmlAddChild; xmlCopyNamespace; xmlDocDumpFormatMemoryEnc; xmlDocGetRootElement; xmlDocSetRootElement; xmlFree; xmlFreeDoc; xmlFreeNode; xmlFreeNs; xmlNewDoc; xmlNewNs; xmlNewProp; xmlSetGenericErrorFunc; xmlStrdup; xmlUnlinkNode; local: *; };' 'LIBXML2_2.6.0 { global: xmlReadMemory; } LIBXML2_2.4.30;' > _stub.ver && ./bin/clang -nostdlib -nostdinc -fuse-ld=lld -shared -o lib/libxml2.so.2 -Wl,--version-script=_stub.ver -Wl,-soname,libxml2.so.2 _stub.c && rm _stub.c _stub.ver""",
+    ],
+    sha256 = "1ead36b3dfcb774b57be530df42bec70ab2d239fbce9889447c7a29a4ddc1ae6",
+    strip_prefix = "LLVM-20.1.8-Linux-X64",
+    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/LLVM-20.1.8-Linux-X64.tar.xz",
+)
+
 llvm = use_extension(
     "@toolchains_llvm//toolchain/extensions:llvm.bzl",
     "llvm",
@@ -88,6 +110,10 @@ llvm = use_extension(
 )
 llvm.toolchain(
     llvm_version = "20.1.8",
+)
+llvm.toolchain_root(
+    name = "llvm_toolchain",
+    label = "@llvm_toolchain_llvm//:BUILD.bazel",
 )
 use_repo(llvm, "llvm_toolchain")
 

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -61,12 +61,32 @@ git_override(
 bazel_dep(name = "glpk", version = "5.0.bcr.4")
 bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 
+# Stub libxml2.so.2 — see @bazel-orfs//tools/xml-hack/README.md for the full
+# story and deletion conditions. Mirrors the block in //MODULE.bazel because
+# llvm.toolchain_root is a root-module tag and gallery is its own root.
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "llvm_toolchain_llvm",
+    build_file = "@bazel-orfs//tools/xml-hack:BUILD.llvm_repo",
+    patch_cmds = [
+        """printf '%s\\n' 'extern void abort(void);' 'void *xmlFree=0;' 'void *xmlAddChild(void*p,void*c){abort();}' 'void *xmlCopyNamespace(void*n){abort();}' 'void xmlDocDumpFormatMemoryEnc(void*d,void*b,void*s,const char*e,int f){abort();}' 'void *xmlDocGetRootElement(void*d){abort();}' 'void *xmlDocSetRootElement(void*d,void*r){abort();}' 'void xmlFreeDoc(void*d){abort();}' 'void xmlFreeNode(void*n){abort();}' 'void xmlFreeNs(void*n){abort();}' 'void *xmlNewDoc(const void*v){abort();}' 'void *xmlNewNs(void*n,const void*h,const void*p){abort();}' 'void *xmlNewProp(void*n,const void*a,const void*v){abort();}' 'void *xmlReadMemory(const char*b,int sz,const char*u,const char*e,int o){abort();}' 'void xmlSetGenericErrorFunc(void*c,void*h){abort();}' 'void *xmlStrdup(const void*s){abort();}' 'void xmlUnlinkNode(void*n){abort();}' > _stub.c && printf '%s\\n' 'LIBXML2_2.4.30 { global: xmlAddChild; xmlCopyNamespace; xmlDocDumpFormatMemoryEnc; xmlDocGetRootElement; xmlDocSetRootElement; xmlFree; xmlFreeDoc; xmlFreeNode; xmlFreeNs; xmlNewDoc; xmlNewNs; xmlNewProp; xmlSetGenericErrorFunc; xmlStrdup; xmlUnlinkNode; local: *; };' 'LIBXML2_2.6.0 { global: xmlReadMemory; } LIBXML2_2.4.30;' > _stub.ver && ./bin/clang -nostdlib -nostdinc -fuse-ld=lld -shared -o lib/libxml2.so.2 -Wl,--version-script=_stub.ver -Wl,-soname,libxml2.so.2 _stub.c && rm _stub.c _stub.ver""",
+    ],
+    sha256 = "1ead36b3dfcb774b57be530df42bec70ab2d239fbce9889447c7a29a4ddc1ae6",
+    strip_prefix = "LLVM-20.1.8-Linux-X64",
+    url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/LLVM-20.1.8-Linux-X64.tar.xz",
+)
+
 llvm = use_extension(
     "@toolchains_llvm//toolchain/extensions:llvm.bzl",
     "llvm",
 )
 llvm.toolchain(
     llvm_version = "20.1.8",
+)
+llvm.toolchain_root(
+    name = "llvm_toolchain",
+    label = "@llvm_toolchain_llvm//:BUILD.bazel",
 )
 use_repo(llvm, "llvm_toolchain")
 

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -180,11 +180,6 @@ use_repo(pip, "pip")
 
 # --- External RTL projects (fetched by Bazel, no source copying) ---
 
-http_archive = use_repo_rule(
-    "@bazel_tools//tools/build_defs/repo:http.bzl",
-    "http_archive",
-)
-
 http_archive(
     name = "picorv32",
     build_file = "//picorv32:external.BUILD.bazel",

--- a/tools/xml-hack/BUILD.bazel
+++ b/tools/xml-hack/BUILD.bazel
@@ -1,0 +1,5 @@
+exports_files([
+    "BUILD.llvm_repo",
+    "libxml2_stub.c",
+    "libxml2_stub.ver",
+])

--- a/tools/xml-hack/BUILD.llvm_repo
+++ b/tools/xml-hack/BUILD.llvm_repo
@@ -1,0 +1,182 @@
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+# Some targets may need to directly depend on these files.
+exports_files(glob(
+    [
+        "bin/*",
+        "lib/**",
+        "include/**",
+        "share/clang/*",
+    ],
+    allow_empty = True,
+))
+
+## LLVM toolchain files
+
+filegroup(
+    name = "clang",
+    srcs = [
+        "bin/clang",
+        "bin/clang++",
+        "bin/clang-cpp",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    # Not all distributions contain wasm-ld.
+    srcs = [
+        "bin/ld.lld",
+        "bin/ld64.lld",
+    ] + glob(["bin/wasm-ld"], allow_empty = True),
+)
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "include/**/c++/**",
+        "lib/clang/*/include/**",
+    ]),
+)
+
+filegroup(
+    name = "all_includes",
+    srcs = glob(
+        ["include/**"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "bin",
+    srcs = glob(["bin/**"]),
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(
+        [
+            "lib/**/lib*.a",
+            "lib/clang/*/lib/**/*.a",
+            "lib/clang/*/lib/**/*.dylib",
+            # clang_rt.*.o supply crtbegin and crtend sections.
+            "lib/**/clang_rt.*.o",
+            # libxml2.so.2 is a compiled abort-on-call stub injected by
+            # patch_cmds on the http_archive that produced this repo.  It
+            # must land in the link-action sandbox so ld.lld's runtime
+            # RUNPATH=$ORIGIN/../lib resolves to the stub instead of the
+            # host's /lib/x86_64-linux-gnu/libxml2.so.2. Only Windows
+            # manifest merging would actually call into it, which we never
+            # do on Linux. See //tools/xml-hack/README.md for the full
+            # story and the upstream changes that would let us delete this.
+            "lib/libxml2.so.2",
+        ],
+        allow_empty = True,
+        exclude = [
+            "lib/libLLVM*.a",
+            "lib/libclang*.a",
+            "lib/liblld*.a",
+        ],
+    ),
+    # Include the .dylib files in the linker sandbox even though they will
+    # not be available at runtime to allow sanitizers to work locally.
+    # Any library linked from the toolchain to be released should be linked statically.
+)
+
+filegroup(
+    name = "ar",
+    srcs = ["bin/llvm-ar"],
+)
+
+filegroup(
+    name = "as",
+    srcs = [
+        "bin/clang",
+        "bin/llvm-as",
+    ],
+)
+
+filegroup(
+    name = "nm",
+    srcs = ["bin/llvm-nm"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/llvm-objcopy"],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = ["bin/llvm-objdump"],
+)
+
+filegroup(
+    name = "profdata",
+    srcs = ["bin/llvm-profdata"],
+)
+
+filegroup(
+    name = "dwp",
+    srcs = ["bin/llvm-dwp"],
+)
+
+filegroup(
+    name = "ranlib",
+    srcs = ["bin/llvm-ranlib"],
+)
+
+filegroup(
+    name = "readelf",
+    srcs = ["bin/llvm-readelf"],
+)
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/llvm-strip"],
+)
+
+filegroup(
+    name = "symbolizer",
+    srcs = ["bin/llvm-symbolizer"],
+)
+
+filegroup(
+    name = "clang-tidy",
+    srcs = ["bin/clang-tidy"],
+)
+
+filegroup(
+    name = "clang-format",
+    srcs = ["bin/clang-format"],
+)
+
+filegroup(
+    name = "git-clang-format",
+    srcs = ["bin/git-clang-format"],
+)
+
+filegroup(
+    name = "libclang",
+    srcs = glob(
+        [
+            "lib/libclang.so",
+            "lib/libclang.dylib",
+        ],
+        allow_empty = True,
+    ),
+)

--- a/tools/xml-hack/README.md
+++ b/tools/xml-hack/README.md
@@ -1,0 +1,71 @@
+# libxml2 stub — boarding up a broken window
+
+The pre-built LLVM toolchain (`ld.lld`) dynamically links `libxml2.so.2`,
+but only uses it for **Windows manifest merging** (`lld/COFF/DriverUtils.cpp`).
+On Linux it is never called, yet every link action prints:
+
+```
+ld.lld: /lib/x86_64-linux-gnu/libxml2.so.2: no version information available
+```
+
+This directory holds a stub `libxml2.so.2` with the correct versioned symbols
+(all of which `abort()` if called). It is compiled into the LLVM archive's
+`lib/` directory via `patch_cmds` on the `http_archive` that backs
+`toolchains_llvm`'s `llvm.toolchain_root`, where `ld.lld`'s
+`RUNPATH=$ORIGIN/../lib` picks it up before the system library.
+
+## When to delete this
+
+Remove this directory and the corresponding `http_archive` + `toolchain_root`
+blocks in `//MODULE.bazel` and `//gallery/MODULE.bazel` as soon as **any** of
+these land upstream:
+
+- LLVM ships `ld.lld` statically linked on Linux (no libxml2 dep), or
+- The BCR `toolchains_llvm` bundles a libxml2 stub itself, or
+- The official LLVM release tarball carries one, or
+- We switch to a toolchain that doesn't have this issue.
+
+Check by bumping the toolchain, deleting this directory + the MODULE.bazel
+blocks, and running `bazelisk build @openroad//:openroad`. If there is no
+`libxml2.so.2: no version information available` warning and the link
+succeeds on a host without `libxml2-dev`, you can delete the whole hack.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `libxml2_stub.c` | Canonical C source (documentation / maintenance copy) |
+| `libxml2_stub.ver` | GNU linker version script with `LIBXML2_2.4.30` / `2.6.0` tags |
+| `BUILD.llvm_repo` | Verbatim copy of `@toolchains_llvm//toolchain:BUILD.llvm_repo`, used as the `build_file` for our pre-patched `http_archive` |
+| `BUILD.bazel` | `exports_files` so the gallery root module can reference `BUILD.llvm_repo` via `@bazel-orfs//tools/xml-hack:...` |
+
+The actual compilation is inlined as a single-line heredoc in each
+`MODULE.bazel`'s `patch_cmds` because `patch_cmds` cannot reference
+workspace files. The canonical `.c` and `.ver` files here are the source
+of truth — keep them and the MODULE.bazel heredocs in sync.
+
+## Hermeticity
+
+The stub is compiled with `./bin/clang -nostdlib -nostdinc -fuse-ld=lld`
+using the Clang and LLD from the just-extracted LLVM archive. This ensures
+the `.so` is byte-identical regardless of the host compiler, which is
+critical for Bazel remote-cache hits — the stub lands in `linker_builtins`
+and becomes an input to every link action.
+
+## Where this should really be fixed
+
+This is a workaround, not a solution. The real seams, most-to-least upstream:
+
+1. **`llvm/llvm-project`** — `lld/COFF/DriverUtils.cpp` conditionally links
+   libxml2; guarding the dep by target OS (or static-linking the tiny
+   manifest-merger path on Linux releases) would delete this cost for
+   every downstream consumer.
+2. **`llvm/llvm-project` release build** — ship `ld.lld` statically linked
+   on Linux release tarballs.
+3. **`bazel-contrib/toolchains_llvm`** (BCR) — either bundle a libxml2
+   stub in the distribution, or add a `patches=` / `patch_cmds=` attr on
+   the `llvm.toolchain` extension so workarounds don't have to route
+   through `toolchain_root`.
+
+Please upstream the real fix if you're in a position to do so, then send
+the revert of this directory.

--- a/tools/xml-hack/libxml2_stub.c
+++ b/tools/xml-hack/libxml2_stub.c
@@ -1,0 +1,31 @@
+// Stub libxml2 — satisfies ld.lld's dynamic dependency on libxml2.so.2.
+// lld only uses libxml2 for Windows manifest merging (lld/COFF), so these
+// symbols are never called on Linux.  Providing a stub here means developers
+// no longer need the system libxml2-dev package installed.
+//
+// Compiled with -nostdlib -nostdinc -fuse-ld=lld using the downloaded Clang
+// from the LLVM archive to produce a hermetic, reproducible .so that does
+// not depend on the host compiler. This is critical for Bazel remote cache
+// hits: the stub becomes an input to every link action via linker_builtins.
+
+extern void abort(void);
+
+void *xmlFree = NULL;
+
+void *xmlAddChild(void *p, void *c)                      { abort(); }
+void *xmlCopyNamespace(void *n)                           { abort(); }
+void  xmlDocDumpFormatMemoryEnc(void *d, void *b, void *s,
+                                const char *e, int f)     { abort(); }
+void *xmlDocGetRootElement(void *d)                       { abort(); }
+void *xmlDocSetRootElement(void *d, void *r)              { abort(); }
+void  xmlFreeDoc(void *d)                                 { abort(); }
+void  xmlFreeNode(void *n)                                { abort(); }
+void  xmlFreeNs(void *n)                                  { abort(); }
+void *xmlNewDoc(const void *v)                            { abort(); }
+void *xmlNewNs(void *n, const void *h, const void *p)    { abort(); }
+void *xmlNewProp(void *n, const void *name, const void *v){ abort(); }
+void *xmlReadMemory(const char *b, int sz, const char *u,
+                    const char *e, int o)                 { abort(); }
+void  xmlSetGenericErrorFunc(void *c, void *h)            { abort(); }
+void *xmlStrdup(const void *s)                            { abort(); }
+void  xmlUnlinkNode(void *n)                              { abort(); }

--- a/tools/xml-hack/libxml2_stub.ver
+++ b/tools/xml-hack/libxml2_stub.ver
@@ -1,0 +1,25 @@
+LIBXML2_2.4.30 {
+    global:
+        xmlAddChild;
+        xmlCopyNamespace;
+        xmlDocDumpFormatMemoryEnc;
+        xmlDocGetRootElement;
+        xmlDocSetRootElement;
+        xmlFree;
+        xmlFreeDoc;
+        xmlFreeNode;
+        xmlFreeNs;
+        xmlNewDoc;
+        xmlNewNs;
+        xmlNewProp;
+        xmlSetGenericErrorFunc;
+        xmlStrdup;
+        xmlUnlinkNode;
+    local:
+        *;
+};
+
+LIBXML2_2.6.0 {
+    global:
+        xmlReadMemory;
+} LIBXML2_2.4.30;


### PR DESCRIPTION
Every C++ link action in bazel-orfs — including the OpenROAD build — currently emits:

    ld.lld: /lib/x86_64-linux-gnu/libxml2.so.2: no version information
    available (required by .../ld.lld)

`ld.lld` from LLVM 20.1.8 dynamically links `libxml2.so.2`, but only calls into it for Windows manifest merging (`lld/COFF/DriverUtils.cpp`). On Linux the symbols are never touched, yet ld.so still has to resolve the library at load time — leaking a silent host dependency on `libxml2-dev` into an otherwise hermetic toolchain, and peppering every link with a noisy version-mismatch warning.

Fix: inject an abort-on-call stub `lib/libxml2.so.2` into the LLVM archive, where ld.lld's `RUNPATH=$ORIGIN/../lib` resolves it before the host's copy. The stub is compiled by the just-extracted `./bin/clang` with `-nostdlib -nostdinc -fuse-ld=lld`, so its bytes are independent of the host compiler — critical for remote-cache hits since the stub lands in every link action's sandbox.

The BCR `toolchains_llvm` bazel_dep has no `patch_cmds` hook, so we use the `llvm.toolchain_root` escape hatch: we declare our own `http_archive` for the LLVM tarball (same url/sha256 `toolchains_llvm` would have fetched) with `patch_cmds` that builds and drops the stub into `lib/`, then point `llvm.toolchain_root` at the patched repo. The BUILD file we give that repo is a copy of `@toolchains_llvm//toolchain:BUILD.llvm_repo` with `lib/libxml2.so.2` added to the `:lib` filegroup so it reaches link actions' sandboxes.

Scope: only helps when bazel-orfs or gallery is the root MODULE (toolchains_llvm is a `dev_dependency` so downstream consumers bring their own toolchain). Downstream consumers that want the same hermeticity can copy the pattern from `tools/xml-hack/` and the two MODULE.bazel blocks — or, ideally, see the upstream-fix checklist below, fix it properly, and delete both.

Where this should really be fixed — please nerd-snipe yourself:

 * llvm/llvm-project: `lld/COFF/DriverUtils.cpp` conditionally links libxml2. Guard it by target OS, or static-link the tiny manifest merger on Linux releases, and every downstream user gets the fix.
 * llvm/llvm-project release build: ship `ld.lld` statically linked on Linux release tarballs.
 * bazel-contrib/toolchains_llvm (BCR): bundle a libxml2 stub in the distribution, or add a `patches=` / `patch_cmds=` attr on the `llvm.toolchain` module-extension so nobody has to detour through `toolchain_root` to apply a one-file fix.

When this commit can be reverted: see `tools/xml-hack/README.md`. Any one of the upstream fixes above is sufficient; try deleting the hack, rebuild, and if the warning is gone and `ldd bin/ld.lld` shows no host libxml2 dependency, send the revert PR.

Verified locally:

 * `ldd external/.../llvm_toolchain_llvm/bin/ld.lld` resolves `libxml2.so.2` to the toolchain's own `lib/libxml2.so.2` (the stub), not `/lib/x86_64-linux-gnu/`.
 * `ld.lld --version` prints cleanly; no libxml2 warning.
 * `bazelisk aquery CppLink` on a test binary lists the stub as an input to the link action (sandboxed next to `ld.lld`).
 * `bazelisk build //tmp_link_test:test` under processwrapper-sandbox links with no warning.
 * `bazelisk run //:fix_lint` clean.