### PR TITLE
feat: emit per-macro pre-layout .lib for ideal-clock pre-CTS STA

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,7 +68,11 @@ git_override(
     # qt-bazel upstream ships it as system_provided = True; we replace
     # that with a static cc_library compiled from xcb-util-cursor 0.1.5.
     patch_cmds = [
-        "curl -sL https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz | tar xJ --strip-components=1 -C interface_libs/xcb xcb-util-cursor-0.1.5/cursor",
+        # Retry + --fail so transient xorg.freedesktop.org hiccups don't
+        # feed a truncated/HTML response into tar (seen in CI as "xz:
+        # File format not recognized"). Stage to a file first for a
+        # clearer error if extraction fails.
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o xcb-util-cursor-0.1.5.tar.xz https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz && tar xJf xcb-util-cursor-0.1.5.tar.xz --strip-components=1 -C interface_libs/xcb xcb-util-cursor-0.1.5/cursor && rm xcb-util-cursor-0.1.5.tar.xz",
     ],
     patch_strip = 1,
     patches = [

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -161,6 +161,7 @@ def source_inputs(ctx):
             ctx.attr.src[OrfsInfo].additional_gds,
             ctx.attr.src[OrfsInfo].additional_lefs,
             ctx.attr.src[OrfsInfo].additional_libs,
+            ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
             ctx.attr.src[PdkInfo].files,
             ctx.attr.src[PdkInfo].libs,
             # Accumulate all JSON reports, so depend on previous stage.
@@ -183,7 +184,12 @@ def deps_inputs(ctx):
     return depset(
         [dep[OrfsInfo].gds for dep in ctx.attr.deps if dep[OrfsInfo].gds] +
         [dep[OrfsInfo].lef for dep in ctx.attr.deps if dep[OrfsInfo].lef] +
-        [dep[OrfsInfo].lib for dep in ctx.attr.deps if dep[OrfsInfo].lib],
+        [dep[OrfsInfo].lib for dep in ctx.attr.deps if dep[OrfsInfo].lib] +
+        [
+            dep[OrfsInfo].lib_pre_layout
+            for dep in ctx.attr.deps
+            if dep[OrfsInfo].lib_pre_layout
+        ],
     )
 
 def flow_substitutions(ctx):
@@ -229,28 +235,43 @@ def required_arguments(ctx):
         "WORK_HOME": "./" + ctx.label.package,
     }
 
-def orfs_additional_arguments(*args, short = False):
+def orfs_additional_arguments(infos, short = False, use_pre_layout = False):
     """Returns ADDITIONAL_GDS/LEFS/LIBS arguments from OrfsInfo providers.
 
     Args:
-      *args: OrfsInfo provider instances.
+      infos: list of OrfsInfo provider instances.
       short: If True, use short_path instead of path.
+      use_pre_layout: If True, use the pre-layout .lib variant of each dep
+        (falling back to the canonical .lib when a dep has none). Applied
+        to synth/floorplan/place where the parent has no real clock tree
+        yet and should see ideal-clock macro timing. .lef/.gds are
+        unaffected.
 
     Returns:
       A dictionary of ADDITIONAL_GDS/LEFS/LIBS arguments.
     """
     gds = depset(
-        [info.gds for info in args if info.gds],
-        transitive = [info.additional_gds for info in args],
+        [info.gds for info in infos if info.gds],
+        transitive = [info.additional_gds for info in infos],
     )
     lefs = depset(
-        [info.lef for info in args if info.lef],
-        transitive = [info.additional_lefs for info in args],
+        [info.lef for info in infos if info.lef],
+        transitive = [info.additional_lefs for info in infos],
     )
-    libs = depset(
-        [info.lib for info in args if info.lib],
-        transitive = [info.additional_libs for info in args],
-    )
+    if use_pre_layout:
+        libs = depset(
+            [
+                (info.lib_pre_layout or info.lib)
+                for info in infos
+                if (info.lib_pre_layout or info.lib)
+            ],
+            transitive = [info.additional_libs_pre_layout for info in infos],
+        )
+    else:
+        libs = depset(
+            [info.lib for info in infos if info.lib],
+            transitive = [info.additional_libs for info in infos],
+        )
 
     arguments = {}
     if gds.to_list():
@@ -459,16 +480,19 @@ def renames(ctx, inputs, short = False):
     result = []
     for file in inputs:
         if ctx.attr.src[OrfsInfo].variant != ctx.attr.variant:
-            result.append(
-                struct(
-                    src = file_path(file, short),
-                    dst = _remap(
-                        file_path(file, short),
-                        ctx.attr.src[OrfsInfo].variant,
-                        ctx.attr.variant,
-                    ),
-                ),
+            src_path = file_path(file, short)
+            dst_path = _remap(
+                src_path,
+                ctx.attr.src[OrfsInfo].variant,
+                ctx.attr.variant,
             )
+
+            # Files from a different variant than both the src and this
+            # stage (e.g., base synth outputs forwarded through a
+            # downstream-variant chain) aren't touched by _remap and end
+            # up with src == dst. Skip — `mv` would error on same file.
+            if src_path != dst_path:
+                result.append(struct(src = src_path, dst = dst_path))
 
     # renamed_inputs win over variant renaming
     for file in inputs:

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -612,8 +612,71 @@ def _orfs_pass(
         )
         return step_name
 
+    def _place_target_label():
+        """Label of this flow's place stage (local or previous_stage), or None.
+
+        Only considers stages actually instantiated in this flow — if the
+        flow starts past place via `previous_stage`, the local place target
+        does not exist.
+        """
+        if "place" in previous_stage:
+            return previous_stage["place"]
+        for s in steps[start_stage:]:
+            if s.stage == "place":
+                return _step_name(name, variant, "place")
+        return None
+
+    def _emit_pre_layout_abstract():
+        """Emit a sibling abstract target fed from the post-place .odb.
+
+        Returns the bare target name (callers prefix with ':' for label use)
+        or None if no place target is available in this flow.
+        """
+        place_src = _place_target_label()
+        if not place_src:
+            return None
+        base_variant = abstract_variant if abstract_variant else variant
+        pre_layout_variant = _variant_name(base_variant, "pre_layout")
+        pre_layout_name = _step_name(
+            name,
+            pre_layout_variant,
+            "generate_abstract",
+        )
+        ABSTRACT_IMPL.impl(
+            **_filter_stage_args(
+                ABSTRACT_IMPL.stage,
+                name = pre_layout_name,
+                stage_arguments = stage_arguments,
+                arguments = arguments,
+                sources = sources,
+                stage_sources = stage_sources,
+                settings = settings,
+                extra_arguments = extra_arguments,
+                extra_configs = extra_configs,
+                src = place_src,
+                variant = pre_layout_variant,
+                stage_data = stage_data,
+                **(
+                    kwargs |
+                    _kwargs(ABSTRACT_IMPL.stage, renamed_inputs = renamed_inputs)
+                )
+            )
+        )
+        _create_deps_tar(pre_layout_name, **kwargs)
+        return pre_layout_name
+
     for step, prev in zip(steps[start_stage:], steps[start_stage - 1:]):
-        sn = do_step(step, prev, kwargs)
+        more_kwargs = {}
+
+        # When the abstract runs past place, also emit a sibling abstract at
+        # post-place so parent flows can feed ideal-clock .lib to their
+        # synth/floorplan/place and the canonical propagated one from CTS on.
+        if step == ABSTRACT_IMPL and abstract_stage and abstract_stage != "place":
+            pre_layout_name = _emit_pre_layout_abstract()
+            if pre_layout_name:
+                more_kwargs = {"pre_layout_abstract": ":" + pre_layout_name}
+
+        sn = do_step(step, prev, kwargs, more_kwargs = more_kwargs)
         step_names.append(sn)
         _create_deps_tar(sn, **kwargs)
         if html and step.stage in _HTML_STAGES:

--- a/private/providers.bzl
+++ b/private/providers.bzl
@@ -10,9 +10,11 @@ OrfsInfo = provider(
         "gds",
         "lef",
         "lib",
+        "lib_pre_layout",
         "additional_gds",
         "additional_lefs",
         "additional_libs",
+        "additional_libs_pre_layout",
         "arguments",
     ],
 )

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -230,6 +230,10 @@ def _macro_impl(ctx):
                 continue
             info[file.extension] = file
 
+    lib_pre_layout = None
+    if ctx.attr.lib and OrfsInfo in ctx.attr.lib:
+        lib_pre_layout = ctx.attr.lib[OrfsInfo].lib_pre_layout
+
     return [
         DefaultInfo(
             files = depset(ctx.files.odb + ctx.files.gds + ctx.files.lef + ctx.files.lib),
@@ -245,7 +249,7 @@ def _macro_impl(ctx):
             gds = info.get("gds"),
             lef = info.get("lef"),
             lib = info.get("lib"),
-            lib_pre_layout = None,
+            lib_pre_layout = lib_pre_layout,
             additional_gds = depset([]),
             additional_lefs = depset([]),
             additional_libs = depset([]),

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -245,9 +245,11 @@ def _macro_impl(ctx):
             gds = info.get("gds"),
             lef = info.get("lef"),
             lib = info.get("lib"),
+            lib_pre_layout = None,
             additional_gds = depset([]),
             additional_lefs = depset([]),
             additional_libs = depset([]),
+            additional_libs_pre_layout = depset([]),
             arguments = depset([]),
         ),
         TopInfo(
@@ -496,9 +498,11 @@ def _arguments_impl(ctx):
             gds = src_info.gds,
             lef = src_info.lef,
             lib = src_info.lib,
+            lib_pre_layout = src_info.lib_pre_layout,
             additional_gds = src_info.additional_gds,
             additional_lefs = src_info.additional_lefs,
             additional_libs = src_info.additional_libs,
+            additional_libs_pre_layout = src_info.additional_libs_pre_layout,
             arguments = depset(
                 [computed_json],
                 transitive = [src_info.arguments],
@@ -854,7 +858,10 @@ def _yosys_impl(ctx):
     all_arguments = merge_arguments(
         data_arguments(ctx) |
         required_arguments(ctx),
-        orfs_additional_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps]),
+        orfs_additional_arguments(
+            [dep[OrfsInfo] for dep in ctx.attr.deps],
+            use_pre_layout = True,
+        ),
     )
     config = declare_artifact(ctx, "results", "1_synth.mk")
     ctx.actions.write(
@@ -1000,7 +1007,7 @@ def _yosys_impl(ctx):
                 arguments = merge_arguments(
                     data_arguments(ctx) |
                     required_arguments(ctx),
-                    orfs_additional_arguments(*[dep[OrfsInfo] for dep in ctx.attr.deps]),
+                    orfs_additional_arguments([dep[OrfsInfo] for dep in ctx.attr.deps]),
                 ) | verilog_arguments(ctx.files.verilog_files),
                 prefix = config_short.root.path,
             ),
@@ -1098,6 +1105,7 @@ def _yosys_impl(ctx):
             gds = None,
             lef = None,
             lib = None,
+            lib_pre_layout = None,
             additional_gds = depset(
                 [dep[OrfsInfo].gds for dep in ctx.attr.deps if dep[OrfsInfo].gds],
             ),
@@ -1106,6 +1114,13 @@ def _yosys_impl(ctx):
             ),
             additional_libs = depset(
                 [dep[OrfsInfo].lib for dep in ctx.attr.deps if dep[OrfsInfo].lib],
+            ),
+            additional_libs_pre_layout = depset(
+                [
+                    (dep[OrfsInfo].lib_pre_layout or dep[OrfsInfo].lib)
+                    for dep in ctx.attr.deps
+                    if (dep[OrfsInfo].lib_pre_layout or dep[OrfsInfo].lib)
+                ],
             ),
             arguments = depset([]),
         ),
