### PR TITLE
fix: behavioral_macros emits VDD/VSS pins so PDN can stitch the macro

### DIFF
--- a/tools/memory_macro_scaler/memory_macro_scaler.py
+++ b/tools/memory_macro_scaler/memory_macro_scaler.py
@@ -1053,27 +1053,55 @@ def rewrite_lef(lef_text, role, bucket):
             h=_M5_PITCH_UM,
             use="CLOCK",
         )
-    # Power pins preserved at well-known positions (top-left / top-right).
+    # Power pins as full-width horizontal M4 stripes — PDN searches for
+    # USE POWER / USE GROUND macro pins on a stripe layer and stitches them
+    # to the parent grid via vias. Small disconnected rects (the previous
+    # M5 corner placement) didn't overlap parent PDN stripes, so floorplan
+    # PDN reported PDN-0231 "<inst> not connected to any power/ground nets"
+    # for every behavioral macro and the parent's downstream power analysis
+    # saw zero macro power. The fakeram_*.lef shipped with the asap7
+    # platform uses exactly this shape (multiple full-width M4 stripes per
+    # rail); one stripe per rail is the minimum that PDN can find.
     for i, name in enumerate(powers):
+        is_power = name.upper().startswith("VDD")
+        # Two stripes per macro evenly split the interior on the y axis;
+        # alternate VDD high / VSS low so the rails don't collide.
+        y_frac = 0.66 if is_power else 0.33
+        stripe_y = y_frac * height - _M4_PITCH_UM / 2.0
         _emit_pin(
             lines,
             name,
             "INOUT",
-            layer="M5",
-            x=(width * 0.25) + (width * 0.5 * i),
-            y=height - _M5_PITCH_UM,
-            w=_M5_PITCH_UM,
-            h=_M5_PITCH_UM,
-            use="POWER" if name.upper().startswith("VDD") else "GROUND",
+            layer="M4",
+            x=0.0,
+            y=stripe_y,
+            w=width,
+            h=_M4_PITCH_UM,
+            use="POWER" if is_power else "GROUND",
         )
 
-    # One OBS rectangle covering the interior (conservative blockage).
+    # One OBS rectangle covering the interior (conservative blockage). Carve
+    # out the M4 stripe rows so PDN sees the PG pin geometry, otherwise the
+    # blockage hides the stripes from the macro-pin search.
     inset = _M4_PITCH_UM
     lines.append("  OBS\n")
