### PR TITLE
yosys: bump to 0.64 via custom registry (BCR PR #8862)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,11 @@
+# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
+# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
+# listed first so all other modules resolve from the official source;
+# the fork is only consulted for modules/versions BCR doesn't carry yet.
+# The commit hash makes the fork reference immutable.
+common --registry=https://bcr.bazel.build/
+common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
+
 build --incompatible_strict_action_env
 
 # Required by OpenROAD (STA uses std::format_string from C++20)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ local_path_override(
 )
 
 bazel_dep(name = "abc", version = "0.64-yosyshq.bcr.1")
-bazel_dep(name = "yosys", version = "0.63")
+bazel_dep(name = "yosys", version = "0.64")
 bazel_dep(name = "orfs")
 
 # Pinned via archive_override (HTTPS tarball) rather than git_override so

--- a/chisel/.bazelrc
+++ b/chisel/.bazelrc
@@ -1,2 +1,10 @@
+# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
+# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
+# listed first so all other modules resolve from the official source;
+# the fork is only consulted for modules/versions BCR doesn't carry yet.
+# The commit hash makes the fork reference immutable.
+common --registry=https://bcr.bazel.build/
+common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
+
 common --experimental_isolated_extension_usages
 common --lockfile_mode=off

--- a/chisel/MODULE.bazel
+++ b/chisel/MODULE.bazel
@@ -19,7 +19,7 @@ local_path_override(
     path = "../verilog",
 )
 
-bazel_dep(name = "yosys", version = "0.63")
+bazel_dep(name = "yosys", version = "0.64")
 
 bazel_dep(name = "orfs")
 git_override(

--- a/gallery/.bazelrc
+++ b/gallery/.bazelrc
@@ -1,6 +1,14 @@
 # OpenROAD Demo Project
 # Common settings for bazel-orfs builds
 
+# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
+# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
+# listed first so all other modules resolve from the official source;
+# the fork is only consulted for modules/versions BCR doesn't carry yet.
+# The commit hash makes the fork reference immutable.
+common --registry=https://bcr.bazel.build/
+common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
+
 build --incompatible_strict_action_env
 
 # Required by OpenROAD (STA uses std::format_string from C++20)

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -13,7 +13,7 @@ local_path_override(
     path = "..",
 )
 
-bazel_dep(name = "yosys", version = "0.63")
+bazel_dep(name = "yosys", version = "0.64")
 
 # --- ORFS flow scripts (Makefile, TCL, PDKs) ---
 

--- a/mock/chisel/.bazelrc
+++ b/mock/chisel/.bazelrc
@@ -1,2 +1,10 @@
+# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
+# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
+# listed first so all other modules resolve from the official source;
+# the fork is only consulted for modules/versions BCR doesn't carry yet.
+# The commit hash makes the fork reference immutable.
+common --registry=https://bcr.bazel.build/
+common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
+
 common --experimental_isolated_extension_usages
 common --lockfile_mode=off

--- a/mock/chisel/MODULE.bazel
+++ b/mock/chisel/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../verilog",
 )
 
-bazel_dep(name = "yosys", version = "0.63")
+bazel_dep(name = "yosys", version = "0.64")
 
 bazel_dep(name = "orfs")
 git_override(

--- a/test/downstream/.bazelrc
+++ b/test/downstream/.bazelrc
@@ -1,6 +1,14 @@
 # Downstream consumer test .bazelrc.
 # Workarounds here are tracked as known issues in README.md.
 
+# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
+# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
+# listed first so all other modules resolve from the official source;
+# the fork is only consulted for modules/versions BCR doesn't carry yet.
+# The commit hash makes the fork reference immutable.
+common --registry=https://bcr.bazel.build/
+common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
+
 common --enable_workspace
 common --lockfile_mode=off
 

--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -60,7 +60,7 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 
-bazel_dep(name = "yosys", version = "0.63")
+bazel_dep(name = "yosys", version = "0.64")
 
 # --- Verilator simulation + Google Test ---
 bazel_dep(name = "rules_verilog", version = "1.1.1")


### PR DESCRIPTION
Pick up the Kogge-Stone adder memory corruption fix in yosys 0.64 without waiting for the BCR pull request to merge.

Bazel's --registry flag is designed for exactly this: downstream projects carry patches and pre-release modules in a fallback registry while the upstreaming review proceeds at its own pace. The official BCR is listed first so every other module still resolves from the canonical source; the fork is only consulted for modules or versions that BCR does not yet carry.

A live project always has some dependency in flight — a fix waiting for review, a patch not yet landed, a version not yet published. Decoupling the urgency of a fix from the cadence of its upstream acceptance is not a workaround; it is how bzlmod registries are meant to be composed.

The commit hash (0586b39) pins the registry content immutably. GitHub never garbage-collects commit objects, even from closed PRs, so the reference remains valid regardless of the PR's fate.  Once yosys 0.64 lands in the official BCR, the --registry lines can be removed in a one-line cleanup.