### PR TITLE
synth: single writer for 1_synth.sdc, fail hard on missing outputs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,6 +42,7 @@ archive_override(
     patch_strip = 1,
     patches = [
         "//patches:0036-fix-bazel-orfs-bazel_dep-non-dev-for-load-visibility.patch",
+        "//patches:0037-orfs-single-writer-1_synth-sdc.patch",
     ],
     strip_prefix = "OpenROAD-flow-scripts-fb65d5b487d2afd443fc1892330f622c776a57ac",
     urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/fb65d5b487d2afd443fc1892330f622c776a57ac.tar.gz"],

--- a/patches/0037-orfs-single-writer-1_synth-sdc.patch
+++ b/patches/0037-orfs-single-writer-1_synth-sdc.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Mon, 6 Jul 2026 09:58:32 +0200
+Subject: [PATCH] synth: single writer for 1_synth.sdc
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+1_synth.sdc had two writers: yosys' synth.tcl copied the user's
+SDC_FILE into place (a leftover from before SDC canonicalization
+existed, "one day a more sophisticated synthesis..."), then
+synth_odb.tcl overwrote it in place with the OpenSTA-canonicalized
+version. cp preserves the source's mode bits, so when SDC_FILE is a
+read-only build input (bazel RBE), the copy is read-only and the
+canonicalization write fails. Locally sources are writable, so this
+only accidentally worked.
+
+Drop the copies from synth.tcl and synth_preamble.tcl:
+synth_odb.tcl/synth_syn.tcl are the sole writers of 1_synth.sdc.
+1_2_yosys.sdc (copied by the do-yosys make recipe) remains the raw
+SDC the yosys stage hands to synth_odb.tcl.
+
+Also write 1_synth.odb/.sdc unconditionally in synth_odb.tcl and
+synth_syn.tcl instead of via the orfs_write_* wrappers: producing
+those files is the step's contract, and the
+WRITE_ODB_AND_SDC_EACH_STAGE=0 no-op silently left downstream stages
+consuming the stale, non-canonicalized copy.
+
+Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
+---
+ flow/scripts/synth.tcl          | 4 ----
+ flow/scripts/synth_odb.tcl      | 9 ++++++---
+ flow/scripts/synth_preamble.tcl | 1 -
+ flow/scripts/synth_syn.tcl      | 9 ++++++---
+ 4 files changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/flow/scripts/synth.tcl b/flow/scripts/synth.tcl
+index fa7982990..8f22a9c99 100644
+--- a/flow/scripts/synth.tcl
++++ b/flow/scripts/synth.tcl
+@@ -299,7 +299,3 @@ if {
+ 
+ # Write synthesized design
+ write_verilog -nohex -nodec $::env(RESULTS_DIR)/1_2_yosys.v
+-# One day a more sophisticated synthesis will write out a modified
+-# .sdc file after synthesis. For now, just copy the input .sdc file,
+-# making synthesis more consistent with other stages.
+-log_cmd exec cp $::env(SDC_FILE) $::env(RESULTS_DIR)/1_synth.sdc
+diff --git a/flow/scripts/synth_odb.tcl b/flow/scripts/synth_odb.tcl
+index 63bdc98cd..234512889 100644
+--- a/flow/scripts/synth_odb.tcl
++++ b/flow/scripts/synth_odb.tcl
+@@ -28,9 +28,12 @@ report_design_area
+ report_design_area_metrics
+ 
+ source_step_tcl POST SYNTH
+-orfs_write_db $::env(RESULTS_DIR)/1_synth.odb
++# Producing 1_synth.odb/.sdc is this step's contract:
++# unconditional, no WRITE_ODB_AND_SDC_EACH_STAGE.
++log_cmd write_db $::env(RESULTS_DIR)/1_synth.odb
+ # Canonicalize 1_synth.sdc. The original SDC_FILE provided by
+ # the user could have dependencies, such as sourcing util.tcl,
+ # which are read in here and a canonicalized version is written
+-# out by OpenSTA that has no dependencies.
+-orfs_write_sdc $::env(RESULTS_DIR)/1_synth.sdc
++# out by OpenSTA that has no dependencies. Sole writer of
++# 1_synth.sdc.
++log_cmd write_sdc -no_timestamp $::env(RESULTS_DIR)/1_synth.sdc
+diff --git a/flow/scripts/synth_preamble.tcl b/flow/scripts/synth_preamble.tcl
+index af43512c0..58c016a7a 100644
+--- a/flow/scripts/synth_preamble.tcl
++++ b/flow/scripts/synth_preamble.tcl
+@@ -14,7 +14,6 @@ if { [env_var_exists_and_non_empty SYNTH_NETLIST_FILES] } {
+     # keep things simple we just use the creation date
+     log_cmd exec cat {*}$::env(SYNTH_NETLIST_FILES) > $::env(RESULTS_DIR)/1_2_yosys.v
+   }
+-  log_cmd exec cp -p $::env(SDC_FILE) $::env(RESULTS_DIR)/1_synth.sdc
+   if { [env_var_exists_and_non_empty CACHED_REPORTS] } {
+     log_cmd exec cp -p {*}$::env(CACHED_REPORTS) $::env(REPORTS_DIR)/.
+   }
+diff --git a/flow/scripts/synth_syn.tcl b/flow/scripts/synth_syn.tcl
+index f0469dce0..f013fd5ea 100644
+--- a/flow/scripts/synth_syn.tcl
++++ b/flow/scripts/synth_syn.tcl
+@@ -68,9 +68,12 @@ log_cmd repair_design -pre_placement
+ 
+ report_metrics 1 "synth" false false
+ 
+-orfs_write_db $::env(RESULTS_DIR)/1_synth.odb
++# Producing 1_synth.odb/.sdc is this step's contract:
++# unconditional, no WRITE_ODB_AND_SDC_EACH_STAGE.
++log_cmd write_db $::env(RESULTS_DIR)/1_synth.odb
+ # Canonicalize 1_synth.sdc. The original SDC_FILE provided by
+ # the user could have dependencies, such as sourcing util.tcl,
+ # which are read in here and a canonicalized version is written
+-# out by OpenSTA that has no dependencies.
+-orfs_write_sdc $::env(RESULTS_DIR)/1_synth.sdc
++# out by OpenSTA that has no dependencies. Sole writer of
++# 1_synth.sdc.
++log_cmd write_sdc -no_timestamp $::env(RESULTS_DIR)/1_synth.sdc

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -743,7 +743,10 @@ orfs_run_executable = rule(
 # --- Synthesis rule ---
 
 CANON_OUTPUT = "1_1_yosys_canonicalize.rtlil"
-SYNTH_OUTPUTS = ["1_2_yosys.v", "1_2_yosys.sdc", "1_synth.sdc", "mem.json"]
+
+# 1_synth.odb/.sdc are not listed here: they are produced by do-1_synth
+# (synth_odb.tcl), not yosys, and are only declared when save_odb=True.
+SYNTH_OUTPUTS = ["1_2_yosys.v", "1_2_yosys.sdc", "mem.json"]
 SYNTH_REPORTS = ["synth_stat.txt", "synth_mocked_memories.txt"]
 
 def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_reports, num_partitions, save_odb, all_arguments = {}):
@@ -1194,9 +1197,10 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
     # do-1_synth is a .PHONY target that runs synth_odb.tcl to read the
     # merged Verilog and produce the ODB; it does not trigger yosys rebuilds.
     if save_odb:
-        odb_commands = [_make_cmd(ctx)] + generation_commands(
-            [synth_outputs["1_synth.odb"]],
-        )
+        # No generation_commands: 1_synth.odb/.sdc are the step's
+        # contract; a missing one must fail the action, not be
+        # papered over with a touched empty file.
+        odb_commands = [_make_cmd(ctx)]
         ctx.actions.run_shell(
             arguments = [
                 "--file",
@@ -1375,7 +1379,7 @@ def _yosys_impl(ctx):
     synth_logs = declare_artifacts(ctx, "logs", ["1_2_yosys.log", "1_2_yosys_metrics.log"] + (["1_synth.log"] if save_odb else []))
 
     synth_outputs = {}
-    for output in SYNTH_OUTPUTS + (["1_synth.odb"] if save_odb else []):
+    for output in SYNTH_OUTPUTS + (["1_synth.odb", "1_synth.sdc"] if save_odb else []):
         synth_outputs[output] = declare_artifact(ctx, "results", output)
 
     synth_reports = declare_artifacts(ctx, "reports", SYNTH_REPORTS)
@@ -1393,10 +1397,13 @@ def _yosys_impl(ctx):
     elif num_partitions > 0:
         validated_kept_macros_json = _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_reports, num_partitions, save_odb, all_arguments)
     else:
-        # SYNTH_NETLIST_FILES will not create an .rtlil file or reports, so we need
-        # an empty placeholder in that case.
+        # SYNTH_NETLIST_FILES will not create an .rtlil file, logs,
+        # reports or mem.json, so touch empty placeholders for those.
+        # Primary artifacts (1_2_yosys.v/.sdc, 1_synth.odb/.sdc) are
+        # deliberately excluded: a missing one must fail the action,
+        # not be papered over with a touched empty file.
         commands = [_make_cmd(ctx)] + generation_commands(
-            synth_logs + synth_outputs.values() + synth_reports,
+            synth_logs + synth_reports + [synth_outputs["mem.json"]],
         )
         ctx.actions.run_shell(
             arguments = [

--- a/synth.tcl
+++ b/synth.tcl
@@ -272,7 +272,3 @@ if {
 
 # Write synthesized design
 write_verilog -nohex -nodec $::env(RESULTS_DIR)/1_2_yosys.v
-# One day a more sophisticated synthesis will write out a modified
-# .sdc file after synthesis. For now, just copy the input .sdc file,
-# making synthesis more consistent with other stages.
-log_cmd exec cp $::env(SDC_FILE) $::env(RESULTS_DIR)/1_synth.sdc


### PR DESCRIPTION
Root-cause fix for the read-only `1_synth.sdc` failure hzeller hit on RBE (OpenROAD PR [#10818](https://github.com/The-OpenROAD-Project/OpenROAD/pull/10818) worked around it with `chmod +w`).

## The bug

`1_synth.sdc` had two writers in ORFS:

1. yosys' `synth.tcl` copied the user's `SDC_FILE` into place — a leftover from before SDC canonicalization existed ("One day a more sophisticated synthesis will write out a modified .sdc").
2. `synth_odb.tcl` then overwrote it **in place** with the OpenSTA-canonicalized version (`write_sdc -no_timestamp`).

`cp` preserves mode bits, so with read-only inputs (bazel RBE) the copy is read-only and the canonicalization write fails. On writable local checkouts it only accidentally worked.

## The fix

**patches/0037** (carried until the identical fix lands in ORFS upstream, then dropped at the next bump):
- `synth.tcl` / `synth_preamble.tcl` no longer produce `1_synth.sdc`; the yosys stage's SDC output is `1_2_yosys.sdc` (raw copy), as before.
- `synth_odb.tcl` / `synth_syn.tcl` are the sole writers of `1_synth.sdc`, and write `1_synth.odb`/`.sdc` unconditionally: producing them is the `do-1_synth` contract. The `WRITE_ODB_AND_SDC_EACH_STAGE=0` no-op silently left downstream stages consuming the stale raw copy.

**rules.bzl** (fail hard and early instead of festering):
- `1_synth.sdc` is declared together with `1_synth.odb` only when `save_odb=True`, instead of as a yosys output. (`save_odb=False` users only consume the `1_2_yosys.v` output group.)
- Stop touch-masking primary artifacts (`1_2_yosys.v`/`.sdc`, `1_synth.odb`/`.sdc`) after make: a synth step that silently produced nothing used to yield empty files that flowed downstream — and would let idempotency tests compare two empty files as "identical". Now bazel fails the action with "declared output was not created". Logs, reports and `mem.json` remain touch-stubbed since the `SYNTH_NETLIST_FILES` path legitimately skips them.

## Testing

- `bazelisk test //test/...`: 43 pass; 17 fail to build locally due to the pre-existing `@scip` glibc 2.41 compile issue (unrelated — real-OpenROAD targets; covered by CI).
- Verified the patch applies to the pinned ORFS and that the patched `@orfs` scripts contain a single `1_synth.sdc` writer.

Follow-ups after merge: `bazelisk run @bazel-orfs//:bump` in OpenROAD (unblocks the RBE tests, replaces #10818), and the same fix as an ORFS PR so patch 0037 can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)