### PR TITLE
orfs_design/orfs_flow: add user_sources= for design-private path hooks

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -171,6 +171,7 @@ def orfs_flow(
         verilog_files = [],
         macros = [],
         sources = {},
+        user_sources = {},
         stage_sources = {},
         stage_arguments = {},
         renamed_inputs = {},
@@ -213,6 +214,12 @@ def orfs_flow(
         validating against ORFS variables.yaml. Use for vars read only by user-supplied .tcl/.mk
         (e.g. ARRAY_COLS in a project's MACRO_PLACEMENT_TCL). Keys that collide with known ORFS
         variables are rejected — route those through 'arguments' instead.
+      user_sources: dictionary of project-specific source-typed (path-label) env vars to expose
+        to every stage without validating against ORFS variables.yaml. The path is still staged
+        into the sandbox like a normal source — only the variable name skips the validator.
+        Use for path hooks read only by user-supplied .tcl/.mk (e.g. an extra-SDC hook
+        source'd from the design's own io.tcl). Keys that collide with known ORFS variables
+        are rejected — route those through 'sources' instead.
       extra_arguments: dictionary keyed by ORFS stages with lists of .json argument file labels.
         These .json files are merged into the stage config, providing computed arguments
         that flow through OrfsInfo to subsequent stages.
@@ -269,6 +276,14 @@ def orfs_flow(
             ) +
             "Use arguments= for ORFS variables; reserve user_arguments= for project-specific env vars.",
         )
+    shadowed_srcs = sorted([k for k in user_sources if k in ALL_VARIABLE_TO_STAGES])
+    if shadowed_srcs:
+        fail(
+            "user_sources contains known ORFS variable(s): {shadowed}. ".format(
+                shadowed = ", ".join(shadowed_srcs),
+            ) +
+            "Use sources= for ORFS variables; reserve user_sources= for project-specific path hooks.",
+        )
     if abstract_stage and last_stage:
         fail("abstract_stage and last_stage are mutually exclusive")
     if variant == "base":
@@ -281,7 +296,7 @@ def orfs_flow(
         top = top,
         verilog_files = verilog_files,
         macros = macros,
-        sources = sources,
+        sources = sources | user_sources,
         stage_sources = stage_sources,
         stage_arguments = stage_arguments,
         renamed_inputs = renamed_inputs,
@@ -319,7 +334,7 @@ def orfs_flow(
         top = top,
         verilog_files = verilog_files,
         macros = macros,
-        sources = sources,
+        sources = sources | user_sources,
         stage_sources = stage_sources,
         stage_arguments = stage_arguments,
         renamed_inputs = {},

--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -47,7 +47,7 @@ def _convert_sources(sources, pkg):
             result[var] = converted
     return result
 
-def orfs_design(name = None, config = "config.mk", platform = None, design = None, designs = None, mock_openroad = None, mock_yosys = None, user_arguments = [], local_arguments = []):  # buildifier: disable=unused-variable
+def orfs_design(name = None, config = "config.mk", platform = None, design = None, designs = None, mock_openroad = None, mock_yosys = None, user_arguments = [], user_sources = [], local_arguments = []):  # buildifier: disable=unused-variable
     """Create orfs_flow() targets for a design based on its parsed config.mk.
 
     Usage:
@@ -79,6 +79,13 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
             Routed through orfs_flow(user_arguments=...) to bypass the
             variables.yaml validator instead of being checked as known
             ORFS arguments.
+        user_sources: List of source-typed variable names (vars in
+            SOURCE_VARS) that are project-specific path hooks read only
+            by user-supplied .tcl/.mk, not by ORFS itself (e.g. a
+            per-design extra-SDC hook source'd from the design's own
+            io.tcl). Routed through orfs_flow(user_sources=...) so the
+            file is still staged into the sandbox, but the variable
+            name bypasses the variables.yaml validator.
         local_arguments: List of variable names that are only used for
             $(VAR) expansion within the same config.mk and are not read
             by ORFS or by any user .tcl/.mk (e.g. VERILOG_FILES_BLACKBOX,
@@ -195,6 +202,15 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
         if var in arguments:
             user_args[var] = arguments.pop(var)
 
+    # Same idea for source-typed (path-label) project-specific knobs:
+    # variables that are in SOURCE_VARS (so the parser staged the path
+    # as a label) but are read only by user .tcl/.mk and have no
+    # variables.yaml entry.
+    user_srcs = {}
+    for var in user_sources:
+        if var in sources:
+            user_srcs[var] = sources.pop(var)
+
     # Default SYNTH_NUM_PARTITIONS to a static value so that the action graph
     # is identical across machines and remote cache hits are possible.  Users
     # who prefer local parallelism over caching can pass NUM_CPUS explicitly.
@@ -213,6 +229,7 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
         arguments = arguments,
         user_arguments = user_args,
         sources = sources,
+        user_sources = user_srcs,
         macros = macros if macros else [],
         stage_data = {"synth": extra_data} if extra_data else {},
         tags = tags,


### PR DESCRIPTION
Symmetric to user_arguments=, but for source-typed (path-label) vars: a variable that the config_mk_parser classifies as a SOURCE_VAR (path staged into the sandbox via _map_source_file) but that is read only by user-supplied .tcl/.mk and has no entry in ORFS variables.yaml.

Today such a variable bumps into check_variables(sources.keys()) in orfs_flow and fails the load phase, even though the file itself is staged correctly. user_arguments= doesn't help because it pops from arguments, not sources.

The motivating case is SDC_FILE_EXTRA — set by
flow/designs/asap7/mock-cpu/config.mk and source'd from that design's io.tcl, with no ORFS-side consumer. SDC_FILE_EXTRA is in this file's SOURCE_VARS list, so its value is path-staged; making it work without declaring it as a global ORFS variable is what user_sources= is for.

API:
- orfs_design() gains user_sources=[VAR, ...]. Each named var is popped from sources and forwarded as orfs_flow(user_sources={...}).
- orfs_flow() gains user_sources={VAR: [label, ...]}. Merged into sources before _orfs_pass so files are still staged, but the key set skips check_variables. Same shadowing guard as user_arguments=: collision with a known ORFS variable fails fast.

Mirrors user_arguments= in both surface and intent.