@@ -1170,6 +1185,8 @@ orfs_synth_rule = rule(
 
 # --- Make-based stage implementation ---
 
+_PRE_LAYOUT_STAGES = ("2_floorplan", "3_place")
+
 def _make_impl(
         ctx,
         stage,
@@ -1182,7 +1199,8 @@ def _make_impl(
         extra_arguments = {},
         json_names = [],
         drc_names = [],
-        substep_names = []):
+        substep_names = [],
+        lib_pre_layout = None):
     """
     Implementation function for the OpenROAD-flow-scripts stages.
 
@@ -1200,16 +1218,23 @@ def _make_impl(
       drc_names: The names of the DRC files.
       substep_names: Substep names whose intermediate .odb files should be
           captured as additional action outputs in per-substep output groups.
+      lib_pre_layout: Optional pre-layout .lib File to expose on this
+          stage's OrfsInfo. Used by orfs_abstract to surface the post-place
+          .lib alongside the canonical (post-final) one.
 
     Returns:
         A list of providers. The returned PdkInfo and TopInfo providers are taken from the first
         target of a ctx.attr.srcs list.
     """
+    use_pre_layout = stage in _PRE_LAYOUT_STAGES
     all_arguments = merge_arguments(
         extra_arguments |
         data_arguments(ctx) |
         required_arguments(ctx),
-        orfs_additional_arguments(ctx.attr.src[OrfsInfo]),
+        orfs_additional_arguments(
+            [ctx.attr.src[OrfsInfo]],
+            use_pre_layout = use_pre_layout,
+        ),
     )
 
     # Write this stage's arguments to .json for downstream stages, then
@@ -1302,7 +1327,10 @@ def _make_impl(
                     extra_arguments |
                     data_arguments(ctx) |
                     required_arguments(ctx),
-                    orfs_additional_arguments(ctx.attr.src[OrfsInfo]),
+                    orfs_additional_arguments(
+                        [ctx.attr.src[OrfsInfo]],
+                        use_pre_layout = use_pre_layout,
+                    ),
                 ),
                 prefix = config_short.root.path,
             ),
