### PR TITLE
rules: add orfs_run_executable for bazelisk-run TCL targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -117,6 +117,15 @@ py_test(
     deps = [":rtlil_kept_modules_lib"],
 )
 
+# Entry point for the orfs_run_executable rule's emitted shell wrapper.
+# Forwards bazelisk-run CLI args to make as variable overrides which become
+# env vars in the Tcl script.
+py_binary(
+    name = "run_executable",
+    srcs = ["run_executable.py"],
+    visibility = ["//visibility:public"],
+)
+
 # Run `bazelisk run //:fix_lint` to format all files changed since origin/main.
 py_library(
     name = "fix_lint_lib",

--- a/EXTERNAL_API.md
+++ b/EXTERNAL_API.md
@@ -12,7 +12,7 @@ consumers.
 
 | File | Exports | External deps |
 |---|---|---|
-| `openroad.bzl` | `orfs_flow`, `orfs_synth`, `orfs_update`, `orfs_run`, `orfs_test`, `orfs_macro`, `orfs_pdk`, `orfs_deps`, `orfs_floorplan`, `orfs_place`, `orfs_cts`, `orfs_grt`, `orfs_route`, `orfs_final`, `orfs_gds`, `orfs_abstract`, `orfs_generate_metadata`, `orfs_update_rules`, providers (`OrfsInfo`, `PdkInfo`, `TopInfo`, `OrfsDepInfo`, `LoggingInfo`) | `bazel_skylib` |
+| `openroad.bzl` | `orfs_flow`, `orfs_synth`, `orfs_update`, `orfs_run`, `orfs_run_executable`, `orfs_test`, `orfs_macro`, `orfs_pdk`, `orfs_deps`, `orfs_floorplan`, `orfs_place`, `orfs_cts`, `orfs_grt`, `orfs_route`, `orfs_final`, `orfs_gds`, `orfs_abstract`, `orfs_generate_metadata`, `orfs_update_rules`, providers (`OrfsInfo`, `PdkInfo`, `TopInfo`, `OrfsDepInfo`, `LoggingInfo`) | `bazel_skylib` |
 | `extension.bzl` | `orfs_repositories` module extension | built-in only |
 | `ppa.bzl` | `orfs_ppa` | `rules_shell` |
 | `verilog.bzl` | `verilog_directory`, `verilog_file`, `verilog_single_file_library` | `rules_verilog` |

--- a/openroad.bzl
+++ b/openroad.bzl
@@ -51,6 +51,7 @@ load(
     _orfs_place = "orfs_place",
     _orfs_route = "orfs_route",
     _orfs_run = "orfs_run",
+    _orfs_run_executable = "orfs_run_executable",
     _orfs_test = "orfs_test",
     _orfs_update_rules = "orfs_update_rules",
 )
@@ -101,6 +102,7 @@ flow_provides = _flow_provides
 orfs_pdk = _orfs_pdk
 orfs_macro = _orfs_macro
 orfs_run = _orfs_run
+orfs_run_executable = _orfs_run_executable
 orfs_test = _orfs_test
 orfs_floorplan = _orfs_floorplan
 orfs_place = _orfs_place

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -614,6 +614,110 @@ orfs_test = rule(
     test = True,
 )
 
+# --- Run-executable rule ---
+#
+# Like orfs_run, but builds a `bazelisk run` target instead of a build-time
+# action. The emitted wrapper exposes the same env that orfs_run sets, plus a
+# pass-through for CLI args: every `KEY=VALUE` positional received after
+# `bazelisk run //path:target -- ...` is forwarded to make as a variable
+# override, which becomes an environment variable when make invokes the Tcl
+# script. Make's last-wins rule means CLI overrides beat the BUILD-time
+# `arguments` dict.
+#
+# Use this when the script has a parameter the user wants to vary
+# per-invocation (e.g. an endpoint glob for a timing-path drill-down) and
+# wiring a separate orfs_run target per parameter value would be tedious.
+
+def _run_executable_impl(ctx):
+    config = ctx.attr.src[OrfsDepInfo].config
+
+    wrapper = ctx.actions.declare_file(
+        "run_{}_{}_executable".format(ctx.attr.name, ctx.attr.variant),
+    )
+
+    # For external repo targets, WORK_HOME must include the external/<repo>/
+    # prefix so Make finds results/reports at the correct runfiles path.
+    # Matches orfs_test's handling.
+    if ctx.label.workspace_name:
+        parts = ["external", ctx.label.workspace_name]
+        if ctx.label.package:
+            parts.append(ctx.label.package)
+        work_home = "/".join(parts)
+    else:
+        work_home = None
+
+    moreargs = environment_string(
+        hack_away_prefix(
+            arguments = odb_arguments(ctx) | data_arguments(ctx),
+            prefix = config.root.path,
+        ) |
+        {"DESIGN_CONFIG": config.short_path} |
+        ({"WORK_HOME": work_home} if work_home else {}),
+    )
+
+    ctx.actions.write(
+        output = wrapper,
+        is_executable = True,
+        content = """#!/bin/sh
+set -e
+if [ ! -e external ]; then
+    # Needed as of Bazel >= 8
+    ln -sf $(realpath $(pwd)/..) external
+fi
+export ORFS_MAKE_EXE={make}
+export ORFS_MAKEFILE={makefile}
+export ORFS_CMD={cmd}
+exec {py_run_executable} {moreargs} "$@"
+""".format(
+            make = ctx.executable._make.short_path,
+            makefile = ctx.file._makefile.path,
+            cmd = ctx.attr.cmd,
+            moreargs = moreargs,
+            py_run_executable = ctx.executable._run_executable.short_path,
+        ),
+    )
+
+    return [
+        ctx.attr.src[PdkInfo],
+        ctx.attr.src[TopInfo],
+        DefaultInfo(
+            executable = wrapper,
+            runfiles = ctx.runfiles(
+                transitive_files = depset(
+                    [config, wrapper],
+                    transitive = [
+                        flow_inputs(ctx),
+                        yosys_inputs(ctx),
+                        data_inputs(ctx),
+                        source_inputs(ctx),
+                    ],
+                ),
+            ).merge(ctx.attr._run_executable[DefaultInfo].default_runfiles),
+        ),
+    ]
+
+orfs_run_executable = rule(
+    implementation = _run_executable_impl,
+    attrs = yosys_attrs() |
+            openroad_attrs() |
+            {
+                "cmd": attr.string(
+                    mandatory = False,
+                    default = "run",
+                ),
+                "script": attr.label(
+                    mandatory = True,
+                    allow_single_file = ["tcl"],
+                ),
+                "_run_executable": attr.label(
+                    default = "@bazel-orfs//:run_executable",
+                    executable = True,
+                    cfg = "exec",
+                ),
+            },
+    executable = True,
+)
+
 # --- Synthesis rule ---
 
 CANON_OUTPUT = "1_1_yosys_canonicalize.rtlil"

--- a/run_executable.py
+++ b/run_executable.py
@@ -1,0 +1,57 @@
+"""Entry point for orfs_run_executable.
+
+The rule's shell wrapper sets ORFS_MAKE_EXE / ORFS_MAKEFILE / ORFS_CMD in
+the environment and prepends the BUILD-time `arguments` dict to argv as
+positional KEY=VALUE tokens. User-supplied `bazelisk run -- ...` args are
+appended after, so make's last-wins rule gives them priority over the
+BUILD-time defaults.
+
+Make-level variable overrides (KEY=VALUE on the make command line) become
+environment variables when make invokes the recipe — that's how the Tcl
+script sees the user's TO_GLOB / OUTPUT etc.
+"""
+
+import argparse
+import os
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run an ORFS Tcl script with runtime arguments.",
+        epilog=(
+            "Positional KEY=VALUE pairs become make variable overrides and "
+            "environment variables for the Tcl script. CLI args override "
+            "the BUILD-time `arguments` dict (make last-wins)."
+        ),
+    )
+    parser.add_argument(
+        "--cmd",
+        default=None,
+        help="Override the make target (default: the rule's `cmd` attr).",
+    )
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="make variable overrides; later values win.",
+    )
+    args = parser.parse_args()
+
+    try:
+        make = os.environ["ORFS_MAKE_EXE"]
+        makefile = os.environ["ORFS_MAKEFILE"]
+    except KeyError as exc:
+        sys.exit(
+            f"{sys.argv[0]}: missing env var {exc.args[0]} — "
+            "was this invoked outside the orfs_run_executable wrapper?"
+        )
+
+    cmd = args.cmd if args.cmd is not None else os.environ.get("ORFS_CMD", "run")
+
+    argv = [make, "--file", makefile, *args.overrides, cmd]
+    os.execvp(make, argv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds \`orfs_run_executable\`: like \`orfs_run\`, but produces a \`bazelisk run\` target instead of a build-time action. The emitted wrapper exposes the same env that \`orfs_run\` sets, plus a pass-through for CLI args.

## Why

\`orfs_run\` bakes its \`arguments\` dict into the BUILD-time action. When a downstream script has a parameter that varies per-invocation (e.g. an endpoint glob for a timing-path drill-down, a debug-level toggle, etc.) there's no idiomatic way to thread it through without one of:

- A new \`orfs_run\` target per parameter value (target proliferation)
- A temporary BUILD.bazel edit (manual + cache-unfriendly)
- \`--action_env=KEY=VALUE\` (does not propagate; \`config_overrides\` only merges \`arguments | defines_for_stage | settings\`, with no shell-env passthrough)

This rule fixes that: \`bazelisk run //path:target -- KEY=VALUE\` forwards each positional to make as a variable override, which becomes an environment variable when make invokes the Tcl script. Make's last-wins rule means CLI overrides beat the BUILD-time \`arguments\` dict.

## Shape

| | \`orfs_run\` | \`orfs_run_executable\` |
|---|---|---|
| Bazel invocation | \`bazelisk build\` | \`bazelisk run -- KEY=VALUE\` |
| Outputs | declared in \`outs\` attr | written by the Tcl script (path comes from arguments or CLI) |
| CLI args | none | \`--cmd\` + free-form \`KEY=VALUE\` positionals |

Mirrors \`orfs_test\`'s executable-with-runfiles pattern exactly: \`ctx.actions.write\` emits a shell wrapper that exports \`ORFS_MAKE_EXE\` / \`ORFS_MAKEFILE\` / \`ORFS_CMD\`, prepends the BUILD-time arguments dict as positional argv to \`run_executable.py\`, then forwards \`\"\$@\"\`. The py_binary parses argparse (\`--help\`, \`--cmd CMD\`) and \`exec()s\` make with the combined argv.

## Files

- \`run_executable.py\` (new) — argparse + \`os.execvp(make, ...)\` entry point.
- \`BUILD\` — \`py_binary\` declaration, visibility public.
- \`private/rules.bzl\` — \`_run_executable_impl\` + \`orfs_run_executable\` rule.
- \`openroad.bzl\` — load + re-export.
- \`EXTERNAL_API.md\` — public API table updated.

## Verified

- \`bazelisk run //:fix_lint\` — formatted, no further diffs.
- \`bazelisk build //:run_executable\` — py_binary builds.
- \`bazel-bin/run_executable --help\` — argparse usage prints correctly.
- \`bazelisk query 'kind(\"rule\", @bazel-orfs//...)'\` — \`orfs_run_executable\` rule loads.

End-to-end test against a real synth ODB happens at the downstream consumer (https://github.com/Pinata-Consulting/ascenium follow-up PR) where a real Tcl script is wired up.

## Test plan

- [x] py_binary builds and \`--help\` works
- [x] Rule loads via Starlark query
- [x] \`fix_lint\` clean
- [ ] End-to-end run against a real ORFS synth target (deferred to downstream PR — needs a checked-out design)