### PR TITLE
orfs_genrule: don't force srcs into exec config; toolchain prep.

### DIFF
--- a/orfs_genrule.bzl
+++ b/orfs_genrule.bzl
@@ -1,11 +1,14 @@
-"""orfs_genrule: a genrule variant where srcs use cfg = "exec".
+"""orfs_genrule: a genrule variant with a tools attr and select() in srcs.
 
-Native genrule forces srcs into the target configuration. When srcs
-come from ORFS rules (which build in the exec configuration), this
-causes the entire ORFS pipeline to be rebuilt in a second configuration.
+Native genrule does not separate executable tools from data srcs and
+does not allow select() in srcs. orfs_genrule adds both: declare
+executable tools on the tools attr (cfg = "exec"), data on srcs
+(caller's config), and parameterise srcs with select() where useful.
 
-orfs_genrule avoids that by keeping srcs in exec configuration,
-matching where ORFS outputs already live.
+ORFS rules (orfs_run, orfs_synth, orfs_floorplan, ...) build in target
+config, so leaving srcs in the caller's (target) config keeps
+orfs_genrule consumers on the same action keys as orfs_run consumers
+of the same pipeline.
 
 Supports the same cmd substitutions as native genrule:
   $(location label), $(locations label),
@@ -60,7 +63,6 @@ orfs_genrule = rule(
         "cmd": attr.string(mandatory = True),
         "outs": attr.output_list(mandatory = True),
         "srcs": attr.label_list(
-            cfg = "exec",
             allow_files = True,
             default = [],
         ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -781,9 +781,10 @@ genrule(
     tags = ["manual"],
 )
 
-# Same as gatelist_wc but using orfs_genrule to keep srcs in exec config.
-# Native genrule forces srcs into target config, causing ORFS outputs to
-# be rebuilt in a second configuration.
+# Same as gatelist_wc but using orfs_genrule -- exercises the rule's
+# tools attr and select()-friendly srcs. Both srcs and outputs stay in
+# target config; the orfs_genrule consumer hits the same action keys
+# as orfs_run consumers of the same gatelist/spef pipeline.
 orfs_genrule(
     name = "gatelist_wc_orfs_genrule",
     srcs = [


### PR DESCRIPTION
@hzeller TL;DR make caching work and build OpenROAD once by using bazel toolchain idiom.


Claude blurb on using bazel idiomatic solution, toolchains, to avoid cfg=exec/target conflaction.


....


ORFS rules (`orfs_run`, `orfs_synth`, `orfs_floorplan`, ...) build in target config -- `src` has no cfg override. `orfs_genrule.srcs` overrides to `cfg = "exec"`, which pulls the same pipeline through a second configuration with distinct action keys. Downstream consumers that reach the pipeline through `orfs_genrule` see different cache entries than those that reach it through `orfs_run`, even though the underlying actions are identical.

Drop the override on `srcs`. Keep it on `tools` (legitimately exec -- that's where the `py_binary` / `sh_binary` tools that run during the action live). Update the docstring and the matching `test/BUILD` comment.

---

Step toward yosys/OpenROAD-as-toolchains. The current pattern in `private/attrs.bzl` is hand-wired:

```python
_openroad = attr.label(
    executable = True,
    cfg = "exec",
    default = "@openroad//:openroad",
)
```

A direct `bazelisk build //:openroad` against the OpenROAD repo resolves the `cc_binary` in target config; the attr above pulls it in exec. Same source, two action keys, rebuilt twice.

The toolchain articulation (sketched in [ideas/toolchains.md](https://github.com/The-OpenROAD-Project/bazel-orfs/blob/main/ideas/toolchains.md), source path only -- prebuilt-binary distribution out of scope):

```python
OpenroadInfo = provider(fields = {
    "openroad": "File: openroad binary",
    "opensta":  "File: opensta binary",
})

openroad_toolchain = rule(
    implementation = _impl,
    attrs = {
        "openroad": attr.label(executable=True, cfg="exec", mandatory=True),
        "opensta":  attr.label(executable=True, cfg="exec", mandatory=True),
    },
)

orfs_synth = rule(
    ...,
    toolchains = [openroad_toolchain_type],
)
# ctx.toolchains[openroad_toolchain_type].openroad_info.openroad
```

On the OpenROAD side (separate PR, gated on upstream agreement):

```python
cc_binary(
    name = "openroad_binary",   # private; source-built from
                                # (patched) tree
    ...
)

openroad_toolchain(
    name = "openroad",          # public; bazelisk build //:openroad
    openroad = ":openroad_binary",
    opensta  = "//src/sta:opensta_binary",
    visibility = ["//visibility:public"],
)
```

Both edges (direct build, rule via `ctx.toolchains[...]`) collapse to one exec-config link. `git_override(openroad, patches=[...])` keeps applying to the source tree -- the toolchain layer is orthogonal to how the binary is produced.
