### PR TITLE
make-yosys-netlist: three fixes so :_final re-synth via SYNTH_NETLIST_FILES works

### DIFF
--- a/make-yosys-netlist.sh
+++ b/make-yosys-netlist.sh
@@ -114,7 +114,19 @@ echo "==> Re-running bazel flow with make's netlist injected via SYNTH_NETLIST_F
 # bazel-orfs supports positional KEY=VAL args after `bazel run` (see
 # bazel-orfs/README.md:354-368).  The override propagates to make on
 # the command line where it wins over the design config.
-bazelisk run "$FINAL_TARGET" -- SYNTH_NETLIST_FILES="$MAKE_NETLIST"
+#
+# Also override VERILOG_FILES= to clear it. When SYNTH_NETLIST_FILES is
+# set, synth_preamble.tcl just `cp -p`s the netlist and exits without
+# reading any .v file. But flow/Makefile's
+#   YOSYS_DEPENDENCIES = $(LIB_FILES) ... $(VERILOG_FILES) ...
+# is unconditional, so make insists the .v files exist as targets.
+# They aren't in _final's runfiles (synth is the upstream-stage that
+# bundled them), so make errors with "No rule to make target ...uart.v".
+# Empty VERILOG_FILES sidesteps that — yosys doesn't need them in this
+# code path anyway.
+bazelisk run "$FINAL_TARGET" -- \
+    SYNTH_NETLIST_FILES="$MAKE_NETLIST" \
+    VERILOG_FILES=
 
 # The second run wrote fresh .odb to the same bazel-bin path.
 BAZEL_OVERLAY="$BAZEL_NATURAL"

--- a/make.tpl
+++ b/make.tpl
@@ -3,7 +3,17 @@ set -e
 
 if [ -z "$FLOW_HOME" ]; then
   export MAKE_PATH="${MAKE_PATH}"
