### PR TITLE
ci: drop --@openroad//:platform=gui to stop double-building openroad

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,9 +9,6 @@ common --lockfile_mode=off
 # Required by OpenROAD's MODULE.bazel (uses isolate = True in use_extension)
 common --experimental_isolated_extension_usages
 
-# Build OpenROAD from source with GUI enabled to match the docker image.
-build --@openroad//:platform=gui
-
 # Garbage-collect disk cache to avoid exhausting CI runner disk.
 build --experimental_disk_cache_gc_max_size=2G
 


### PR DESCRIPTION
The root .bazelrc pinned --@openroad//:platform=gui, but gallery/, chisel/, lec/, and orfs/ do not — they fall back to the default platform=cli. OpenROAD's BUILD.bazel branches :openroad_lib's deps on that flag via select() (//src/gui vs //src/gui:gui_qt, plus BUILD_GUI define), so the two variants don't share a cache key. CI ends up linking openroad once with Qt for the root step and again with CLI-only deps for the sibling-module steps.

Remove the flag so every step uses the same CLI build. GUI use (bazelisk run <design>_synth -- gui_synth) now requires re-adding the flag in user.bazelrc until OpenROAD PR #10384 lands the separate :openroad-qt target, at which point bazel-orfs can switch to that binary and avoid the cache-busting flag entirely.