### PR TITLE
fix: load sh_binary from @rules_shell in mock_klayout

### DIFF
--- a/mock_klayout.bzl
+++ b/mock_klayout.bzl
@@ -65,6 +65,8 @@ exit 1
 '''
 
 _BUILD = '''\
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 sh_binary(
     name = "klayout",
     srcs = ["klayout.sh"],


### PR DESCRIPTION
## Problem

Bazel 9 removed the native `sh_binary` rule. A `BUILD` file that calls it without a `load()` statement fails to load with:

```
name 'sh_binary' is not defined (did you mean 'cc_binary'?)
```

The `mock_klayout` repository rule generates a `BUILD` from the `_BUILD` template, which calls `sh_binary` directly. Under Bazel 9 this breaks any build that reaches the mock klayout target (the default klayout for the ORFS flow), e.g. `orfs_flow`/`orfs_test`/`orfs_final` targets.

## Fix

Add `load("@rules_shell//shell:sh_binary.bzl", "sh_binary")` to the generated `BUILD` template. `rules_shell` is already a `bazel_dep` in this module, so `@rules_shell` resolves in the generated repo. The load is a no-op on Bazel 8 and required on Bazel 9.

## Testing

Discovered while migrating OpenROAD to Bazel 9.1.1. With this change, `bazelisk test //test/...` (which includes ORFS gcd and mock-array flow tests) passes 45/45 under Bazel 9.