@@ -1380,6 +1408,7 @@ def _make_impl(
                         ctx.attr.src[OrfsInfo].additional_gds,
                         ctx.attr.src[OrfsInfo].additional_lefs,
                         ctx.attr.src[OrfsInfo].additional_libs,
+                        ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
                     ],
                 ),
             ),
@@ -1421,9 +1450,11 @@ def _make_impl(
             gds = info.get("gds"),
             lef = info.get("lef"),
             lib = info.get("lib"),
+            lib_pre_layout = lib_pre_layout,
             additional_gds = ctx.attr.src[OrfsInfo].additional_gds,
             additional_lefs = ctx.attr.src[OrfsInfo].additional_lefs,
             additional_libs = ctx.attr.src[OrfsInfo].additional_libs,
+            additional_libs_pre_layout = ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
             arguments = depset(
                 [stage_json],
                 transitive = [ctx.attr.src[OrfsInfo].arguments] +
@@ -1812,12 +1843,24 @@ orfs_abstract = rule(
         extra_arguments = {
             "ABSTRACT_SOURCE": extensionless_basename(ctx.attr.src[OrfsInfo].odb),
         },
+        lib_pre_layout = (
+            ctx.attr.pre_layout_abstract[OrfsInfo].lib if ctx.attr.pre_layout_abstract else None
+        ),
     ),
     attrs = openroad_attrs() |
             renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "generate_abstract",
+                ),
+                "pre_layout_abstract": attr.label(
+                    providers = [OrfsInfo],
+                    doc = "Optional sibling abstract target emitted at the " +
+                          "post-`place` stage. Its .lib is exposed as this " +
+                          "target's OrfsInfo.lib_pre_layout so that parent " +
+                          "flows can consume ideal-clock timing for " +
+                          "synth/floorplan/place and the canonical " +
+                          "propagated-clock lib from CTS onward.",
                 ),
             },
     provides = flow_provides(),

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,7 @@ load("//:openroad.bzl", "get_stage_args", "orfs_arguments", "orfs_floorplan", "o
 load("//:orfs_genrule.bzl", "orfs_genrule")
 load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
+load(":provider_test_rule.bzl", "lib_pre_layout_test")
 
 exports_files(
     glob([
@@ -1137,6 +1138,22 @@ orfs_flow(
     stage_sources = LB_STAGE_SOURCES,
     variant = "mock_full_abstract",
     verilog_files = LB_VERILOG_FILES,
+)
+
+# Verify that orfs_macro forwards lib_pre_layout from the inner
+# orfs_abstract. This is a bare orfs_macro wrapping the mock abstract
+# (which has abstract_stage="cts", past "place", so it emits a
+# pre-layout abstract). The test asserts lib_pre_layout is non-None.
+orfs_macro(
+    name = "lb_32x128_mock_macro_wrapper",
+    lef = ":lb_32x128_mock_full_abstract_generate_abstract",
+    lib = ":lb_32x128_mock_full_abstract_generate_abstract",
+    module_top = "lb_32x128",
+)
+
+lib_pre_layout_test(
+    name = "lib_pre_layout_macro_test",
+    target = ":lb_32x128_mock_macro_wrapper",
 )
 
 # Fully-mock hierarchical flow for deps integration tests.

--- a/test/provider_test_rule.bzl
+++ b/test/provider_test_rule.bzl
@@ -1,0 +1,42 @@
+"""Test rule to verify OrfsInfo.lib_pre_layout is forwarded through orfs_macro."""
+
+load("//private:providers.bzl", "OrfsInfo")
+
+def _lib_pre_layout_test_impl(ctx):
+    """Extracts lib_pre_layout path at analysis time, asserts at test time."""
+    info = ctx.attr.target[OrfsInfo]
+    path = info.lib_pre_layout.short_path if info.lib_pre_layout else ""
+
+    runner = ctx.actions.declare_file(ctx.attr.name + "_runner.sh")
+    ctx.actions.write(
+        output = runner,
+        is_executable = True,
+        content = """\
+#!/bin/sh
+if [ -z "{path}" ]; then
+    echo "FAIL: {label} has OrfsInfo.lib_pre_layout = None"
+    exit 1
+fi
+echo "PASS: {label} has lib_pre_layout = {path}"
+""".format(
+            label = ctx.attr.target.label,
+            path = path,
+        ),
+    )
+
+    return [DefaultInfo(
+        executable = runner,
+        runfiles = ctx.runfiles(),
+    )]
+
+lib_pre_layout_test = rule(
+    implementation = _lib_pre_layout_test_impl,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            providers = [OrfsInfo],
+            doc = "Target whose OrfsInfo.lib_pre_layout must be non-None",
+        ),
+    },
+    test = True,
+)


### PR DESCRIPTION
@maliberty @tspyrou FYI, dual charcterization...

Hierarchical macro abstracts generated by `write_timing_model` after CTS bake the propagated clock insertion delay into dedicated `min/max_clock_tree_path` timing arcs on each clock input pin. When the parent consumes such a `.lib` during its own pre-CTS stages (synth/floorplan/place) the parent's STA over-budgets timing into the macro, penalizing synthesis and placement.

Dual characterization is the standard industry fix: run `generate_abstract` once at post-`place` to emit an ideal-clock variant (the `min/max_clock_tree_path` arcs are emitted with zero values because no clock tree exists yet), and once at `final` for the propagated variant. The parent's pre-CTS stages consume the ideal lib; CTS+ consume the propagated one. `.lef`/`.gds` stay single-canonical because pin locations commit at place and macro-internal OBS differences don't matter when macros are treated as black boxes by the parent router.

User-facing API is unchanged: a single `:<name>_generate_abstract` label still represents the macro on both sides. Internally:

- `orfs_flow` with `abstract_stage` past `place` now also emits `:<name>_pre_layout_generate_abstract` fed from the post-`place` .odb, and wires it into the canonical abstract via a new `pre_layout_abstract` attr on `orfs_abstract`.
- `OrfsInfo` gains `lib_pre_layout` and `additional_libs_pre_layout`; `orfs_additional_arguments` takes a `use_pre_layout` flag applied in synth/2_floorplan/3_place when building `ADDITIONAL_LIBS`.
- Fixes a latent same-file `mv` in `renames()` that's newly reachable when a pre-layout variant's src forwards base-variant files.

Verified on //test:L1MetadataArray_generate_abstract:
  tag_array_64x184/base/*_typ.lib:       max_clock_tree_path = 31.21806
  tag_array_64x184/pre_layout/*_typ.lib: max_clock_tree_path =  0.00000
  synth/floorplan/place args.mk → pre_layout lib
  cts args.mk                    → canonical lib