### PR TITLE
bump: source yosys/openroad/yosys-slang from ORFS tools/ submodules

### DIFF
--- a/bump.py
+++ b/bump.py
@@ -523,38 +523,116 @@ def fetch_tag_commit(github_repo, tag):
     return obj.get("sha", "")
 
 
-def update_yosys_build_bzl(filepath, yosys_commit):
-    """Update yosys_commit in yosys_build.bzl (inside extension.bzl yosys_build() call)."""
-    with open(filepath) as f:
-        content = f.read()
+# Source of truth for EDA tool versions: ORFS's tools/ submodules at master.
+# The bumper reads each submodule's pinned sha at the just-bumped ORFS commit
+# and applies it to the consumer's git_override blocks.
+ORFS_REPO = "The-OpenROAD-Project/OpenROAD-flow-scripts"
+ORFS_TOOLS = {
+    # tools/ subdir name -> (MODULE.bazel module name, upstream repo for --head)
+    "yosys": ("yosys", "YosysHQ/yosys"),
+    "OpenROAD": ("openroad", "The-OpenROAD-Project/OpenROAD"),
+    "yosys-slang": ("yosys-slang", "povik/yosys-slang"),
+}
 
-    content = re.sub(
-        r'(yosys_commit\s*=\s*")[^"]*(")',
-        rf"\g<1>{yosys_commit}\2",
-        content,
+# The oldest povik/yosys-slang sha that satisfies today's build.  Once ORFS's
+# tools/yosys-slang submodule advances past this, the floor becomes a no-op
+# and the bumper transparently switches back to following ORFS's pin.  Update
+# this constant when a newer yosys-slang feature is needed.
+YOSYS_SLANG_MIN_COMMIT = "4e53d772996184b07e9bfe784060f96e6cb0a267"
+
+
+def fetch_orfs_tool_sha(orfs_commit, tool):
+    """Submodule sha of ORFS/tools/<tool> at a specific ORFS commit.
+
+    Pinning the ``?ref=<commit>`` matters: an unpinned query would silently
+    drift if ORFS master moved between our ORFS bump and the tools/ reads.
+    """
+    url = (
+        f"https://api.github.com/repos/{ORFS_REPO}/contents/tools/{tool}"
+        f"?ref={orfs_commit}"
     )
+    data = fetch_json(url)
+    if data.get("type") != "submodule":
+        raise RuntimeError(
+            f"tools/{tool} is not a submodule at {orfs_commit} (got {data.get('type')!r})"
+        )
+    return data["sha"]
 
-    with open(filepath, "w") as f:
-        f.write(content)
+
+def fetch_compare_status(repo, base, head):
+    """Return the GitHub /compare status: 'ahead' | 'behind' | 'identical' | 'diverged'."""
+    url = f"https://api.github.com/repos/{repo}/compare/{base}...{head}"
+    return fetch_json(url).get("status")
+
+
+def update_yosys_slang_commit(workspace_dir, new_commit):
+    """Rewrite the povik/yosys-slang commit pin in a workspace .bzl file.
+
+    Walks ``workspace_dir`` for ``*.bzl`` files that fetch yosys-slang from
+    ``povik/yosys-slang.git`` and rewrites the single ``commit = "..."``
+    literal inside that call.  Scoped by the remote URL so unrelated commit
+    fields aren't touched.  No-op (returns False) if no such file exists
+    — bazel-orfs itself doesn't carry yosys-slang.
+    """
+    needle = "povik/yosys-slang.git"
+    for root, _dirs, files in os.walk(workspace_dir):
+        rel = os.path.relpath(root, workspace_dir)
+        if rel != "." and any(
+            part.startswith(".") or part.startswith("bazel-")
+            for part in rel.split(os.sep)
+        ):
+            continue
+        for fname in files:
+            if not fname.endswith(".bzl"):
+                continue
+            fpath = os.path.join(root, fname)
+            try:
+                with open(fpath) as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            if needle not in text:
+                continue
+            new_text, n = re.subn(
+                r'(commit\s*=\s*")[^"]*(")',
+                rf"\g<1>{new_commit}\2",
+                text,
+                count=1,
+            )
+            if n:
+                with open(fpath, "w") as fh:
+                    fh.write(new_text)
+                return True
+    return False
 
 
 def bump(
     module_file,
     fetch_commit_fn=fetch_latest_commit,
-    fetch_release_fn=fetch_latest_github_release,
-    fetch_tag_commit_fn=fetch_tag_commit,
     fetch_integrity_fn=compute_integrity,
+    fetch_orfs_tool_sha_fn=fetch_orfs_tool_sha,
+    fetch_compare_status_fn=fetch_compare_status,
     workspace_dir=None,
+    head_tools=None,
 ):
     """Main bump orchestrator.
 
-    Implements the project-type matrix:
-        Project      bazel-orfs  OpenROAD  ORFS     yosys
-                      commit      commit   commit   release
-        bazel-orfs   skip(self)  yes       yes      yes
-        OpenROAD     yes         skip      skip     skip
-        downstream   yes         if present skip    skip
+    Versions for yosys / openroad / yosys-slang come from ORFS's tools/
+    submodules at the just-bumped ORFS master HEAD.  yosys-slang is gated
+    against ``YOSYS_SLANG_MIN_COMMIT`` so we never regress past the floor
+    when ORFS lags upstream.  ``head_tools`` (set of tool names) forces
+    individual tools to chase upstream HEAD instead — escape hatch for
+    debugging against an older ORFS pin.
+
+    Project-type matrix (for the bazel-orfs / orfs commits proper):
+        Project      bazel-orfs  ORFS
+        bazel-orfs   skip(self)  yes
+        OpenROAD     yes         skip
+        downstream   yes         yes
     """
+    if head_tools is None:
+        head_tools = set()
+
     with open(module_file) as f:
         content = f.read()
 
@@ -583,27 +661,18 @@ def bump(
         if workspace_dir:
             copy_patches(bazel_orfs_dir, workspace_dir)
 
-    # --- Update OpenROAD commit (skip for OpenROAD itself) ---
-    openroad_commit = fetch_commit_fn("The-OpenROAD-Project/OpenROAD", "master")
-
+    # --- Update ORFS commit (skip for OpenROAD itself) ---
+    # bazel-orfs and downstream both follow ORFS master; downstream's tool
+    # overrides (yosys/openroad/yosys-slang below) are then resolved at the
+    # new ORFS commit so the whole stack moves coherently.
+    orfs_commit = None
     if project != "openroad":
-        content = update_git_override_commit(content, "openroad", openroad_commit)
-        updated_modules.append(f"openroad -> {openroad_commit[:12]}")
-
-    # --- Update ORFS commit ---
-    # For bazel-orfs itself: bump to latest ORFS.
-    # For downstream: ORFS commit is pinned by bazel-orfs (patches must match),
-    # so only update if the override was already present (user manages their own).
-    orfs_repo = "The-OpenROAD-Project/OpenROAD-flow-scripts"
-    orfs_commit = fetch_commit_fn(orfs_repo, "master")
-    if project == "bazel-orfs":
-        # Dispatch on which override style ORFS uses.  archive_override is
-        # required when fetching ORFS via git is blocked (e.g. inside the
-        # maintainers org); git_override is the historical default.
-        if find_archive_override_block(content, "orfs"):
-            integrity = fetch_integrity_fn(github_archive_url(orfs_repo, orfs_commit))
+        orfs_commit = fetch_commit_fn(ORFS_REPO, "master")
+        if project == "bazel-orfs" and find_archive_override_block(content, "orfs"):
+            # bazel-orfs's archive_override path needs an SRI integrity refresh.
+            integrity = fetch_integrity_fn(github_archive_url(ORFS_REPO, orfs_commit))
             content = update_archive_override(
-                content, "orfs", orfs_repo, orfs_commit, integrity
+                content, "orfs", ORFS_REPO, orfs_commit, integrity
             )
         else:
             content = update_git_override_commit(content, "orfs", orfs_commit)
@@ -615,15 +684,42 @@ def bump(
         content = update_git_override_commit(content, "qt-bazel", qt_commit)
         updated_modules.append(f"qt-bazel -> {qt_commit[:12]}")
 
-    # --- Update yosys release (bazel-orfs only) ---
-    if project == "bazel-orfs":
-        yosys_tag = fetch_release_fn("YosysHQ/yosys")
-        yosys_commit = fetch_tag_commit_fn("YosysHQ/yosys", yosys_tag)
-        if workspace_dir:
-            ext_file = os.path.join(workspace_dir, "extension.bzl")
-            if os.path.exists(ext_file):
-                update_yosys_build_bzl(ext_file, yosys_commit)
-                updated_modules.append(f"yosys -> {yosys_tag} ({yosys_commit[:12]})")
+    # --- Update EDA tools from ORFS tools/ (yosys, openroad, yosys-slang) ---
+    if orfs_commit is not None:
+        for tool, (module_name, upstream_repo) in ORFS_TOOLS.items():
+            if module_name in head_tools:
+                # --head=<module_name> bypasses ORFS entirely.
+                upstream_branch = (
+                    "main" if upstream_repo.startswith("povik/") else "master"
+                )
+                sha = fetch_commit_fn(upstream_repo, upstream_branch)
+                source = f"HEAD of {upstream_repo}"
+            else:
+                orfs_sha = fetch_orfs_tool_sha_fn(orfs_commit, tool)
+                if module_name == "yosys-slang":
+                    # Gate against the hardcoded floor: if ORFS's pin is at-or-
+                    # past the floor, follow ORFS; otherwise hold at the floor.
+                    status = fetch_compare_status_fn(
+                        upstream_repo, YOSYS_SLANG_MIN_COMMIT, orfs_sha
+                    )
+                    if status in ("ahead", "identical"):
+                        sha = orfs_sha
+                        source = f"ORFS tools/{tool}"
+                    else:
+                        sha = YOSYS_SLANG_MIN_COMMIT
+                        source = f"yosys-slang floor (ORFS {status})"
+                else:
+                    sha = orfs_sha
+                    source = f"ORFS tools/{tool}"
+
+            if module_name == "yosys-slang":
+                if workspace_dir and update_yosys_slang_commit(workspace_dir, sha):
+                    updated_modules.append(f"{module_name} -> {sha[:12]} ({source})")
+            else:
+                new_content = update_git_override_commit(content, module_name, sha)
+                if new_content != content:
+                    content = new_content
+                    updated_modules.append(f"{module_name} -> {sha[:12]} ({source})")
 
     with open(module_file, "w") as f:
         f.write(content)
@@ -655,6 +751,9 @@ def run_mod_tidy(workspace_dir):
         sys.exit(result.returncode)
 
 
+_HEAD_TOOLS = {module_name for module_name, _ in ORFS_TOOLS.values()}
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Bump bazel-orfs and dependency versions"
@@ -667,10 +766,22 @@ def main():
         ),
         help="Path to MODULE.bazel",
     )
+    parser.add_argument(
+        "--head",
+        action="append",
+        default=[],
+        choices=sorted(_HEAD_TOOLS),
+        metavar="TOOL",
+        help=(
+            "Pin TOOL to its upstream HEAD instead of the ORFS-tools-pinned "
+            "sha. Repeatable. Useful when debugging against a fix that ORFS "
+            "hasn't picked up yet."
+        ),
+    )
     args = parser.parse_args()
 
     workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY", ".")
-    bump(args.module_file, workspace_dir=workspace)
+    bump(args.module_file, workspace_dir=workspace, head_tools=set(args.head))
     run_mod_tidy(workspace)
 
 

--- a/test/bump/bump_test.py
+++ b/test/bump/bump_test.py
@@ -16,8 +16,9 @@ import bump
 BAZEL_ORFS_COMMIT = "new_bazel_orfs_aaa111"
 OPENROAD_COMMIT = "new_openroad_bbb222"
 ORFS_COMMIT = "new_orfs_ccc333"
-YOSYS_TAG = "v0.99"
-YOSYS_TAG_COMMIT = "new_yosys_ddd444"
+YOSYS_TOOLS_COMMIT = "new_yosys_ddd444"
+YOSYS_SLANG_TOOLS_COMMIT = "new_yosys_slang_eee555"
+UPSTREAM_HEAD_COMMIT = "upstream_head_fff666"
 MOCK_INTEGRITY = "sha256-MOCKMOCKMOCKMOCKMOCKMOCKMOCKMOCKMOCKMOCKMOCK="
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
@@ -28,22 +29,38 @@ def mock_fetch_commit(repo, branch):
         return BAZEL_ORFS_COMMIT
     if "OpenROAD-flow-scripts" in repo:
         return ORFS_COMMIT
-    return OPENROAD_COMMIT
+    # --head=<tool> resolves to upstream HEAD for any of yosys/openroad/yosys-slang.
+    return UPSTREAM_HEAD_COMMIT
 
 
-def mock_fetch_release(_repo):
-    return YOSYS_TAG
+def mock_fetch_orfs_tool_sha(_orfs_commit, tool):
+    return {
+        "yosys": YOSYS_TOOLS_COMMIT,
+        "OpenROAD": OPENROAD_COMMIT,
+        "yosys-slang": YOSYS_SLANG_TOOLS_COMMIT,
+    }[tool]
 
 
-def mock_fetch_tag_commit(_repo, _tag):
-    return YOSYS_TAG_COMMIT
+def mock_fetch_compare_status_ahead(_repo, _base, _head):
+    """ORFS is at-or-past the floor — follow ORFS."""
+    return "identical"
+
+
+def mock_fetch_compare_status_behind(_repo, _base, _head):
+    """ORFS lags the floor — hold at the floor."""
+    return "behind"
 
 
 def mock_fetch_integrity(_url):
     return MOCK_INTEGRITY
 
 
-def apply_bump(fixture_name, workspace_dir=None):
+def apply_bump(
+    fixture_name,
+    workspace_dir=None,
+    compare_status_fn=mock_fetch_compare_status_ahead,
+    head_tools=None,
+):
     """Copy a fixture, run bump on it, return the result content."""
     src = os.path.join(FIXTURES_DIR, fixture_name)
     tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".MODULE.bazel", delete=False)
