### PR TITLE
Bump: ORFS c9c22caf, OpenROAD 4c26918f

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,19 +38,19 @@ bazel_dep(name = "orfs")
 # blocked (e.g. inside the maintainers organization).
 archive_override(
     module_name = "orfs",
-    integrity = "sha256-mAqlLynBNOx/poiXu+BLa7s1cJcpDR21u5leDEUF3JY=",
+    integrity = "sha256-7S55c4KG5JB/PBITOUuQQsedVpEssp11I6IYjl5/Gqs=",
     patch_strip = 1,
     patches = [
         "//patches:0036-fix-bazel-orfs-bazel_dep-non-dev-for-load-visibility.patch",
     ],
-    strip_prefix = "OpenROAD-flow-scripts-d90873f47b79f343c6be15210ce398e1383c08d2",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/d90873f47b79f343c6be15210ce398e1383c08d2.tar.gz"],
+    strip_prefix = "OpenROAD-flow-scripts-c9c22caf9bf9cfe46c5a4236c6ec7e7ae9863cc3",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/c9c22caf9bf9cfe46c5a4236c6ec7e7ae9863cc3.tar.gz"],
 )
 
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-69usuVgG/PLsXp9KcGvsndunHbJJzLFUFrlVUjORu/8=",
+    integrity = "sha256-il+C3RFw2D3109NxSuWtD2lqYNvHXMvytT62yeJqBKM=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -58,13 +58,13 @@ archive_override(
     # aren't covered by archive_override's integrity.  Regenerated
     # by bump.py on every commit bump; do not edit by hand.
     patch_cmds = [
-        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz && echo '17c490baf588ae564067d639a4938f1b749e55734a82445b0e742397a0f34ba9  .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz",
-        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz && echo 'bebf58d918646b0f6ebf62dd8cafaec5e04957388d19e99d3083456c971c211a  .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz",
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/244797f162b465751912b651d55d9854296aa745.tar.gz && echo '3780fc3badd4b3abe6047a241892c9cdfb3fef1634c466c431f8d33a444cbd18  .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz",
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz && echo '0cbf538e60d0303d0e00360d8973aaad7dae198954bed6e34cc31c9a13b3f802  .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz",
         "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz https://github.com/povik/yosys-slang/archive/82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz && echo 'd319a1f49116fb9f30341bf06324e40e0ceadfe05d0fa7b00aed4dc0dc6723f1  .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz --strip-components=1 -C third-party/slang-elab && rm .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz",
         "sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|' third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-299f30154c9a3621a701763263dc532f835ab4a5",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/299f30154c9a3621a701763263dc532f835ab4a5.tar.gz"],
+    strip_prefix = "OpenROAD-4c26918f5a77392910939b51b9c2490b7e7e3201",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/4c26918f5a77392910939b51b9c2490b7e7e3201.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.

--- a/gallery/MODULE.bazel
+++ b/gallery/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "yosys", version = "0.64")
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "d90873f47b79f343c6be15210ce398e1383c08d2",
+    commit = "c9c22caf9bf9cfe46c5a4236c6ec7e7ae9863cc3",
     patch_strip = 1,
     patches = [
         "//patches:0036-fix-bazel-orfs-bazel_dep-non-dev-for-load-visibility.patch",
@@ -39,7 +39,7 @@ use_repo(orfs, "gnumake")
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-69usuVgG/PLsXp9KcGvsndunHbJJzLFUFrlVUjORu/8=",
+    integrity = "sha256-il+C3RFw2D3109NxSuWtD2lqYNvHXMvytT62yeJqBKM=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -47,13 +47,13 @@ archive_override(
     # aren't covered by archive_override's integrity.  Regenerated
     # by bump.py on every commit bump; do not edit by hand.
     patch_cmds = [
-        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz && echo '17c490baf588ae564067d639a4938f1b749e55734a82445b0e742397a0f34ba9  .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz",
-        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz && echo 'bebf58d918646b0f6ebf62dd8cafaec5e04957388d19e99d3083456c971c211a  .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz",
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/244797f162b465751912b651d55d9854296aa745.tar.gz && echo '3780fc3badd4b3abe6047a241892c9cdfb3fef1634c466c431f8d33a444cbd18  .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz",
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz && echo '0cbf538e60d0303d0e00360d8973aaad7dae198954bed6e34cc31c9a13b3f802  .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz",
         "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz https://github.com/povik/yosys-slang/archive/82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz && echo 'd319a1f49116fb9f30341bf06324e40e0ceadfe05d0fa7b00aed4dc0dc6723f1  .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz --strip-components=1 -C third-party/slang-elab && rm .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz",
         "sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|' third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-299f30154c9a3621a701763263dc532f835ab4a5",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/299f30154c9a3621a701763263dc532f835ab4a5.tar.gz"],
+    strip_prefix = "OpenROAD-4c26918f5a77392910939b51b9c2490b7e7e3201",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/4c26918f5a77392910939b51b9c2490b7e7e3201.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.

--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -27,7 +27,7 @@ local_path_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "91d5e6af43ec5935b024d966e67c1f21a54170b0",
+    commit = "c9c22caf9bf9cfe46c5a4236c6ec7e7ae9863cc3",
     patch_strip = 1,
     patches = [
         "//patches:0036-fix-bazel-orfs-bazel_dep-non-dev-for-load-visibility.patch",
@@ -38,7 +38,7 @@ git_override(
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-2jY7mMoVfKpqmqSjAfRxrRuR2MtFlFUfDXP9mwbzmOA=",
+    integrity = "sha256-il+C3RFw2D3109NxSuWtD2lqYNvHXMvytT62yeJqBKM=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -46,13 +46,13 @@ archive_override(
     # aren't covered by archive_override's integrity.  Regenerated
     # by bump.py on every commit bump; do not edit by hand.
     patch_cmds = [
-        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz && echo '17c490baf588ae564067d639a4938f1b749e55734a82445b0e742397a0f34ba9  .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-8575070292cd0eb0150d191795ba59ca7e610ec2.tar.gz",
-        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz && echo 'bebf58d918646b0f6ebf62dd8cafaec5e04957388d19e99d3083456c971c211a  .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-17cadca080b33edc5a13c8e6e8e8092f8c350b25.tar.gz",
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/244797f162b465751912b651d55d9854296aa745.tar.gz && echo '3780fc3badd4b3abe6047a241892c9cdfb3fef1634c466c431f8d33a444cbd18  .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-244797f162b465751912b651d55d9854296aa745.tar.gz",
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz && echo '0cbf538e60d0303d0e00360d8973aaad7dae198954bed6e34cc31c9a13b3f802  .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz",
         "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz https://github.com/povik/yosys-slang/archive/82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz && echo 'd319a1f49116fb9f30341bf06324e40e0ceadfe05d0fa7b00aed4dc0dc6723f1  .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz --strip-components=1 -C third-party/slang-elab && rm .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz",
         "sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|' third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-04cbde6e14ad4f94ab65f0fef83d3923a44d269b",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/04cbde6e14ad4f94ab65f0fef83d3923a44d269b.tar.gz"],
+    strip_prefix = "OpenROAD-4c26918f5a77392910939b51b9c2490b7e7e3201",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/4c26918f5a77392910939b51b9c2490b7e7e3201.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.


### PR DESCRIPTION
Routine dependency bump via `bazelisk run //:bump`, mirrored to `gallery/`
and `test/downstream/` via `python3 bump.py --module-file <path> --ignore`.

| dep | new |
|-----|-----|
| orfs | `c9c22caf9bf9` |
| openroad | `4c26918f5a77` (src/sta `244797f1`, third-party/abc `d527cfab`) |
| bazel-orfs (gallery/test downstream pins) | `553c1c3a44f0` |

`yosys 0.64` / `yosys-slang 4e53d7729961` / `qt-bazel 886104974c2f` unchanged.

**No patches dropped this cycle.** Both remaining patches still have live
consumers and apply cleanly:
- `0036-fix-bazel-orfs-bazel_dep-non-dev-for-load-visibility.patch` — ORFS
  `c9c22caf` still declares `bazel_dep(name = "bazel-orfs", dev_dependency = True)`,
  so the fix is not upstreamed.
- `qt-bazel-xcb-cursor-from-source.patch` — qt-bazel module unchanged.

Pre-existing (not from this bump): bazel resolution warns `abc@0.64-yosyshq.bcr.1`
requested vs `bcr.2` resolved; the `bcr.1` pin is identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)