### PR TITLE
remove oharboe BCR fork registry override

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,11 +1,3 @@
-# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
-# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
-# listed first so all other modules resolve from the official source;
-# the fork is only consulted for modules/versions BCR doesn't carry yet.
-# The commit hash makes the fork reference immutable.
-common --registry=https://bcr.bazel.build/
-common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
-
 build --incompatible_strict_action_env
 
 # Required by OpenROAD (STA uses std::format_string from C++20)


### PR DESCRIPTION
## Summary
- yosys 0.64 (bazelbuild/bazel-central-registry#8862) landed in official BCR today
- Drop the fork-registry override + the redundant explicit `https://bcr.bazel.build/` line (BCR is the default registry when no `--registry` flag is given)

## Test plan
- [x] `bazelisk mod deps` resolves cleanly with no override