### PR TITLE
orfs_gds: declare 6_final.def, fix klayout under sandbox, honor klayout attr

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,6 +36,7 @@ archive_override(
     patch_strip = 1,
     patches = [
         "//patches:0036-fix-bazel-orfs-bazel_dep-non-dev-for-load-visibility.patch",
+        "//patches:0037-fix-generate_klayout_tech-drop-realpath.patch",
     ],
     strip_prefix = "OpenROAD-flow-scripts-ae34c73b7ddc382179dad3ac4653806cf6f81ee5",
     urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/ae34c73b7ddc382179dad3ac4653806cf6f81ee5.tar.gz"],

--- a/patches/0037-fix-generate_klayout_tech-drop-realpath.patch
+++ b/patches/0037-fix-generate_klayout_tech-drop-realpath.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Wed, 14 May 2026 09:00:00 +0200
+Subject: [PATCH] fix(generate_klayout_tech): drop realpath() — breaks Bazel
+ sandbox
+
+`os.path.realpath()` follows symlinks. Inside a Bazel sandbox, the
+`bazel-out/` tree is symlinked from the sandbox back to the bare
+execroot; `realpath` resolves through that symlink and yields the
+bare-execroot path, not the sandbox path.
+
+That alone doesn't matter for `os.path.relpath(a, b)` when both
+operands are realpath'd from the same sandbox — the relative result
+is unchanged. But the resulting `<lef-files>` path in the generated
+klayout.lyt is later resolved by klayout against the LYT file's
+location. Klayout opens the LYT (also through a symlink), resolves
+through to the bare execroot, and then looks for the sibling
+`klayout_tech.lef` at the bare-execroot path — where the in-flight
+file does not exist during action execution (only the sandbox copy
+does), so def2stream fails with errno=2.
+
+Fix: don't realpath. `os.path.relpath` produces the correct relative
+path from sandbox-relative inputs directly. Map files keep their
+absolute form via `abspath` for the unchanged-under-non-sandbox case.
+
+Signed-off-by: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+---
+ flow/util/generate_klayout_tech.py | 13 ++++++-------
+ 1 file changed, 6 insertions(+), 7 deletions(-)
+
+diff --git a/flow/util/generate_klayout_tech.py b/flow/util/generate_klayout_tech.py
+--- a/flow/util/generate_klayout_tech.py
++++ b/flow/util/generate_klayout_tech.py
+@@ -51,16 +51,15 @@ def generate_klayout_tech(
+     with open(template_lyt, "r") as f:
+         content = f.read()
+
+-    # Both modes use relative paths from reference_dir, matching the
+-    # original sed-based behavior which always uses realpath --relative-to.
+-    resolved_lefs = [
+-        os.path.relpath(os.path.realpath(f), os.path.realpath(reference_dir))
+-        for f in lef_files
+-    ]
++    # Compute relpath without realpath(): under a Bazel sandbox, bazel-out/
++    # entries are symlinks to the bare execroot; realpath follows them and
++    # makes the generated LYT reference files at the bare-execroot path,
++    # where in-flight outputs do not exist during action execution.
++    resolved_lefs = [os.path.relpath(f, reference_dir) for f in lef_files]
+
+     content = replace_lef_files(content, resolved_lefs)
+
+-    resolved_maps = [os.path.realpath(f) for f in map_files]
++    resolved_maps = [os.path.abspath(f) for f in map_files]
+     content = replace_map_files(content, resolved_maps)
+
+     with open(output_lyt, "w") as f:
+--
+2.51.0

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -40,10 +40,19 @@ def orfs_environment(ctx):
 def _executable_path(attr):
     return attr[DefaultInfo].files_to_run.executable.path
 
+def _klayout_attr(ctx):
+    """Resolve which klayout binary the action should invoke.
+
+    Honors a rule's public `klayout` attr (orfs_gds defines one) when set,
+    otherwise falls back to the private CONFIG_KLAYOUT-defaulted `_klayout`.
+    """
+    pub = getattr(ctx.attr, "klayout", None)
+    return pub if pub else ctx.attr._klayout
+
 def flow_environment(ctx):
     return {
         "FLOW_HOME": ctx.file._makefile.dirname,
-        "KLAYOUT_CMD": _executable_path(ctx.attr._klayout),
+        "KLAYOUT_CMD": _executable_path(_klayout_attr(ctx)),
         "OPENROAD_EXE": _executable_path(ctx.attr.openroad),
         "OPENSTA_EXE": _executable_path(ctx.attr.opensta),
     } | orfs_environment(ctx)
@@ -95,7 +104,7 @@ def flow_inputs(ctx):
         transitive = [
             _runfiles(
                 [
-                    ctx.attr._klayout,
+                    _klayout_attr(ctx),
                     ctx.attr._make,
                     ctx.attr.openroad,
                     ctx.attr.opensta,
@@ -203,7 +212,7 @@ def deps_inputs(ctx):
 def flow_substitutions(ctx):
     return {
         "${FLOW_HOME}": ctx.file._makefile.dirname,
-        "${KLAYOUT_PATH}": "./" + ctx.attr._klayout[DefaultInfo].files_to_run.executable.short_path,
+        "${KLAYOUT_PATH}": "./" + _klayout_attr(ctx)[DefaultInfo].files_to_run.executable.short_path,
         "${MAKEFILE_PATH}": ctx.file._makefile.path,
         "${MAKE_PATH}": "./" + ctx.executable._make.short_path,
         # OpenROAD uses //:openroad, //:opensta here and puts the binary in the pwd

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1888,6 +1888,7 @@ orfs_final = rule(
             "VSS.rpt",
         ],
         result_names = [
+            "6_final.def",
             "6_final.odb",
             "6_final.sdc",
             "6_final.spef",


### PR DESCRIPTION
…ut attr

Three fixes that surface when an `orfs_gds` target is wired onto a `final` stage and actually expected to produce a usable GDS:

1. `orfs_final` produced `6_final.def` but didn't declare it as an output. Anything that runs after `final` (orfs_gds, downstream def2stream invocations) finds the file missing in its sandbox. Declare it in `result_names` so it gets forwarded.

2. ORFS's `flow/util/generate_klayout_tech.py` uses `os.path.realpath()` on its `--lef-files` and `--reference-dir` inputs to compute the `<lef-files>` paths embedded in klayout.lyt. Under a Bazel sandbox, `bazel-out/` is symlinked back to the bare execroot; realpath follows the symlink, and the resulting LYT references files at the bare-execroot path. Klayout later resolves through that path and finds nothing — the in-flight outputs only exist at the sandbox path. Patched via patches/0037 to drop realpath; relpath alone produces the right relative path.

3. The public `klayout` attr on `orfs_gds` was dead code — the rule's docstring promised "Override to use a custom or mock klayout", but nothing in the action plumbing read it; the private `_klayout` (defaulted from CONFIG_KLAYOUT) was used everywhere. Now flow_environment / flow_inputs / flow_substitutions resolve through a helper that prefers the public attr when set.

No behavior change for existing callers (none of them set the public `klayout` attr or care about `6_final.def`), but
`orfs_gds(klayout = "@bazel-orfs//:klayout")` now actually exec's the host's klayout instead of the mock, and the resulting def2stream call finds its inputs.