@@ -53,10 +70,11 @@ def apply_bump(fixture_name, workspace_dir=None):
     bump.bump(
         tmp.name,
         fetch_commit_fn=mock_fetch_commit,
-        fetch_release_fn=mock_fetch_release,
-        fetch_tag_commit_fn=mock_fetch_tag_commit,
         fetch_integrity_fn=mock_fetch_integrity,
+        fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+        fetch_compare_status_fn=compare_status_fn,
         workspace_dir=workspace_dir,
+        head_tools=head_tools,
     )
 
     with open(tmp.name) as f:
@@ -162,11 +180,18 @@ class TestDownstreamWithSubmodules(unittest.TestCase):
         self.assertIn('strip_prefix = "verilog"', self.content)
 
 
-def _apply_bump_with_workspace(fixture_name, build_files):
+def _apply_bump_with_workspace(
+    fixture_name,
+    build_files,
+    compare_status_fn=mock_fetch_compare_status_ahead,
+    head_tools=None,
+):
     """Copy a fixture into a temp workspace with the given BUILD files.
 
-    build_files is a dict of relpath -> content.  Returns the resulting
-    MODULE.bazel content.
+    build_files is a dict of relpath -> content.  Returns (MODULE.bazel
+    content, workspace dir).  Caller is responsible for cleanup if it
+    needs to read more files; this helper cleans up only on the no-need
+    paths via the simpler `_apply_bump_in_workspace` below.
     """
     tmpdir = tempfile.mkdtemp()
     try:
