### PR TITLE
Add yosys_prefix_tar packaging macro and :yosys_tar target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":yosys_pkg.bzl", "yosys_prefix_tar")
 
 exports_files([
     "bump.py",
@@ -30,6 +31,14 @@ exports_files([
     "synth_keep.tcl",
     "synth_partition.sh",
 ])
+
+# Relocatable PREFIX tarball of the hermetic yosys build (bin/yosys,
+# bin/yosys-abc, share/yosys/...). Consumers that want plugins bundled
+# (e.g. yosys-slang) instantiate yosys_prefix_tar() themselves.
+yosys_prefix_tar(
+    name = "yosys_tar",
+    visibility = ["//visibility:public"],
+)
 
 sh_binary(
     name = "klayout",

--- a/yosys_pkg.bzl
+++ b/yosys_pkg.bzl
@@ -1,0 +1,73 @@
+"""Package the hermetic @yosys build as a relocatable PREFIX tarball.
+
+The tarball follows the standard `make install` PREFIX layout:
+
+  bin/yosys
+  bin/yosys-abc
+  share/yosys/...
+  share/yosys/plugins/*.so   (optional, via the plugins attribute)
+
+Yosys resolves its data directory as <bindir>/../share/yosys/ and abc as
+<bindir>/yosys-abc (proc_self_dirname()), so the tarball can be extracted
+into any prefix (e.g. /usr/local or a user directory) without patching.
+"""
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+# Label() resolves in bazel-orfs's repo mapping, so consumers of the
+# macro don't need their own @yosys/@abc bazel_dep.
+_YOSYS = Label("@yosys//:yosys")
+_YOSYS_SHARE = Label("@yosys//:yosys_share")
+_ABC = Label("@abc//:abc_bin")
+
+def yosys_prefix_tar(name, plugins = [], visibility = None):
+    """Create <name>.tar.gz with a relocatable PREFIX install of yosys.
+
+    Args:
+      name: name of the resulting pkg_tar target.
+      plugins: optional list of yosys plugin shared-object labels
+        (e.g. @yosys-slang//src/yosys_plugin:slang.so) placed in
+        share/yosys/plugins/ where `plugin -i <name>` finds them.
+      visibility: standard visibility.
+    """
+    pkg_files(
+        name = name + "_bin",
+        srcs = [
+            _YOSYS,
+            _ABC,
+        ],
+        attributes = pkg_attributes(mode = "0755"),
+        prefix = "bin",
+        renames = {
+            # proc_self_dirname() + "yosys-abc" is how yosys finds abc.
+            _ABC: "yosys-abc",
+        },
+    )
+    pkg_files(
+        name = name + "_share",
+        # The share tree is declared as share/<dst> in @yosys's root
+        # package; remap to the installed share/yosys/<dst> layout.
+        srcs = [_YOSYS_SHARE],
+        prefix = "share/yosys",
+        strip_prefix = strip_prefix.from_pkg("share"),
+    )
+    srcs = [
+        name + "_bin",
+        name + "_share",
+    ]
+    if plugins:
+        pkg_files(
+            name = name + "_plugins",
+            srcs = plugins,
+            attributes = pkg_attributes(mode = "0755"),
+            prefix = "share/yosys/plugins",
+        )
+        srcs.append(name + "_plugins")
+    pkg_tar(
+        name = name,
+        srcs = srcs,
+        extension = "tar.gz",
+        tags = ["manual"],
+        visibility = visibility,
+    )


### PR DESCRIPTION
Adds a `yosys_prefix_tar()` macro (rules_pkg, already a dep) and a
plugin-free `//:yosys_tar` instantiation that package the hermetic
`@yosys` BCR build as a relocatable PREFIX tarball:

```
bin/yosys
bin/yosys-abc
share/yosys/...
share/yosys/plugins/*.so   # optional, via plugins = [...]
```

Yosys resolves its data directory as `<bindir>/../share/yosys/` and abc
as `<bindir>/yosys-abc`, and the bazel build links
readline/tcl/zlib/ffi/abc statically, so the tarball extracts into any
prefix (e.g. `/usr/local`, `~/.local`, `tools/install/yosys`) without
patching.

Motivation: give installers a single source of truth for yosys — the
`@yosys` pin in bazel-orfs — instead of ad-hoc git-clone-and-make
builds. First consumer is ORFS `etc/DependencyInstaller.sh` /
`bazel/install.sh` (The-OpenROAD-Project/OpenROAD-flow-scripts#4325); ORFS vendors this
change as a `git_override` patch in the meantime, so this PR can land
whenever convenient.

Consumers that want plugins bundled instantiate the macro themselves,
e.g.:

```starlark
load("@bazel-orfs//:yosys_pkg.bzl", "yosys_prefix_tar")

yosys_prefix_tar(
    name = "yosys_tar",
    plugins = ["@yosys-slang//src/yosys_plugin:slang.so"],
)
```

Known gap: the tarball does not include the `make install` extras
(`yosys-config`, `yosys-smtbmc`, `yosys-witness`, `yosys-filterlib`);
those can be added later if a consumer needs them.