-  export YOSYS_EXE="${YOSYS_PATH}"
+  # Yosys-stage runners pass yosys_substitutions(ctx) and get a concrete
+  # ${YOSYS_PATH} substituted in. Openroad-stage runners (orfs_final etc.)
+  # use only flow_substitutions(ctx) and leave ${YOSYS_PATH} as a literal,
+  # which the shell then expands to empty. Only export YOSYS_EXE when
+  # we actually got a path; otherwise fall back to the caller's env so
+  # `bazel run :_final -- SYNTH_NETLIST_FILES=...` (used by
+  # //:make-yosys-netlist for re-synth) can supply yosys via YOSYS_EXE
+  # from the user shell.
+  if [ -n "${YOSYS_PATH}" ]; then
+    export YOSYS_EXE="${YOSYS_PATH}"
+  fi
   export OPENROAD_EXE="${OPENROAD_PATH}"
   export OPENSTA_EXE="${OPENSTA_PATH}"
   export KLAYOUT_CMD="${KLAYOUT_PATH}"

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -171,6 +171,7 @@ def orfs_flow(
         verilog_files = [],
         macros = [],
         sources = {},
+        user_sources = {},
         stage_sources = {},
         stage_arguments = {},
         renamed_inputs = {},
@@ -213,6 +214,12 @@ def orfs_flow(
         validating against ORFS variables.yaml. Use for vars read only by user-supplied .tcl/.mk
         (e.g. ARRAY_COLS in a project's MACRO_PLACEMENT_TCL). Keys that collide with known ORFS
         variables are rejected — route those through 'arguments' instead.
+      user_sources: dictionary of project-specific source-typed (path-label) env vars to expose
+        to every stage without validating against ORFS variables.yaml. The path is still staged
+        into the sandbox like a normal source — only the variable name skips the validator.
+        Use for path hooks read only by user-supplied .tcl/.mk (e.g. an extra-SDC hook
+        source'd from the design's own io.tcl). Keys that collide with known ORFS variables
+        are rejected — route those through 'sources' instead.
       extra_arguments: dictionary keyed by ORFS stages with lists of .json argument file labels.
         These .json files are merged into the stage config, providing computed arguments
         that flow through OrfsInfo to subsequent stages.
@@ -269,6 +276,14 @@ def orfs_flow(
             ) +
             "Use arguments= for ORFS variables; reserve user_arguments= for project-specific env vars.",
         )
+    shadowed_srcs = sorted([k for k in user_sources if k in ALL_VARIABLE_TO_STAGES])
+    if shadowed_srcs:
+        fail(
+            "user_sources contains known ORFS variable(s): {shadowed}. ".format(
+                shadowed = ", ".join(shadowed_srcs),
+            ) +
+            "Use sources= for ORFS variables; reserve user_sources= for project-specific path hooks.",
+        )
     if abstract_stage and last_stage:
         fail("abstract_stage and last_stage are mutually exclusive")
     if variant == "base":
@@ -281,7 +296,7 @@ def orfs_flow(
         top = top,
         verilog_files = verilog_files,
         macros = macros,
-        sources = sources,
+        sources = sources | user_sources,
         stage_sources = stage_sources,
         stage_arguments = stage_arguments,
         renamed_inputs = renamed_inputs,
@@ -319,7 +334,7 @@ def orfs_flow(
         top = top,
         verilog_files = verilog_files,
         macros = macros,
-        sources = sources,
+        sources = sources | user_sources,
         stage_sources = stage_sources,
         stage_arguments = stage_arguments,
         renamed_inputs = {},

--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -47,7 +47,7 @@ def _convert_sources(sources, pkg):
             result[var] = converted
     return result
 
-def orfs_design(name = None, config = "config.mk", platform = None, design = None, designs = None, mock_openroad = None, mock_yosys = None, user_arguments = [], local_arguments = []):  # buildifier: disable=unused-variable
+def orfs_design(name = None, config = "config.mk", platform = None, design = None, designs = None, mock_openroad = None, mock_yosys = None, user_arguments = [], user_sources = [], local_arguments = []):  # buildifier: disable=unused-variable
     """Create orfs_flow() targets for a design based on its parsed config.mk.
 
     Usage:
@@ -79,6 +79,13 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
             Routed through orfs_flow(user_arguments=...) to bypass the
             variables.yaml validator instead of being checked as known
             ORFS arguments.
+        user_sources: List of source-typed variable names (vars in
+            SOURCE_VARS) that are project-specific path hooks read only
+            by user-supplied .tcl/.mk, not by ORFS itself (e.g. a
+            per-design extra-SDC hook source'd from the design's own
+            io.tcl). Routed through orfs_flow(user_sources=...) so the
+            file is still staged into the sandbox, but the variable
+            name bypasses the variables.yaml validator.
         local_arguments: List of variable names that are only used for
             $(VAR) expansion within the same config.mk and are not read
             by ORFS or by any user .tcl/.mk (e.g. VERILOG_FILES_BLACKBOX,
@@ -195,6 +202,15 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
         if var in arguments:
             user_args[var] = arguments.pop(var)
 
+    # Same idea for source-typed (path-label) project-specific knobs:
+    # variables that are in SOURCE_VARS (so the parser staged the path
+    # as a label) but are read only by user .tcl/.mk and have no
+    # variables.yaml entry.
+    user_srcs = {}
+    for var in user_sources:
+        if var in sources:
+            user_srcs[var] = sources.pop(var)
+
     # Default SYNTH_NUM_PARTITIONS to a static value so that the action graph
     # is identical across machines and remote cache hits are possible.  Users
     # who prefer local parallelism over caching can pass NUM_CPUS explicitly.
@@ -213,6 +229,7 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
         arguments = arguments,
         user_arguments = user_args,
         sources = sources,
+        user_sources = user_srcs,
         macros = macros if macros else [],
         stage_data = {"synth": extra_data} if extra_data else {},
         tags = tags,

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1146,6 +1146,21 @@ def _yosys_impl(ctx):
 
     outputs = [canon_output, variables] + synth_outputs.values()
 
+    # Write synth's data_arguments to a JSON so downstream stages
+    # inherit synth-time variables (SDC_FILE, VERILOG_FILES, SYNTH_*)
+    # via OrfsInfo.arguments propagation. Without this, `bazel run :_final
+    # -- SYNTH_NETLIST_FILES=...` (used by //:make-yosys-netlist to feed
+    # make's netlist into the bazel flow) fails inside the resulting
+    # re-synth: synth_preamble.tcl reads $::env(SDC_FILE) but _final's
+    # args.mk only contains openroad-stage data_arguments.
+    synth_args_json = declare_artifact(ctx, "results", "1_synth.args.json")
+    ctx.actions.write(
+        output = synth_args_json,
+        content = json.encode(
+            data_arguments(ctx) | verilog_arguments(ctx.files.verilog_files),
+        ),
+    )
+
     config_short = declare_artifact(ctx, "results", "1_synth.short.mk")
     ctx.actions.write(
         output = config_short,
@@ -1270,7 +1285,7 @@ def _yosys_impl(ctx):
                     if (dep[OrfsInfo].lib_pre_layout or dep[OrfsInfo].lib)
                 ],
             ),
-            arguments = depset([]),
+            arguments = depset([synth_args_json]),
         ),
         ctx.attr.pdk[PdkInfo],
         TopInfo(


### PR DESCRIPTION
## Summary

Three patches that together let \`@bazel-orfs//:make-yosys-netlist\`'s phase-3
re-synth (\`bazel run :_final -- SYNTH_NETLIST_FILES=\$MAKE_NETLIST\`) get past
the gates that block it on a normal openroad-stage runner. Each commit is a
standalone fix:

1. **\`make.tpl: guard export YOSYS_EXE when YOSYS_PATH unsubstituted\`** —
   openroad-stage runners are generated with \`flow_substitutions(ctx)\` only,
   which doesn't include \`\${YOSYS_PATH}\`. The literal survives into the
   generated script, the shell expands it to empty, and \`flow/Makefile\`'s
   \`check-yosys\` then trips on \`YOSYS_EXE=''\`. Guard the export so the
   runner only sets \`YOSYS_EXE\` when a concrete path was substituted in.

2. **\`make-yosys-netlist: clear VERILOG_FILES on the re-synth bazel run\`** —
   \`flow/Makefile\`'s \`do-yosys-canonicalize\` declares \`VERILOG_FILES\` as a
   make-target prerequisite unconditionally. Sub-block \`.v\` sources aren't
   staged into \`orfs_final\`'s runfiles, so make errors with
   \`No rule to make target …uart.v\` before \`synth_preamble.tcl\` runs.
   When \`SYNTH_NETLIST_FILES\` is set, the preamble \`cp -p\`s the netlist
   and exits without reading any \`.v\`, so passing an empty
   \`VERILOG_FILES=\` on the bazel-run command line sidesteps the check.

3. **\`orfs_synth_rule: propagate synth args via OrfsInfo.arguments\`** —
   the synth rule emitted \`arguments = depset([])\`, so synth-time vars
   (\`SDC_FILE\`, \`VERILOG_FILES\`, \`SYNTH_*\`) never made it into downstream
   stages' merged \`args.mk\`. \`bazel run :_final -- SYNTH_NETLIST_FILES=…\`
   then dies inside the canonicalize step with
   \`can't read \"::env(SDC_FILE)\": no such variable\`. Mirror the
   openroad-stage approach: write \`1_synth.args.json\` from \`data_arguments\`
   + \`verilog_arguments\`, propagate via \`OrfsInfo.arguments\`, and let the
   existing \`_merge_arguments.py\` fold it into downstream args.mk.

## Status

End-to-end phase-3 still doesn't complete because \`SDC_FILE\` resolves to a
source path (\`flow/designs/<plat>/<design>/constraint.sdc\`) that isn't in
\`orfs_final\`'s runfiles either — same structural gap as \`VERILOG_FILES\`,
but \`SDC_FILE\` is actually read by \`synth_preamble.tcl:17\` so the
\"clear it\" workaround doesn't apply. Beyond a quick patch; this PR records
the three independently-useful fixes that got us past the first two gates.

The natural follow-up is to bundle synth source inputs (verilog + sdc +
extra_configs) into downstream stages' runfiles via an OrfsInfo extension,
which would also make non-override \`bazel run :_final\` work standalone.

## Test plan

- [x] \`bazelisk run @bazel-orfs//:make-yosys-netlist //flow/designs/asap7/uart:uart_test\`
  with \`YOSYS_PATH=...\` pre-set: phase 1 ✓, phase 2 ✓, phase 3 now advances
  past \`check-yosys\` and the canonicalize \`SDC_FILE\` errors before hitting
  the SDC-runfiles gap.
- [ ] Full SHA matrix once the runfiles gap is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)