### PR TITLE
bump: skip in-comment matches in override-block finders

### DIFF
--- a/bump.py
+++ b/bump.py
@@ -242,6 +242,39 @@ def find_starlark_call_end(content, start):
     return n
 
 
+def _position_is_in_comment(content, pos):
+    """True if ``content[pos]`` is in a ``#`` line comment.
+
+    Walks the current line from its start, tracking single- and double-quoted
+    strings (so a ``#`` inside a string is not treated as a comment marker)
+    and returns True the moment an unquoted ``#`` is seen before ``pos``.
+
+    Used by the override-block finders below to skip regex matches that
+    fall inside a comment — e.g. a documentation line that mentions
+    ``archive_override(`` would otherwise be treated as the start of a real
+    Starlark call, with ``find_starlark_call_end`` then walking past the
+    comment lines into unrelated code and returning a runaway span.
+    """
+    line_start = content.rfind("\n", 0, pos) + 1
+    in_str = None
+    i = line_start
+    while i < pos:
+        c = content[i]
+        if in_str:
+            if c == "\\":
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+        else:
+            if c in ('"', "'"):
+                in_str = c
+            elif c == "#":
+                return True
+        i += 1
+    return False
+
+
 def find_git_override_block(content, module_name):
     """Find the full git_override() block for a module, handling nested strings.
 
@@ -249,6 +282,8 @@ def find_git_override_block(content, module_name):
     """
     pattern = r"git_override\s*\("
     for m in re.finditer(pattern, content):
+        if _position_is_in_comment(content, m.start()):
+            continue
         end = find_starlark_call_end(content, m.start())
         block = content[m.start() : end]
         if f'module_name = "{module_name}"' in block:
