### PR TITLE
yosys: pass use_pre_layout=True when writing 1_synth.short.mk

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1301,7 +1301,10 @@ def _yosys_impl(ctx):
                 arguments = merge_arguments(
                     data_arguments(ctx) |
                     required_arguments(ctx),
-                    orfs_additional_arguments([dep[OrfsInfo] for dep in ctx.attr.deps]),
+                    orfs_additional_arguments(
+                        [dep[OrfsInfo] for dep in ctx.attr.deps],
+                        use_pre_layout = True,
+                    ),
                 ) | verilog_arguments(ctx.files.verilog_files),
                 prefix = config_short.root.path,
             ),


### PR DESCRIPTION
`_yosys_impl` writes two configs from the same `orfs_additional_arguments` call: the full `1_synth.mk` consumed by Yosys, and the "short" deploy config `1_synth.short.mk` used by `bazelisk run` entry points (`gui_synth`, `orfs_run`-against-the-synth-target). The Yosys path correctly passes `use_pre_layout = True`; the short path was missed, so every `gui_synth` / `wns-families` invocation loaded the post-CTS macro `.libs` that bake the macro's internal clock-tree delay into setup/hold. With no CTS at the synth stage in the parent, OpenSTA compounds the macro-internal CTS into the parent's data-required time and reports slack > T_clock on met paths terminating in macro input pins and |WNS| > T_clock on the worst path.

Pre-layout (post-place, pre-CTS) macro libs are the correct match for ideal-clock pre-CTS STA; bazel-orfs already emits them as `OrfsInfo.lib_pre_layout` via the sibling `pre_layout_abstract` target. This change just makes the deploy config pick them up too, matching what the Yosys-fed full config already does.