### PR TITLE
rules: include stage data in synth OrfsDepInfo.files

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1586,8 +1586,13 @@ def _yosys_impl(ctx):
             make = make,
             config = config_short,
             renames = [],
+            # Include the stage data (sources= files) like the PnR stage
+            # rule does: orfs_arguments/orfs_run consumers stage
+            # OrfsDepInfo.files, and the synth config can reference
+            # sources= paths (e.g. LAYER_PARASITICS_FILE) that load.tcl
+            # sources at load_design time.
             files = depset(
-                [config_short] + ctx.files.extra_configs,
+                [config_short] + ctx.files.data + ctx.files.extra_configs,
             ),
             runfiles = ctx.runfiles(transitive_files = deploy_files),
         ),


### PR DESCRIPTION
## Problem

The PnR stage rule propagates `[config] + ctx.files.src + ctx.files.data + ctx.files.extra_configs` through `OrfsDepInfo.files`, but the synth rule only propagates `[config] + ctx.files.extra_configs`.

`orfs_arguments` / `orfs_run` consumers stage `OrfsDepInfo.files` of their `src` (via `source_inputs()`). When `src` is the **synth** stage, they inherit synth's config — including `sources=` variables such as `LAYER_PARASITICS_FILE` — but not the referenced files, so ORFS `load.tcl` fails at `load_design` with:

```
source hardware/tile/setRC.tcl
Error: ... couldn't read file "hardware/tile/setRC.tcl": no such file or directory
```

Hit in practice by an `orfs_arguments` heuristic reading the synth ODB in a flow that injects a per-design setRC via `sources = {"LAYER_PARASITICS_FILE": [":setRC.tcl"]}` (The-OpenROAD-Project-private/ascenium#27 follow-up). Consumers of PnR stages are unaffected.

## Fix

Include `ctx.files.data` (where `sources=` files land) in synth's `OrfsDepInfo.files`, matching the PnR stage rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
