### PR TITLE
fix: add args_mk to stage runfiles so bazel run <stage> works

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1394,9 +1394,9 @@ def _make_impl(
     return [
         DefaultInfo(
             executable = exe,
-            files = depset(forwards + results + reports + [args_mk]),
+            files = depset(forwards + results + reports),
             runfiles = ctx.runfiles(
-                [config_short, make] +
+                [config_short, make, args_mk] +
                 forwards +
                 results +
                 logs +

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1394,7 +1394,7 @@ def _make_impl(
     return [
         DefaultInfo(
             executable = exe,
-            files = depset(forwards + results + reports),
+            files = depset(forwards + results + reports + [args_mk]),
             runfiles = ctx.runfiles(
                 [config_short, make, args_mk] +
                 forwards +

--- a/test/lint_test.sh
+++ b/test/lint_test.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
-# Test that lint=True excludes heavy dependencies from runfiles.
-# The test's own runfiles (which include the lint flow target as data)
-# should NOT contain klayout or opensta.
+# Test that lint=True excludes heavy dependencies from runfiles, and that
+# stage runfiles contain the files that config.mk `include`s at runtime.
+#
+# `bazel run <stage>` uses the stage exe's DefaultInfo.runfiles. Any file
+# referenced by `<stage>.short.mk` (deployed as config.mk) must be present
+# there, otherwise make fails parsing config.mk before doing any work.
+# Historically args.mk was in the deps tarball but not the bazel-run
+# runfiles, so `bazel run <stage> -- gui_cts` broke with
+# "No such file or directory: .../4_cts.args.mk" — tarball-based tests
+# can't catch that.
 set -euo pipefail
 
 # The test runfiles directory contains symlinks to the lint flow target's deps
@@ -24,9 +31,29 @@ for dep in "${HEAVY_DEPS[@]}"; do
   fi
 done
 
+# For every *.short.mk in the runfiles, verify every `include <path>`
+# resolves to an existing file at the expected short_path location.
+while IFS= read -r short_mk; do
+  [ -n "$short_mk" ] || continue
+  # Deploy copies config_short to $dst_main/config.mk, then `cd`s into
+  # _main before running make. Resolve includes relative to the _main/
+  # prefix of the short.mk's own path — use `%` (shortest match from
+  # the right) so we stop at the innermost `/_main/`, i.e. the runfiles
+  # root, not the execroot `/_main/` that's farther up the path.
+  main_prefix="${short_mk%/_main/*}/_main"
+  [ -d "$main_prefix" ] || main_prefix="$(dirname "$short_mk")"
+  while IFS= read -r inc; do
+    inc_path="$main_prefix/$inc"
+    if [ ! -e "$inc_path" ]; then
+      echo "FAIL: $short_mk includes '$inc' but $inc_path is missing"
+      errors=$((errors + 1))
+    fi
+  done < <(grep -E '^include ' "$short_mk" | awk '{print $2}')
+done < <(echo "$manifest_content" | grep -E '\.short\.mk$' || true)
+
 if [[ $errors -gt 0 ]]; then
-  echo "FAIL: $errors heavy dependencies found in lint flow runfiles"
+  echo "FAIL: $errors problem(s) found in lint flow runfiles"
   exit 1
 fi
 
-echo "PASS: No heavy dependencies found in lint flow runfiles"
+echo "PASS: Lint flow runfiles exclude heavy deps and satisfy short.mk includes"


### PR DESCRIPTION
Each stage's `<stage>.short.mk` is deployed as `config.mk` and `include`s `<stage>.args.mk` at its runfiles short_path. args_mk was listed in `DefaultInfo.files` and in the `_deps` tarball's `deploy_files`, but was absent from the stage exe's `DefaultInfo.runfiles`. Running the stage directly (e.g. `bazelisk run <stage> -- gui_cts`) therefore failed with `config.mk:1: .../<stage>.args.mk: No such file or directory` before make could run any target.

Tarball-based tests can't catch this — they build from `deploy_files`, which already contained args_mk. And `sh_test(data=[<stage>])` auto-pulls `DefaultInfo.files` into the test's runfiles, masking a missing-from- runfiles bug even if the test walks the runfiles tree. Drop args_mk from `files` (nothing external references it by location — it's purely an include target for make) so `data=` only pulls it in via runfiles, and amend the existing lint_no_heavy_deps_test script to verify every `include` line in every `*.short.mk` resolves inside the runfiles tree.