@@ -181,10 +206,11 @@ def _apply_bump_with_workspace(fixture_name, build_files):
         bump.bump(
             module_file,
             fetch_commit_fn=mock_fetch_commit,
-            fetch_release_fn=mock_fetch_release,
-            fetch_tag_commit_fn=mock_fetch_tag_commit,
             fetch_integrity_fn=mock_fetch_integrity,
+            fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+            fetch_compare_status_fn=compare_status_fn,
             workspace_dir=tmpdir,
+            head_tools=head_tools,
         )
         with open(module_file) as f:
             return f.read()
@@ -277,44 +303,6 @@ class TestFindBazelOrfsSubmodules(unittest.TestCase):
             'git_override(\n    module_name = "bazel-orfs",\n    commit = "x",\n)\n'
         )
         self.assertEqual(bump.find_bazel_orfs_submodules(content), [])
-
-
-class TestBazelOrfsYosysUpdate(unittest.TestCase):
-    """bazel-orfs project updates yosys commit in extension.bzl."""
-
-    def test_yosys_commit_updated_in_extension(self):
-        tmpdir = tempfile.mkdtemp()
-        try:
-            main_file = os.path.join(tmpdir, "MODULE.bazel")
-            shutil.copy2(
-                os.path.join(FIXTURES_DIR, "self.MODULE.bazel"),
-                main_file,
-            )
-
-            ext_file = os.path.join(tmpdir, "extension.bzl")
-            with open(ext_file, "w") as f:
-                f.write(
-                    "yosys_build(\n"
-                    '    name = "yosys",\n'
-                    '    yosys_commit = "old_yosys_commit",\n'
-                    ")\n"
-                )
-
-            bump.bump(
-                main_file,
-                fetch_commit_fn=mock_fetch_commit,
-                fetch_release_fn=mock_fetch_release,
-                fetch_tag_commit_fn=mock_fetch_tag_commit,
-                workspace_dir=tmpdir,
-            )
-
-            with open(ext_file) as f:
-                ext_content = f.read()
-
-            self.assertIn(YOSYS_TAG_COMMIT, ext_content)
-            self.assertNotIn("old_yosys_commit", ext_content)
-        finally:
-            shutil.rmtree(tmpdir)
 
 
 class TestDetectProject(unittest.TestCase):