-    lines.append(
-        f"    LAYER M4 ; RECT {inset:.3f} {inset:.3f} "
-        f"{width - inset:.3f} {height - inset:.3f} ;\n"
+    pg_y_fracs = sorted(set(0.66 if n.upper().startswith("VDD") else 0.33 for n in powers))
+    cuts = sorted(
+        f * height - _M4_PITCH_UM / 2.0 for f in pg_y_fracs
     )
+    cur_y = inset
+    for cy in cuts:
+        if cy > cur_y:
+            lines.append(
+                f"    LAYER M4 ; RECT {inset:.3f} {cur_y:.3f} "
+                f"{width - inset:.3f} {cy:.3f} ;\n"
+            )
+        cur_y = cy + _M4_PITCH_UM
+    if cur_y < height - inset:
+        lines.append(
+            f"    LAYER M4 ; RECT {inset:.3f} {cur_y:.3f} "
+            f"{width - inset:.3f} {height - inset:.3f} ;\n"
+        )
     lines.append("  END\n")
     lines.append(f"END {macro_name}\n")
     return "".join(lines)
@@ -1431,6 +1459,18 @@ def generate_lef(role, tech_nm=DEFAULT_TECH_NM):
             else:
                 stub.append(f"    PORT LAYER M4 ; RECT 0 0 0.1 0.1 ; END")
             stub.append(f"  END {pn}")
+    # Power/ground pins. rewrite_lef() turns these into full-width M4
+    # stripes that PDN can stitch to the parent power grid; without them
+    # the floorplan's PDN stage warns PDN-0231 "<inst> not connected to
+    # any power/ground nets" for every behavioral macro and the parent's
+    # downstream power analysis sees zero macro power. _is_power_pin()
+    # already classifies VDD / VSS, so only the stub entries are new.
+    for pg, use in (("VDD", "POWER"), ("VSS", "GROUND")):
+        stub.append(f"  PIN {pg}")
+        stub.append(f"    DIRECTION INOUT ;")
+        stub.append(f"    USE {use} ;")
+        stub.append(f"    PORT LAYER M4 ; RECT 0 0 0.1 0.1 ; END")
+        stub.append(f"  END {pg}")
     stub.append(f"END {name}")
     stub.append("")
     stub.append("END LIBRARY")

--- a/tools/memory_macro_scaler/memory_macro_scaler_test.py
+++ b/tools/memory_macro_scaler/memory_macro_scaler_test.py
@@ -649,6 +649,38 @@ class TestGenerateFromScratch(unittest.TestCase):
         self.assertIn("PIN RW0_rdata", lef)
         self.assertIn("PIN RW0_clk", lef)
 
+    def test_generate_lef_has_pg_pins(self):
+        """Behavioral macros must declare VDD/VSS pins so PDN can stitch
+        them to the parent power grid; without these the parent floorplan
+        emits PDN-0231 'not connected to any power/ground nets' for every
+        macro instance and the downstream power flow sees zero macro power.
+        """
+        role = mms.MemoryRole(
+            kind="sram", rows=128, bits=64, nRW=1, library_name="mem", cell_name="mem"
+        )
+        lef = mms.generate_lef(role, tech_nm=7)
+        # PG pins present with the right USE classification.
+        self.assertIn("PIN VDD", lef)
+        self.assertIn("USE POWER", lef)
+        self.assertIn("PIN VSS", lef)
+        self.assertIn("USE GROUND", lef)
+        # And they must land as full-width M4 stripes — small disconnected
+        # rects don't overlap parent PDN stripes and PDN-0231 fires anyway.
+        m = re.search(r"SIZE\s+([\d.]+)\s+BY\s+([\d.]+)", lef)
+        self.assertIsNotNone(m)
+        width = float(m.group(1))
+        for pg in ("VDD", "VSS"):
+            block = re.search(
+                rf"PIN {pg}.*?END {pg}", lef, re.DOTALL
+            ).group(0)
+            stripe = re.search(
+                r"LAYER M4 ; RECT ([\d.]+) [\d.]+ ([\d.]+) [\d.]+", block
+            )
+            self.assertIsNotNone(stripe, f"{pg} stripe not found on M4")
+            x_lo, x_hi = float(stripe.group(1)), float(stripe.group(2))
+            self.assertEqual(x_lo, 0.0)
+            self.assertAlmostEqual(x_hi, width, places=3)
+
 
 class TestBanking(unittest.TestCase):
     def test_small_memory_is_single_bank(self):


### PR DESCRIPTION
## Summary

Behavioral memory macros (`@bazel-orfs//tools/memory_macro_scaler:behavioral_macros`) were dropping VDD/VSS pins from their generated `.lef`. The first downstream project to wire `behavioral_macros` into a real SAIF-driven power-simulation flow ([Pinata-Consulting/ascenium#22358](https://github.com/Pinata-Consulting/ascenium/issues/22358)) hit the gap immediately:

```
[WARNING PDN-0231] vectorUnit/vrf_slice0_ext is not connected to any power/ground nets.
[WARNING PDN-0231] branchPredictor/loop.specEntries_ext is not connected to any power/ground nets.
... [hundreds of memory instances] ...
```

Every behavioral memory stayed off the parent power grid; the parent's `report_power` then accounted zero macro power. The `.lib` was already power-aware (per-pin `internal_power`, cell-level `default_cell_leakage_power`) — the gap was strictly LEF-side, matching the precedent that `fakeram_*.lib` shipped with the asap7 platform also has no `pg_pin` declarations.

## Fix

`generate_lef()` now appends `PIN VDD` / `PIN VSS` (with `USE POWER` / `USE GROUND`) to the stub LEF, and `rewrite_lef()` lays them down as full-width horizontal M4 stripes — the same shape `fakeram_*.lef` uses. The OBS rectangle is split into segments around the PG stripe rows so the blockage doesn't hide the pin geometry from PDN's macro-pin search.

## Test plan

- [x] `python3 -m unittest memory_macro_scaler_test` — all 57 existing tests pass; new `test_generate_lef_has_pg_pins` covers PIN VDD/VSS presence with the right USE classification and full-width M4 stripe geometry
- [ ] Validation build of the consumer that surfaced the gap (Pinata-Consulting/ascenium `//hardware/tile:report_power` and `//hardware/aptos-run:cts-8-Saif-run`) currently in flight; the ascenium-side PR vendors this same change as a `git_override` patch and will drop it after this lands