### PR TITLE
fix: load cc_binary from @rules_cc in gnumake BUILD overlay

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ local_path_override(
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 
 bazel_dep(name = "rules_pkg", version = "1.2.0")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 bazel_dep(name = "mock-klayout", version = "0.0.1", dev_dependency = True)

--- a/tools/gnumake/BUILD.gnumake
+++ b/tools/gnumake/BUILD.gnumake
@@ -4,6 +4,8 @@
 # am__append_6 (remote-stub), and the lib/Makefile am_libgnu_a_OBJECTS
 # from a configure run on Linux glibc. See tools/gnumake/config.h for the
 # matching #define set.
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "make",
     srcs = [


### PR DESCRIPTION
## Problem

Bazel 9 removed the native \`cc_binary\` rule, so a BUILD file that calls it without a \`load()\` statement fails to load. The \`gnumake\` repo's BUILD overlay (\`tools/gnumake/BUILD.gnumake\`, added in #717 when gnumake switched from the zig bootstrap to a \`cc_binary\` build) uses \`cc_binary\` directly. This is fine on Bazel 8 (bazel-orfs's own \`.bazelversion\`), but breaks any consumer that reaches \`@gnumake//:make\` under Bazel 9 — e.g. OpenROAD-as-root, which is migrating to Bazel 9:

\`\`\`
ERROR: .../gnumake/BUILD.bazel:7:10: cc_binary(
  ...
  This rule has been removed from Bazel. Please add a \`load()\` statement for it.
ERROR: no such target '@@...+gnumake//:make': target 'make' not declared in package ''
\`\`\`

## Fix

- Load \`cc_binary\` from \`@rules_cc//cc:cc_binary.bzl\` in the overlay.
- Declare \`rules_cc\` as a \`bazel_dep\` so \`@rules_cc\` resolves in the generated repo's mapping (bazel-orfs did not previously depend on it directly).

Backward-compatible: works on both Bazel 8 and Bazel 9. Mirrors the mock_klayout \`sh_binary\` fix (#759).

## Test

- \`bazelisk build --nobuild @gnumake//:make\` resolves on bazel-orfs (Bazel 8.6.0).
- With this change carried as a patch, OpenROAD-as-root passes \`bazelisk test //test/...\` 45/45 under Bazel 9.1.1.