@@ -506,8 +494,8 @@ class TestSubmodulesDoubleUpdate(unittest.TestCase):
 
         kwargs = dict(
             fetch_commit_fn=mock_fetch_commit,
-            fetch_release_fn=mock_fetch_release,
-            fetch_tag_commit_fn=mock_fetch_tag_commit,
+            fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+            fetch_compare_status_fn=mock_fetch_compare_status_ahead,
         )
         bump.bump(tmp.name, **kwargs)
         with open(tmp.name) as f:
@@ -537,8 +525,8 @@ class TestNetworkErrorHandling(unittest.TestCase):
                 bump.bump(
                     tmp.name,
                     fetch_commit_fn=bad_commit,
-                    fetch_release_fn=mock_fetch_release,
-                    fetch_tag_commit_fn=mock_fetch_tag_commit,
+                    fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+                    fetch_compare_status_fn=mock_fetch_compare_status_ahead,
                 )
             finally:
                 os.unlink(tmp.name)
@@ -604,8 +592,8 @@ class TestArchiveOverrideDoubleBumpIdempotent(unittest.TestCase):
 
         kwargs = dict(
             fetch_commit_fn=mock_fetch_commit,
-            fetch_release_fn=mock_fetch_release,
-            fetch_tag_commit_fn=mock_fetch_tag_commit,
+            fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+            fetch_compare_status_fn=mock_fetch_compare_status_ahead,
             fetch_integrity_fn=mock_fetch_integrity,
         )
         bump.bump(tmp.name, **kwargs)
