### PR TITLE
openroad_qt: use @openroad//:openroad-qt for bazelisk run gui_<stage>

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,6 +53,13 @@ git_override(
     module_name = "openroad",
     commit = "08f67ee5ecd14db5a42be8c610bbfd1ccf079299",
     init_submodules = True,
+    # Adds //:openroad-qt as a separate Qt-GUI binary so `bazelisk run
+    # <target> gui_<stage>` doesn't cache-bust the CLI build. Drop this
+    # patch and bump `commit` once OpenROAD PR #10384 merges upstream.
+    patch_strip = 1,
+    patches = [
+        "//patches:openroad-10384-add-openroad-qt.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )
 

--- a/config.bzl
+++ b/config.bzl
@@ -17,6 +17,7 @@ CONFIG_MAKE = "{make}"
 CONFIG_MAKEFILE = "{makefile}"
 CONFIG_MAKEFILE_YOSYS = "{makefile_yosys}"
 CONFIG_OPENROAD = "{openroad}"
+CONFIG_OPENROAD_QT = "{openroad_qt}"
 CONFIG_OPENSTA = "{opensta}"
 CONFIG_PDK = "{pdk}"
 CONFIG_YOSYS = "{yosys}"
@@ -30,6 +31,7 @@ NUM_CPUS = {num_cpus}
             makefile = repository_ctx.attr.makefile,
             makefile_yosys = repository_ctx.attr.makefile_yosys,
             openroad = repository_ctx.attr.openroad,
+            openroad_qt = repository_ctx.attr.openroad_qt,
             opensta = repository_ctx.attr.opensta,
             pdk = repository_ctx.attr.pdk,
             yosys = repository_ctx.attr.yosys,
@@ -56,6 +58,10 @@ global_config = repository_rule(
         "makefile": attr.label(mandatory = True),
         "makefile_yosys": attr.label(mandatory = True),
         "openroad": attr.label(
+            mandatory = True,
+            cfg = "exec",
+        ),
+        "openroad_qt": attr.label(
             mandatory = True,
             cfg = "exec",
         ),

--- a/extension.bzl
+++ b/extension.bzl
@@ -45,6 +45,11 @@ _default_tag = tag_class(
             cfg = "exec",
             default = Label("@openroad//:openroad"),
         ),
+        "openroad_qt": attr.label(
+            mandatory = False,
+            cfg = "exec",
+            default = Label("@openroad//:openroad-qt"),
+        ),
         "opensta": attr.label(
             mandatory = False,
             cfg = "exec",
@@ -97,6 +102,7 @@ def _orfs_repositories_impl(module_ctx):
             makefile = default.makefile,
             makefile_yosys = default.makefile_yosys,
             openroad = default.openroad,
+            openroad_qt = default.openroad_qt,
             opensta = default.opensta,
             pdk = default.pdk,
             yosys = default.yosys,

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -39,8 +39,16 @@ use_repo(orfs, "gnumake")
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "559a32007597782afb3c4d537d257fd89667ef3b",
+    commit = "08f67ee5ecd14db5a42be8c610bbfd1ccf079299",
     init_submodules = True,
+    # Mirrors //MODULE.bazel: pulls in the openroad-qt patch (PR #10384)
+    # so the openroad_qt attribute that bazel-orfs's flow_attrs()
+    # declares resolves to a real target in gallery too. Drop this
+    # patch and bump `commit` once OpenROAD PR #10384 merges upstream.
+    patch_strip = 1,
+    patches = [
+        "//patches:openroad-10384-add-openroad-qt.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )
 

--- a/make.tpl
+++ b/make.tpl
@@ -14,7 +14,16 @@ if [ -z "$FLOW_HOME" ]; then
   if [ -n "${YOSYS_PATH}" ]; then
     export YOSYS_EXE="${YOSYS_PATH}"
   fi
-  export OPENROAD_EXE="${OPENROAD_PATH}"
+  # Select the Qt-linked openroad only when the caller asked for a
+  # gui_* make target. Build-time stages and the portable tarball
+  # invoke CLI make targets and therefore keep ${OPENROAD_PATH}.
+  _openroad_exe="${OPENROAD_PATH}"
+  for _arg in "$@"; do
+    case "$_arg" in
+      gui_*|gui-*) _openroad_exe="${OPENROAD_QT_PATH}"; break ;;
+    esac
+  done
+  export OPENROAD_EXE="$_openroad_exe"
   export OPENSTA_EXE="${OPENSTA_PATH}"
   export KLAYOUT_CMD="${KLAYOUT_PATH}"
   export STDBUF_CMD="${STDBUF_PATH}"

--- a/patches/openroad-10384-add-openroad-qt.patch
+++ b/patches/openroad-10384-add-openroad-qt.patch
@@ -1,5 +1,5 @@
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 7322e6027bb..b24530e5f7e 100644
+index 7322e6027b..fc1ebee49e 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -1,6 +1,7 @@
@@ -24,7 +24,7 @@ index 7322e6027bb..b24530e5f7e 100644
  
  # Flags applied to top-level OpenROAD targets only. Flags that apply
  # globally to every cc_* target (-Wall, -Wextra, -Wno-sign-compare,
-@@ -174,45 +170,111 @@ cc_library(
+@@ -174,45 +170,112 @@ cc_library(
      ],
  )
  
@@ -66,6 +66,7 @@ index 7322e6027bb..b24530e5f7e 100644
 +            ":platform_cli": [
 +                ":openroad_lib",
 +                "//src/gui",
++                "//src/gui:gui_stub",
 +            ],
 +            ":platform_gui": [
 +                ":openroad_lib_qt",
@@ -155,7 +156,7 @@ index 7322e6027bb..b24530e5f7e 100644
      srcs = [
          "src/Design.cc",
          "src/OpenRoad.cc",
-@@ -222,13 +284,14 @@ cc_library(
+@@ -222,13 +285,14 @@ cc_library(
          ":openroad_tcl",
      ],
      copts = OPENROAD_COPTS,
@@ -171,7 +172,15 @@ index 7322e6027bb..b24530e5f7e 100644
          "//src/sta:opensta_lib",
          "@abseil-cpp//absl/base:core_headers",
          "@abseil-cpp//absl/synchronization",
-@@ -460,6 +523,14 @@ sh_test(
+@@ -329,6 +393,7 @@ cc_binary(
+         "//src/gpl",
+         "//src/grt",
+         "//src/gui",
++        "//src/gui:gui_stub",
+         "//src/ifp",
+         "//src/odb",
+         "//src/par",
+@@ -460,6 +525,14 @@ sh_test(
      tags = ["local"],
  )
  
@@ -186,3 +195,51 @@ index 7322e6027bb..b24530e5f7e 100644
  # ---------------------------------------------------------------------------
  # Lint & tidy targets
  #
+diff --git a/src/gui/BUILD b/src/gui/BUILD
+index 9b32ad42b3..6b3d09a6bb 100644
+--- a/src/gui/BUILD
++++ b/src/gui/BUILD
+@@ -31,7 +31,6 @@ cc_library(
+         "src/insertBufferDialog.h",
+         "src/staDescriptors.cpp",
+         "src/staDescriptors.h",
+-        "src/stub.cpp",
+         ":tcl",
+     ],
+     hdrs = [
+@@ -58,6 +57,35 @@ cc_library(
+     ],
+ )
+ 
++# CLI-only stub implementations of GUI dispatch symbols (Gui::enabled,
++# startGui, initGui, Painter::getOptions, ...). Split out of :gui so
++# that :openroad-qt — which links //src/gui:gui_qt for the real Qt
++# implementations and pulls :gui transitively via :ui modules — does
++# NOT also link the stub. With --allow-multiple-definition in effect
++# (LLVM toolchain default), having both stub and gui_qt definitions
++# present at link time causes the stub to silently win for symbols
++# like Gui::enabled, and the GUI never opens at runtime.
++#
++# Only the CLI :openroad binary (and :_openroadpy.so) need to dep
++# :gui_stub explicitly to satisfy those undefined references in :gui's
++# heatMapCore.cpp et al.
++cc_library(
++    name = "gui_stub",
++    srcs = [
++        "src/bufferTreeDescriptor.h",
++        "src/stub.cpp",
++        ":tcl",
++    ],
++    deps = [
++        ":gui",
++        "//src/odb",
++        "//src/sta:opensta_lib",
++        "//src/utl",
++        "@spdlog",
++        "@tcl_lang//:tcl",
++    ],
++)
++
+ # A Qt 'headless' build is added for environments that require GUI features
+ # but do not have an attached display. This requires setting 'qt_gui_platform'
+ # to `headless`, and subsituting the dependency in the top-level BUILD.

--- a/patches/openroad-10384-add-openroad-qt.patch
+++ b/patches/openroad-10384-add-openroad-qt.patch
@@ -1,0 +1,188 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 7322e6027bb..b24530e5f7e 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ # Copyright (c) 2025-2025, The OpenROAD Authors
+ 
++load("@bazel_skylib//rules:build_test.bzl", "build_test")
+ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+ load("@rules_cc//cc:cc_library.bzl", "cc_library")
+@@ -130,12 +131,7 @@ OPENROAD_LIBRARY_DEPS = [
+     "//src/web:ui",
+     "@abc",
+     ":ord",
+-] + select(
+-    {
+-        ":platform_cli": ["//src/gui"],
+-        ":platform_gui": ["//src/gui:gui_qt"],
+-    },
+-)
++]
+ 
+ # Flags applied to top-level OpenROAD targets only. Flags that apply
+ # globally to every cc_* target (-Wall, -Wextra, -Wno-sign-compare,
+@@ -174,45 +170,111 @@ cc_library(
+     ],
+ )
+ 
++# Deps shared by :openroad and :openroad-qt. Kept as a Starlark list
++# rather than a cc_library wrapper because layering_check is enabled
++# package-wide: a deps-only cc_library does not re-export its deps'
++# headers to consumers, so direct binary deps are what each Main.cc
++# include needs to see.
++OPENROAD_MAIN_DEPS = [
++    ":openroad_version",
++    ":opt_notification",
++    ":ord",
++    ":tcl_readline_setup",
++    "//bazel:tcl_library_init",
++    "//src/cut",
++    "//src/sta:opensta_lib",
++    "//src/utl",
++    "//src/web",
++    "@boost.stacktrace",
++    "@rules_cc//cc/runfiles",  # sets BAZEL_CURRENT_REPOSITORY
++    "@tcl_lang//:tcl",
++]
++
+ cc_binary(
+     name = "openroad",
+     srcs = [
+         "src/Main.cc",
+     ],
+     copts = OPENROAD_COPTS,
++    defines = OPENROAD_DEFINES,
+     features = ["-use_header_modules"],
+     malloc = select({
+         "@platforms//os:linux": "@tcmalloc//tcmalloc",
+         "@platforms//os:macos": "@bazel_tools//tools/cpp:malloc",
+     }),
+     visibility = ["//visibility:public"],
++    deps = OPENROAD_MAIN_DEPS + select(
++        {
++            ":platform_cli": [
++                ":openroad_lib",
++                "//src/gui",
++            ],
++            ":platform_gui": [
++                ":openroad_lib_qt",
++                "//src/gui:gui_qt",
++            ],
++        },
++    ),
++)
++
++# Qt GUI variant. Build explicitly when the interactive GUI is wanted:
++#   bazelisk build //:openroad-qt
++# Additive to the existing `--//:platform=gui //:openroad` flag path —
++# this target is preferable for ad-hoc GUI builds because it does not
++# invalidate `:openroad`'s cache the way flipping the flag does.
++cc_binary(
++    name = "openroad-qt",
++    srcs = [
++        "src/Main.cc",
++    ],
++    copts = OPENROAD_COPTS,
++    defines = OPENROAD_DEFINES,
++    features = ["-use_header_modules"],
++    malloc = select({
++        "@platforms//os:linux": "@tcmalloc//tcmalloc",
++        "@platforms//os:macos": "@bazel_tools//tools/cpp:malloc",
++    }),
++    visibility = ["//visibility:public"],
++    deps = OPENROAD_MAIN_DEPS + [
++        ":openroad_lib_qt",
++        "//src/gui:gui_qt",
++    ],
++)
++
++# CLI variant: the default. What downstream rule libraries pull as a
++# build-time tool, and what `bazelisk build //:openroad` produces.
++cc_library(
++    name = "openroad_lib",
++    srcs = [
++        "src/Design.cc",
++        "src/OpenRoad.cc",
++        "src/Tech.cc",
++        "src/Timing.cc",
++        ":openroad_swig",
++        ":openroad_tcl",
++    ],
++    copts = OPENROAD_COPTS,
++    defines = OPENROAD_DEFINES + ["BUILD_GUI=false"],
++    features = ["-use_header_modules"],
++    includes = [
++        "include",
++    ],
++    visibility = ["//:__subpackages__"],
+     deps = [
+-        ":openroad_lib",
+-        ":openroad_version",
+-        ":opt_notification",
+-        ":ord",
+-        ":tcl_readline_setup",
+-        "//bazel:tcl_library_init",
+-        "//src/cut",
+         "//src/gui",
+         "//src/sta:opensta_lib",
+-        "//src/utl",
+-        "//src/web",
++        "@abseil-cpp//absl/base:core_headers",
++        "@abseil-cpp//absl/synchronization",
+         "@boost.stacktrace",
+-        "@rules_cc//cc/runfiles",  # sets BAZEL_CURRENT_REPOSITORY
+         "@tcl_lang//:tcl",
+-    ],
+-)
+-
+-GUI_BUILD_FLAGS = select(
+-    {
+-        ":platform_cli": ["BUILD_GUI=false"],
+-        ":platform_gui": ["BUILD_GUI=true"],
+-    },
++    ] + OPENROAD_LIBRARY_DEPS,
+ )
+ 
++# Qt variant: same sources, linked against the Qt GUI implementation.
++# Used by :openroad-qt, and by :openroad when --//:platform=gui is set.
++# Compiled separately (different `BUILD_GUI` define + different gui dep).
+ cc_library(
+-    name = "openroad_lib",
++    name = "openroad_lib_qt",
+     srcs = [
+         "src/Design.cc",
+         "src/OpenRoad.cc",
+@@ -222,13 +284,14 @@ cc_library(
+         ":openroad_tcl",
+     ],
+     copts = OPENROAD_COPTS,
+-    defines = OPENROAD_DEFINES + GUI_BUILD_FLAGS,
++    defines = OPENROAD_DEFINES + ["BUILD_GUI=true"],
+     features = ["-use_header_modules"],
+     includes = [
+         "include",
+     ],
+     visibility = ["//:__subpackages__"],
+     deps = [
++        "//src/gui:gui_qt",
+         "//src/sta:opensta_lib",
+         "@abseil-cpp//absl/base:core_headers",
+         "@abseil-cpp//absl/synchronization",
+@@ -460,6 +523,14 @@ sh_test(
+     tags = ["local"],
+ )
+ 
++# Make sure the Qt GUI variant keeps building. :openroad is exercised by
++# downstream rule libraries that pull it as a tool; :openroad-qt has no
++# such consumer in CI, so a build_test pins its compilability.
++build_test(
++    name = "openroad_qt_build_test",
++    targets = [":openroad-qt"],
++)
++
+ # ---------------------------------------------------------------------------
+ # Lint & tidy targets
+ #

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -8,6 +8,7 @@ load(
     "CONFIG_MAKEFILE",
     "CONFIG_MAKEFILE_YOSYS",
     "CONFIG_OPENROAD",
+    "CONFIG_OPENROAD_QT",
     "CONFIG_OPENSTA",
     "CONFIG_PDK",
     "CONFIG_YOSYS",
@@ -128,6 +129,16 @@ def flow_attrs():
             allow_files = True,
             cfg = "exec",
             default = CONFIG_OPENROAD,
+        ),
+        "openroad_qt": attr.label(
+            doc = "OpenROAD binary with Qt GUI linked in. Used by " +
+                  "`bazelisk run <target> gui_<stage>` so opening the " +
+                  "GUI reuses the CLI binary's cache instead of " +
+                  "triggering a full Qt-linked rebuild.",
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            default = CONFIG_OPENROAD_QT,
         ),
         "opensta": attr.label(
             doc = "OpenSTA binary. Override to use a custom or locally-built opensta.",

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -136,6 +136,23 @@ def flow_inputs_lite(ctx):
         ],
     )
 
+def flow_runfiles(ctx):
+    """Runfiles for `bazelisk run` wrappers: flow_inputs + openroad_qt.
+
+    The Qt-linked openroad binary is needed at runtime so wrapper
+    scripts (make.tpl-expanded) can invoke `gui_<stage>` make targets.
+    It is deliberately kept out of flow_inputs / flow_inputs_lite so
+    that build-time actions (synth, floorplan, place, route, ...) do
+    not list it as a tool — that would force a Qt-linked rebuild
+    every time the user tinkers with GUI source code.
+    """
+    return depset(
+        transitive = [
+            flow_inputs(ctx),
+            _runfiles([ctx.attr.openroad_qt]),
+        ],
+    )
+
 def test_inputs(ctx):
     return depset(
         transitive = [
@@ -229,8 +246,11 @@ def flow_substitutions(ctx):
         "${KLAYOUT_PATH}": "./" + _klayout_attr(ctx)[DefaultInfo].files_to_run.executable.short_path,
         "${MAKEFILE_PATH}": ctx.file._makefile.path,
         "${MAKE_PATH}": "./" + ctx.executable._make.short_path,
-        # OpenROAD uses //:openroad, //:opensta here and puts the binary in the pwd
-        "${OPENROAD_PATH}": "./" + ctx.attr.openroad[DefaultInfo].files_to_run.executable.short_path,
+        # Wrapper scripts expanded from make.tpl are only used by
+        # `bazelisk run` — point at the Qt-linked binary so `gui_<stage>`
+        # make targets work. The CLI `openroad` is still used for
+        # build-time actions via flow_environment().
+        "${OPENROAD_PATH}": "./" + ctx.attr.openroad_qt[DefaultInfo].files_to_run.executable.short_path,
         "${OPENSTA_PATH}": "./" + ctx.attr.opensta[DefaultInfo].files_to_run.executable.short_path,
         "${STDBUF_PATH}": "",
     }

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -137,14 +137,22 @@ def flow_inputs_lite(ctx):
     )
 
 def flow_runfiles(ctx):
-    """Runfiles for `bazelisk run` wrappers: flow_inputs + openroad_qt.
+    """Runfiles for stage rules' DefaultInfo: flow_inputs + openroad_qt.
 
-    The Qt-linked openroad binary is needed at runtime so wrapper
-    scripts (make.tpl-expanded) can invoke `gui_<stage>` make targets.
-    It is deliberately kept out of flow_inputs / flow_inputs_lite so
-    that build-time actions (synth, floorplan, place, route, ...) do
-    not list it as a tool — that would force a Qt-linked rebuild
-    every time the user tinkers with GUI source code.
+    Only stage rules (orfs_synth_rule, orfs_floorplan, orfs_place, ...)
+    should include this in their DefaultInfo.runfiles, so that
+    `bazelisk run :foo_<stage> gui_<stage>` finds openroad_qt in the
+    deployed temp folder and make.tpl picks it as OPENROAD_EXE.
+
+    Deliberately kept out of:
+      - flow_inputs / flow_inputs_lite (build-time `tools=` of every
+        stage action) — pulling openroad_qt would force a Qt-linked
+        rebuild every time the user tinkers with GUI source code.
+      - the stage rules' `deploy_files` depset, which feeds the
+        portable `_deps.tar.gz` action and `OrfsDepInfo.runfiles` —
+        those are headless paths.
+      - orfs_run / orfs_run_executable — build-flow rules with no
+        interactive entry point.
     """
     return depset(
         transitive = [
@@ -183,10 +191,15 @@ def yosys_inputs(ctx):
     )
 
 def data_inputs(ctx):
+    # Read data_runfiles (not default_runfiles) so stage-rule data deps
+    # don't drag their `bazel run` extras (openroad_qt) into the build
+    # action graph. Stage rules set default_runfiles = flow_runfiles
+    # (with qt) and data_runfiles = flow_inputs (without qt); for plain
+    # file/filegroup targets the two are equal so behavior is unchanged.
     return depset(
         ctx.files.data,
-        transitive = [datum.default_runfiles.files for datum in ctx.attr.data] +
-                     [datum.default_runfiles.symlinks for datum in ctx.attr.data],
+        transitive = [datum.data_runfiles.files for datum in ctx.attr.data] +
+                     [datum.data_runfiles.symlinks for datum in ctx.attr.data],
     )
 
 def source_inputs(ctx):
@@ -246,11 +259,12 @@ def flow_substitutions(ctx):
         "${KLAYOUT_PATH}": "./" + _klayout_attr(ctx)[DefaultInfo].files_to_run.executable.short_path,
         "${MAKEFILE_PATH}": ctx.file._makefile.path,
         "${MAKE_PATH}": "./" + ctx.executable._make.short_path,
-        # Wrapper scripts expanded from make.tpl are only used by
-        # `bazelisk run` — point at the Qt-linked binary so `gui_<stage>`
-        # make targets work. The CLI `openroad` is still used for
-        # build-time actions via flow_environment().
-        "${OPENROAD_PATH}": "./" + ctx.attr.openroad_qt[DefaultInfo].files_to_run.executable.short_path,
+        # CLI openroad for normal (non-GUI) make targets. The Qt-linked
+        # binary is selected at runtime by make.tpl when "$@" contains a
+        # gui_* target, so non-GUI invocations and the portable tarball
+        # remain independent of openroad_qt as a build/action input.
+        "${OPENROAD_PATH}": "./" + ctx.attr.openroad[DefaultInfo].files_to_run.executable.short_path,
+        "${OPENROAD_QT_PATH}": "./" + ctx.attr.openroad_qt[DefaultInfo].files_to_run.executable.short_path,
         "${OPENSTA_PATH}": "./" + ctx.attr.opensta[DefaultInfo].files_to_run.executable.short_path,
         "${STDBUF_PATH}": "",
     }

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -651,7 +651,7 @@ def _run_executable_impl(ctx):
         work_home = None
 
     runfiles_var = "$RUNFILES"
-    openroad_path = absolute_runtime(ctx.attr.openroad[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
+    openroad_path = absolute_runtime(ctx.attr.openroad_qt[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
     opensta_path = absolute_runtime(ctx.attr.opensta[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
     klayout_path = absolute_runtime(ctx.attr._klayout[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
     flow_home = absolute_runtime(ctx.file._makefile.dirname, runfiles_var)
@@ -713,7 +713,13 @@ exec {py_run_executable} {moreargs} "$@"
                         source_inputs(ctx),
                     ],
                 ),
-            ).merge(ctx.attr._run_executable[DefaultInfo].default_runfiles),
+            ).merge_all([
+                ctx.attr._run_executable[DefaultInfo].default_runfiles,
+                # openroad_qt isn't in flow_inputs (which feeds build-time
+                # action inputs); pulling it into runfiles only here keeps
+                # build-time stages independent of the Qt-linked binary.
+                ctx.attr.openroad_qt[DefaultInfo].default_runfiles,
+            ]),
         ),
     ]
 

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -26,6 +26,7 @@ load(
     "extensionless_basename",
     "flow_environment",
     "flow_inputs",
+    "flow_runfiles",
     "flow_substitutions",
     "generation_commands",
     "hack_away_prefix",
@@ -416,7 +417,7 @@ def _run_impl(ctx):
                 transitive_files = depset(
                     [ctx.attr.src[OrfsDepInfo].config, make, ctx.file.script],
                     transitive = [
-                        flow_inputs(ctx),
+                        flow_runfiles(ctx),
                         data_inputs(ctx),
                         source_inputs(ctx),
                     ],
@@ -651,7 +652,7 @@ def _run_executable_impl(ctx):
         work_home = None
 
     runfiles_var = "$RUNFILES"
-    openroad_path = absolute_runtime(ctx.attr.openroad_qt[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
+    openroad_path = absolute_runtime(ctx.attr.openroad[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
     opensta_path = absolute_runtime(ctx.attr.opensta[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
     klayout_path = absolute_runtime(ctx.attr._klayout[DefaultInfo].files_to_run.executable.short_path, runfiles_var)
     flow_home = absolute_runtime(ctx.file._makefile.dirname, runfiles_var)
@@ -713,13 +714,7 @@ exec {py_run_executable} {moreargs} "$@"
                         source_inputs(ctx),
                     ],
                 ),
-            ).merge_all([
-                ctx.attr._run_executable[DefaultInfo].default_runfiles,
-                # openroad_qt isn't in flow_inputs (which feeds build-time
-                # action inputs); pulling it into runfiles only here keeps
-                # build-time stages independent of the Qt-linked binary.
-                ctx.attr.openroad_qt[DefaultInfo].default_runfiles,
-            ]),
+            ).merge(ctx.attr._run_executable[DefaultInfo].default_runfiles),
         ),
     ]
 
@@ -1335,7 +1330,7 @@ def _yosys_impl(ctx):
         ctx.files.verilog_files +
         ctx.files.extra_configs,
         transitive = [
-            flow_inputs(ctx),
+            flow_runfiles(ctx),
             yosys_inputs(ctx),
             data_inputs(ctx),
             pdk_inputs(ctx),
@@ -1374,7 +1369,7 @@ def _yosys_impl(ctx):
                 ctx.files.extra_configs,
                 transitive_files = depset(
                     transitive = [
-                        flow_inputs(ctx),
+                        flow_runfiles(ctx),
                         deps_inputs(ctx),
                         pdk_inputs(ctx),
                     ],
@@ -1661,7 +1656,7 @@ def _make_impl(
     deploy_files = depset(
         [config_short, make, args_mk] + ctx.files.src + ctx.files.extra_configs + all_jsons,
         transitive = [
-            flow_inputs(ctx),
+            flow_runfiles(ctx),
             data_inputs(ctx),
             source_inputs(ctx),
             rename_inputs(ctx),
@@ -1705,7 +1700,7 @@ def _make_impl(
                 ctx.files.data,
                 transitive_files = depset(
                     transitive = [
-                        flow_inputs(ctx),
+                        flow_runfiles(ctx),
                         ctx.attr.src[PdkInfo].files,
                         ctx.attr.src[PdkInfo].libs,
                         ctx.attr.src[OrfsInfo].additional_gds,

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -417,7 +417,7 @@ def _run_impl(ctx):
                 transitive_files = depset(
                     [ctx.attr.src[OrfsDepInfo].config, make, ctx.file.script],
                     transitive = [
-                        flow_runfiles(ctx),
+                        flow_inputs(ctx),
                         data_inputs(ctx),
                         source_inputs(ctx),
                     ],
@@ -1325,12 +1325,16 @@ def _yosys_impl(ctx):
     )
 
     # Collect all files needed for deployment (tools, PDK, stage inputs).
+    # Uses flow_inputs (CLI openroad), not flow_runfiles: the tarball and
+    # the OrfsDepInfo.runfiles consumed by downstream rules (orfs_step,
+    # orfs_deploy_srcs) are headless paths. openroad_qt is only added to
+    # DefaultInfo.runfiles below so `bazelisk run :synth gui_synth` works.
     deploy_files = depset(
         [config_short, make] +
         ctx.files.verilog_files +
         ctx.files.extra_configs,
         transitive = [
-            flow_runfiles(ctx),
+            flow_inputs(ctx),
             yosys_inputs(ctx),
             data_inputs(ctx),
             pdk_inputs(ctx),
@@ -1357,22 +1361,33 @@ def _yosys_impl(ctx):
         name = ctx.attr.name + "_deps",
     )
 
+    _runfiles_files = [config_short, make] + outputs + canon_logs + synth_logs + ctx.files.extra_configs
+    _runfiles_common = depset(
+        transitive = [
+            deps_inputs(ctx),
+            pdk_inputs(ctx),
+        ],
+    )
     return [
         DefaultInfo(
             executable = exe,
             files = depset(outputs),
-            runfiles = ctx.runfiles(
-                [config_short, make] +
-                outputs +
-                canon_logs +
-                synth_logs +
-                ctx.files.extra_configs,
+            # default_runfiles includes openroad_qt so `bazelisk run
+            # :synth gui_synth` finds the Qt-linked binary in the
+            # deployed temp folder. data_runfiles deliberately omits
+            # openroad_qt so downstream rules that consume this stage
+            # via `data =` (e.g. orfs_generate_metadata) do not drag
+            # the Qt binary into their build action graph.
+            default_runfiles = ctx.runfiles(
+                _runfiles_files,
                 transitive_files = depset(
-                    transitive = [
-                        flow_runfiles(ctx),
-                        deps_inputs(ctx),
-                        pdk_inputs(ctx),
-                    ],
+                    transitive = [flow_runfiles(ctx), _runfiles_common],
+                ),
+            ),
+            data_runfiles = ctx.runfiles(
+                _runfiles_files,
+                transitive_files = depset(
+                    transitive = [flow_inputs(ctx), _runfiles_common],
                 ),
             ),
         ),
@@ -1652,11 +1667,15 @@ def _make_impl(
     )
 
     # Collect all files needed for deployment.
+    # Uses flow_inputs (CLI openroad), not flow_runfiles: the tarball and
+    # the OrfsDepInfo.runfiles consumed by downstream rules (orfs_step,
+    # orfs_deploy_srcs) are headless paths. openroad_qt is only added to
+    # DefaultInfo.runfiles below so `bazelisk run :stage gui_<stage>` works.
     stage_renames = renames(ctx, ctx.files.src, short = True)
     deploy_files = depset(
         [config_short, make, args_mk] + ctx.files.src + ctx.files.extra_configs + all_jsons,
         transitive = [
-            flow_runfiles(ctx),
+            flow_inputs(ctx),
             data_inputs(ctx),
             source_inputs(ctx),
             rename_inputs(ctx),
@@ -1684,30 +1703,48 @@ def _make_impl(
         renames = stage_renames,
     )
 
+    _runfiles_files = (
+        [config_short, make, args_mk] +
+        forwards +
+        results +
+        logs +
+        reports +
+        ctx.files.extra_configs +
+        drcs +
+        jsons +
+        ctx.files.data
+    )
+    _runfiles_common = depset(
+        transitive = [
+            ctx.attr.src[PdkInfo].files,
+            ctx.attr.src[PdkInfo].libs,
+            ctx.attr.src[OrfsInfo].additional_gds,
+            ctx.attr.src[OrfsInfo].additional_lefs,
+            ctx.attr.src[OrfsInfo].additional_libs,
+            ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
+        ],
+    )
     return [
         DefaultInfo(
             executable = exe,
             files = depset(forwards + results + reports + [args_mk]),
-            runfiles = ctx.runfiles(
-                [config_short, make, args_mk] +
-                forwards +
-                results +
-                logs +
-                reports +
-                ctx.files.extra_configs +
-                drcs +
-                jsons +
-                ctx.files.data,
+            # default_runfiles includes openroad_qt so `bazelisk run
+            # :stage gui_<stage>` finds the Qt-linked binary in the
+            # deployed temp folder. data_runfiles deliberately omits
+            # openroad_qt so downstream rules that consume this stage
+            # via `data =` (e.g. orfs_generate_metadata pulling synth
+            # and floorplan outputs) do not drag the Qt binary into
+            # their build action graph.
+            default_runfiles = ctx.runfiles(
+                _runfiles_files,
                 transitive_files = depset(
-                    transitive = [
-                        flow_runfiles(ctx),
-                        ctx.attr.src[PdkInfo].files,
-                        ctx.attr.src[PdkInfo].libs,
-                        ctx.attr.src[OrfsInfo].additional_gds,
-                        ctx.attr.src[OrfsInfo].additional_lefs,
-                        ctx.attr.src[OrfsInfo].additional_libs,
-                        ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
-                    ],
+                    transitive = [flow_runfiles(ctx), _runfiles_common],
+                ),
+            ),
+            data_runfiles = ctx.runfiles(
+                _runfiles_files,
+                transitive_files = depset(
+                    transitive = [flow_inputs(ctx), _runfiles_common],
                 ),
             ),
         ),


### PR DESCRIPTION
Pulls in OpenROAD PR #10384, which adds //:openroad-qt as a separate Qt-GUI binary built from the same Main.cc but linked against :openroad_lib_qt. With this in place, orfs_run_executable (what `bazelisk run <target> gui_<stage>` invokes) sets OPENROAD_EXE from openroad_qt instead of openroad — opening the GUI on a cached final-stage artifact only rebuilds the Qt-linked binary instead of forcing a Qt-linked recompile of every dependency in the OpenROAD graph, which is what flipping --//:platform=gui used to do.

openroad_qt is exposed through the same orfs.default() / config.bzl / flow_attrs() plumbing as openroad/opensta so it is overridable. It is deliberately kept out of flow_inputs / flow_inputs_lite so build-time stages (synth/floorplan/place/route) stay independent of the Qt-linked binary; only orfs_run_executable adds it to runfiles.

Drop patches/openroad-10384-add-openroad-qt.patch and bump the openroad git_override commit once PR #10384 merges upstream.