@@ -263,6 +298,8 @@ def find_archive_override_block(content, module_name):
     """
     pattern = r"archive_override\s*\("
     for m in re.finditer(pattern, content):
+        if _position_is_in_comment(content, m.start()):
+            continue
         end = find_starlark_call_end(content, m.start())
         block = content[m.start() : end]
         if f'module_name = "{module_name}"' in block:

--- a/test/bump/bump_test.py
+++ b/test/bump/bump_test.py
@@ -743,6 +743,162 @@ class TestFindArchiveOverrideBlock(unittest.TestCase):
         content = 'git_override(\n    module_name = "orfs",\n    commit = "x",\n)'
         self.assertIsNone(bump.find_archive_override_block(content, "orfs"))
 
+    def test_ignores_match_inside_comment_before_real_block(self):
+        # A prose comment that wraps an ``archive_override(`` mention across
+        # lines — opening paren on one comment line, closing paren on a
+        # *subsequent* comment line — is the realistic shape this guard
+        # protects against.  ``find_starlark_call_end`` skips comment-line
+        # interiors when it encounters ``#``, so the closing ``)`` on the
+        # next comment line is silently consumed; without the comment
+        # filter on ``re.finditer`` matches, the scan would then walk on,
+        # increment depth at the real ``archive_override(`` below, and only
+        # exit at some later stray ``)`` — wrapping the real block (and
+        # everything between) inside one runaway "block" that the rewriter
+        # then either no-ops or corrupts.
+        content = (
+            "# Pinned via archive_override (GitHub /archive/<sha>.tar.gz +\n"
+            "# patch_cmds for submodules) rather than git_override +\n"
+            "# init_submodules — the latter has a non-atomic-fetch bug.\n"
+            "archive_override(\n"
+            '    module_name = "orfs",\n'
+            '    urls = ["https://example/x.tar.gz"],\n'
+            ")"
+        )
+        span = bump.find_archive_override_block(content, "orfs")
+        self.assertIsNotNone(span)
+        block = content[span[0] : span[1]]
+        self.assertTrue(block.startswith("archive_override("))
+        self.assertTrue(block.endswith(")"))
+        self.assertNotIn("Pinned via", block)
+        self.assertNotIn("# patch_cmds for submodules", block)
+
+    def test_ignores_match_in_indented_comment(self):
+        # Comments aren't always at column 0 — buildifier preserves leading
+        # whitespace before ``#``.  Indented prose with an unbalanced ``(``
+        # on the same line as the call mention must still be skipped.
+        comment = (
+            "    # see archive_override( above for the parent pin;\n"
+            "    # the close-paren is on this trailing comment line ).\n"
+        )
+        active = 'archive_override(\n    module_name = "orfs",\n)'
+        content = comment + active
+        span = bump.find_archive_override_block(content, "orfs")
+        self.assertIsNotNone(span)
+        # The span must start at the active block, not at the comment.
+        self.assertEqual(span[0], len(comment))
+        block = content[span[0] : span[1]]
+        self.assertEqual(block, active)
+
+    def test_only_commented_block_returns_none(self):
+        # If every occurrence is inside a comment, the finder must return
+        # None.  Returning a runaway span (or a bogus in-comment span) would
+        # make ``update_openroad_archive_override`` either rewrite the
+        # comment in place or corrupt unrelated code below it.
+        content = (
+            "# archive_override(\n"
+            '#     module_name = "orfs",\n'
+            "# )\n"
+            'git_override(\n    module_name = "other",\n    commit = "x",\n)'
+        )
+        self.assertIsNone(bump.find_archive_override_block(content, "orfs"))
+
+
+class TestFindGitOverrideBlock(unittest.TestCase):
+    def test_ignores_match_inside_comment_before_real_block(self):
+        # Same hazard as the archive_override case: a commented-out
+        # ``# git_override(`` ahead of the real block must be skipped so the
+        # finder doesn't return a span that begins inside the comment.
+        content = (
+            "# Worker-wrapper fork — swap the git_override( above to enable.\n"
+            "# git_override(\n"
+            '#     module_name = "bazel-orfs",\n'
+            '#     commit = "old",\n'
+            "# )\n"
+            "\n"
+            "git_override(\n"
+            '    module_name = "bazel-orfs",\n'
+            '    commit = "real",\n'
+            ")"
+        )
+        span = bump.find_git_override_block(content, "bazel-orfs")
+        self.assertIsNotNone(span)
+        block = content[span[0] : span[1]]
+        self.assertTrue(block.startswith("git_override("))
+        self.assertIn('commit = "real"', block)
+        self.assertNotIn("Worker-wrapper", block)
+        self.assertNotIn('commit = "old"', block)
+
+    def test_only_commented_block_returns_none(self):
+        content = (
+            "# git_override(\n"
+            '#     module_name = "bazel-orfs",\n'
+            '#     commit = "old",\n'
+            "# )\n"
+        )
+        self.assertIsNone(bump.find_git_override_block(content, "bazel-orfs"))
+
+
+class TestUpdateOpenroadArchiveOverrideAroundComments(unittest.TestCase):
+    """Regression: comments mentioning ``archive_override(`` next to the
+    real block must not derail the openroad rewriter.
+
+    The original bug: a downstream MODULE.bazel with a leading prose
+    comment ``# Pinned via archive_override (...)`` caused
+    ``find_archive_override_block`` to match inside the comment.
+    ``find_starlark_call_end`` then walked from the ``#`` line into the
+    real block and beyond, returning a runaway span.  The rewriter then
+    either no-oped (because depth tracking landed at the wrong ``)``) or
+    corrupted everything between the comment and the next stray ``)`` in
+    the file.
+    """
+
+    def test_rewrite_targets_active_block_not_comment(self):
+        # Realistic comment shape: ``(`` on one comment line, ``)`` on a
+        # later one — Starlark-call-end skips the inner ``#`` lines, so the
+        # unbalanced ``(`` in the comment used to leak into the real block
+        # below and produce a runaway span.
+        content = (
+            "# Pinned via archive_override (GitHub /archive/<sha>.tar.gz +\n"
+            "# patch_cmds for submodules) so the submodule-fetch race in\n"
+            "# git_override + init_submodules can't strand us.\n"
+            "archive_override(\n"
+            '    module_name = "openroad",\n'
+            '    integrity = "sha256-OLD=",\n'
+            '    patches = [],\n'
+            '    strip_prefix = "OpenROAD-old_openroad_commit",\n'
+            '    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/old_openroad_commit.tar.gz"],\n'
+            ")\n"
+        )
+
+        def fake_int(_url):
+            return "sha256-NEW="
+
+        def fake_hex(_url):
+            return "f" * 64
+
+        def fake_sub(_repo, _commit, path):
+            return OPENROAD_SUBMODULE_SHAS[path]
+
+        new_content = bump.update_openroad_archive_override(
+            content,
+            "new_openroad_commit",
+            fetch_integrity_fn=fake_int,
+            fetch_sha256_hex_fn=fake_hex,
+            fetch_submodule_sha_fn=fake_sub,
+        )
+        # The active block was actually rewritten — old SHA is gone.
+        self.assertNotIn("old_openroad_commit", new_content)
+        self.assertIn(
+            'strip_prefix = "OpenROAD-new_openroad_commit"', new_content
+        )
+        self.assertIn("new_openroad_commit.tar.gz", new_content)
+        # And the comment block is intact (not consumed by a runaway span).
+        self.assertIn("# Pinned via archive_override (GitHub", new_content)
+        self.assertIn(
+            "# patch_cmds for submodules) so the submodule-fetch race",
+            new_content,
+        )
+
 
 class TestDownstreamOrfsToolsFlow(unittest.TestCase):
     """Downstream: openroad commit and yosys BCR version follow ORFS tools/."""


### PR DESCRIPTION
find_archive_override_block and find_git_override_block both feed every re.finditer hit into find_starlark_call_end without first checking whether the match position is inside a # comment.  When a comment contains an unbalanced `archive_override(` (or `git_override(`) — for example a multi-line prose block that opens the paren on one comment line and closes it on a subsequent one — find_starlark_call_end skips the inner # lines, never sees the closing paren, and walks on with depth=1 into the next real Starlark call.  The returned span starts inside the comment and ends at some stray ) far downstream, wrapping the real override block in a runaway region.

Downstream consequences observed in a real downstream MODULE.bazel:

  1. update_openroad_archive_override silently no-ops because the span it gets back doesn't bound a single Starlark call.
  2. With a slightly different comment shape, the rewriter writes a new block over the runaway span and deletes everything between the comment opener and the next stray ).

Fix is a _position_is_in_comment helper that walks from the start of the current line, tracking quoted strings, and returns True the moment it sees an unquoted #.  Both finders skip re.finditer matches that fail this check.

Six new regression tests in test/bump/bump_test.py cover the comment shapes that triggered the original bug, plus the end-to-end update_openroad_archive_override rewrite around a comment.  All six fail on the pre-fix bump.py; all 116 bump tests pass after.