### PR TITLE
registry: drop yosys-0.64 fork registry, BCR #8862 landed

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,13 +1,5 @@
 build --incompatible_strict_action_env
 
-# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
-# registry until bazelbuild/bazel-central-registry#8862 lands. BCR is listed
-# first; the fork is only consulted for versions BCR doesn't carry yet. The
-# commit hash makes the fork reference immutable. Drop once yosys 0.64 lands
-# on BCR.
-common --registry=https://bcr.bazel.build/
-common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/c220c8fc735c0e05c0354330b8885ca36275bd02/
-
 # Required by OpenROAD (STA uses std::format_string from C++20)
 build --cxxopt "-std=c++20" --host_cxxopt "-std=c++20"
 

--- a/gallery/.bazelrc
+++ b/gallery/.bazelrc
@@ -1,14 +1,6 @@
 # OpenROAD Demo Project
 # Common settings for bazel-orfs builds
 
-# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
-# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is listed
-# first so all other modules resolve from the official source; the fork is
-# only consulted for modules/versions BCR doesn't carry yet.  The commit hash
-# makes the fork reference immutable.
-common --registry=https://bcr.bazel.build/
-common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/c220c8fc735c0e05c0354330b8885ca36275bd02/
-
 build --incompatible_strict_action_env
 
 # Required by OpenROAD (STA uses std::format_string from C++20)

--- a/test/downstream/.bazelrc
+++ b/test/downstream/.bazelrc
@@ -1,14 +1,6 @@
 # Downstream consumer test .bazelrc.
 # Workarounds here are tracked as known issues in README.md.
 
-# yosys 0.64 is not yet in BCR; add the unmerged PR's fork as a fallback
-# registry until bazelbuild/bazel-central-registry#8862 lands.  BCR is
-# listed first so all other modules resolve from the official source;
-# the fork is only consulted for modules/versions BCR doesn't carry yet.
-# The commit hash makes the fork reference immutable.
-common --registry=https://bcr.bazel.build/
-common --registry=https://raw.githubusercontent.com/oharboe/bazel-central-registry/0586b398db6edd245da97cbec29e26c5e2a808d7/
-
 common --enable_workspace
 common --lockfile_mode=off
 


### PR DESCRIPTION
yosys 0.64 (and abc 0.64-yosyshq.bcr.1) are now published on bcr.bazel.build, so the oharboe/bazel-central-registry fallback added while bazelbuild/bazel-central-registry#8862 was pending is obsolete. Dropping the --registry lines entirely also removes the explicit bcr.bazel.build entry: BCR is Bazel's default registry when no --registry flag is set.

Verified with 'bazelisk mod deps' in the root, gallery, and test/downstream workspaces.