@@ -701,6 +689,178 @@ class TestFindArchiveOverrideBlock(unittest.TestCase):
     def test_returns_none_when_absent(self):
         content = 'git_override(\n    module_name = "orfs",\n    commit = "x",\n)'
         self.assertIsNone(bump.find_archive_override_block(content, "orfs"))
+
+
+class TestDownstreamOrfsToolsFlow(unittest.TestCase):
+    """Downstream: yosys/openroad commits come from ORFS tools/ submodules."""
+
+    def setUp(self):
+        self.content = apply_bump("downstream.MODULE.bazel")
+
+    def test_orfs_commit_updated(self):
+        # New: downstream bumps ORFS too (used to be bazel-orfs-project only).
+        self.assertIn(ORFS_COMMIT, self.content)
+        self.assertNotIn("old_orfs_commit", self.content)
+
+    def test_yosys_pinned_to_orfs_tools_sha(self):
+        self.assertIn(YOSYS_TOOLS_COMMIT, self.content)
+        self.assertNotIn("old_yosys_commit", self.content)
+
+    def test_openroad_pinned_to_orfs_tools_sha(self):
+        self.assertIn(OPENROAD_COMMIT, self.content)
+        self.assertNotIn("old_openroad_commit", self.content)
+
+
+class TestYosysSlangFloorGate(unittest.TestCase):
+    """yosys-slang follows ORFS unless ORFS lags YOSYS_SLANG_MIN_COMMIT."""
+
+    def _run(self, compare_status_fn):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            module_file = os.path.join(tmpdir, "MODULE.bazel")
+            shutil.copy2(
+                os.path.join(FIXTURES_DIR, "downstream.MODULE.bazel"), module_file
+            )
+            slang_path = os.path.join(tmpdir, "yosys_slang.bzl")
+            with open(slang_path, "w") as f:
+                f.write(
+                    'load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")\n'
+                    "\n"
+                    "def _impl(_ctx):\n"
+                    "    new_git_repository(\n"
+                    '        name = "yosys-slang",\n'
+                    '        remote = "https://github.com/povik/yosys-slang.git",\n'
+                    '        commit = "old_yosys_slang_commit",\n'
+                    "    )\n"
+                )
+            bump.bump(
+                module_file,
+                fetch_commit_fn=mock_fetch_commit,
+                fetch_integrity_fn=mock_fetch_integrity,
+                fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+                fetch_compare_status_fn=compare_status_fn,
+                workspace_dir=tmpdir,
+            )
+            with open(slang_path) as f:
+                return f.read()
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_orfs_at_or_past_floor_uses_orfs_pin(self):
+        slang = self._run(mock_fetch_compare_status_ahead)
+        self.assertIn(YOSYS_SLANG_TOOLS_COMMIT, slang)
+        self.assertNotIn(bump.YOSYS_SLANG_MIN_COMMIT, slang)
+        self.assertNotIn("old_yosys_slang_commit", slang)
+
+    def test_orfs_lags_floor_holds_at_floor(self):
+        slang = self._run(mock_fetch_compare_status_behind)
+        self.assertIn(bump.YOSYS_SLANG_MIN_COMMIT, slang)
+        self.assertNotIn(YOSYS_SLANG_TOOLS_COMMIT, slang)
+
+
+class TestHeadFlagOverrides(unittest.TestCase):
+    """--head=<tool> bypasses ORFS-tools sha and (for yosys-slang) the floor."""
+
+    def test_head_yosys_uses_upstream_head(self):
+        content = apply_bump(
+            "downstream.MODULE.bazel",
+            head_tools={"yosys"},
+        )
+        self.assertIn(UPSTREAM_HEAD_COMMIT, content)
+        # The ORFS-tools sha for yosys must NOT appear (was bypassed).
+        # OpenROAD's ORFS-tools sha still does — only yosys was --head'd.
+        block = re.search(
+            r'git_override\(\s*module_name\s*=\s*"yosys".*?\)',
+            content,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(block)
+        self.assertIn(UPSTREAM_HEAD_COMMIT, block.group())
+        self.assertNotIn(YOSYS_TOOLS_COMMIT, block.group())
+
+    def test_head_openroad_uses_upstream_head(self):
+        content = apply_bump(
+            "downstream.MODULE.bazel",
+            head_tools={"openroad"},
+        )
+        block = re.search(
+            r'git_override\(\s*module_name\s*=\s*"openroad".*?\)',
+            content,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(block)
+        self.assertIn(UPSTREAM_HEAD_COMMIT, block.group())
+        self.assertNotIn(OPENROAD_COMMIT, block.group())
+
+    def test_head_yosys_slang_bypasses_floor(self):
+        # Even with ORFS lagging (would otherwise hold at floor), --head wins.
+        tmpdir = tempfile.mkdtemp()
+        try:
+            module_file = os.path.join(tmpdir, "MODULE.bazel")
+            shutil.copy2(
+                os.path.join(FIXTURES_DIR, "downstream.MODULE.bazel"), module_file
+            )
+            slang_path = os.path.join(tmpdir, "yosys_slang.bzl")
+            with open(slang_path, "w") as f:
+                f.write(
+                    "new_git_repository(\n"
+                    '    remote = "https://github.com/povik/yosys-slang.git",\n'
+                    '    commit = "old",\n'
+                    ")\n"
+                )
+            bump.bump(
+                module_file,
+                fetch_commit_fn=mock_fetch_commit,
+                fetch_integrity_fn=mock_fetch_integrity,
+                fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+                fetch_compare_status_fn=mock_fetch_compare_status_behind,
+                workspace_dir=tmpdir,
+                head_tools={"yosys-slang"},
+            )
+            with open(slang_path) as f:
+                slang = f.read()
+            self.assertIn(UPSTREAM_HEAD_COMMIT, slang)
+            self.assertNotIn(bump.YOSYS_SLANG_MIN_COMMIT, slang)
+            self.assertNotIn(YOSYS_SLANG_TOOLS_COMMIT, slang)
+        finally:
+            shutil.rmtree(tmpdir)
+
+
+class TestUpdateYosysSlangCommit(unittest.TestCase):
+    """update_yosys_slang_commit rewrites the right commit literal."""
+
+    def test_rewrites_when_remote_matches(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "yosys_slang.bzl"), "w") as f:
+                f.write(
+                    "new_git_repository(\n"
+                    '    remote = "https://github.com/povik/yosys-slang.git",\n'
+                    '    commit = "old_slang_commit",\n'
+                    ")\n"
+                )
+            self.assertTrue(bump.update_yosys_slang_commit(tmpdir, "new_slang"))
+            with open(os.path.join(tmpdir, "yosys_slang.bzl")) as f:
+                self.assertIn('commit = "new_slang"', f.read())
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_noop_when_no_matching_file(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            # An unrelated .bzl file with a commit literal — must not be touched.
+            with open(os.path.join(tmpdir, "other.bzl"), "w") as f:
+                f.write(
+                    "git_repository(\n"
+                    '    remote = "https://github.com/foo/bar.git",\n'
+                    '    commit = "keep_this",\n'
+                    ")\n"
+                )
+            self.assertFalse(bump.update_yosys_slang_commit(tmpdir, "new_slang"))
+            with open(os.path.join(tmpdir, "other.bzl")) as f:
+                self.assertIn('commit = "keep_this"', f.read())
+        finally:
+            shutil.rmtree(tmpdir)
 
 
 if __name__ == "__main__":

--- a/test/bump/fixtures/downstream.MODULE.bazel
+++ b/test/bump/fixtures/downstream.MODULE.bazel
@@ -12,5 +12,26 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 
+bazel_dep(name = "orfs")
+git_override(
+    module_name = "orfs",
+    commit = "old_orfs_commit",
+    remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
+)
+
+bazel_dep(name = "yosys", version = "0.62.bcr.2")
+git_override(
+    module_name = "yosys",
+    commit = "old_yosys_commit",
+    remote = "https://github.com/YosysHQ/yosys.git",
+)
+
+bazel_dep(name = "openroad")
+git_override(
+    module_name = "openroad",
+    commit = "old_openroad_commit",
+    remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
+)
+
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
 orfs.default()


### PR DESCRIPTION
ORFS's tools/ directory pins each EDA tool as a git submodule, so its master HEAD is the source of truth for the versions we should run. Make the bumper read those submodule shas at the just-bumped ORFS commit and apply them to the consumer's git_override blocks:

- yosys git_override commit -> ORFS tools/yosys submodule sha
- openroad git_override commit -> ORFS tools/OpenROAD (previously chased The-OpenROAD-Project/OpenROAD master HEAD; that's a behavior change)
- yosys-slang commit pin in workspace yosys_slang.bzl -> gated against YOSYS_SLANG_MIN_COMMIT, a hardcoded floor that bumps as our build needs evolve. ORFS lags upstream povik/yosys-slang today; the gate holds at the floor until ORFS catches up, at which point the special case disappears on its own.

Downstream consumers now also get the ORFS commit bumped (used to be bazel-orfs-project only) so the whole stack moves coherently.

Add --head=<tool> (repeatable: yosys, openroad, yosys-slang) as an escape hatch for debugging against a fix that ORFS hasn't picked up yet. The flag bypasses both the ORFS-tools sha and the yosys-slang floor and pins straight to upstream HEAD.

Drop the dead update_yosys_build_bzl path: extension.bzl hasn't carried a yosys_commit field since the bazel-orfs ORFS-prebuilts simplification.