### PR TITLE
sv-elab follow-ups: slang blackbox regression test + hermetic test/downstream build

### DIFF
--- a/slang/BUILD
+++ b/slang/BUILD
@@ -1,4 +1,4 @@
-load("//:openroad.bzl", "orfs_flow")
+load("//:openroad.bzl", "orfs_flow", "orfs_synth")
 
 # The slang yosys plugin (slang.so) is provided from BCR sv-elab via
 # orfs.default(yosys_plugins=...) in MODULE.bazel.
@@ -15,4 +15,25 @@ orfs_flow(
     verilog_files = [
         "test.sv",
     ],
+)
+
+# Regression coverage for the slang blackboxed-module path (the sv-elab
+# slang-11 failure class from OpenROAD #10884, where --ignore-unknown-modules
+# was rejected). Exercises SYNTH_BLACKBOXES + --empty-blackboxes through the
+# slang frontend; canonicalize + synth only (save_odb = False: the blackboxed
+# leaf has no LEF master). A future sv-elab bump that breaks blackboxing fails
+# here in CI.
+orfs_synth(
+    name = "blackbox_synth",
+    arguments = {
+        "SYNTH_BLACKBOXES": "leaf",
+        "SYNTH_HDL_FRONTEND": "slang",
+        "SYNTH_SLANG_ARGS": "--empty-blackboxes",
+    },
+    module_top = "blackbox_top",
+    save_odb = False,
+    sources = {
+        "SDC_FILE": ["constraints.sdc"],
+    },
+    verilog_files = ["blackbox.sv"],
 )

--- a/slang/blackbox.sv
+++ b/slang/blackbox.sv
@@ -1,0 +1,24 @@
+// Regression coverage for the slang frontend's blackboxed-module path — the
+// class of design that broke in the sv-elab slang-11 migration (OpenROAD
+// mock-array, The-OpenROAD-Project/OpenROAD#10884). `leaf` is declared with an
+// empty body and blackboxed by name via SYNTH_BLACKBOXES + --empty-blackboxes,
+// so a future sv-elab bump that regresses blackbox handling fails here in CI
+// instead of surfacing in a downstream.
+module leaf (
+    input  logic       clock,
+    input  logic [7:0] a,
+    output logic [7:0] q
+);
+endmodule
+
+module blackbox_top (
+    input  logic       clock,
+    input  logic [7:0] a,
+    output logic [7:0] q
+);
+  leaf u_leaf (
+      .clock(clock),
+      .a(a),
+      .q(q)
+  );
+endmodule

--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -58,19 +58,65 @@ single_version_override(
     version = "10.0.1-20260316-f04e8156",
 )
 
-# sed-4.9 ships gnulib's lib/memchr.c, which compiles cleanly only
-# when `memchr` is not a function-like macro at the point it defines
-# `__memchr (...)`. The existing `# undef memchr` is gated on _LIBC
-# (glibc's own build), so outside _LIBC the system <string.h>'s
-# `__glibc_const_generic` _Generic macro survives and clang rejects
-# the function header with "expected identifier or '('".  Force the
-# `# undef memchr` to run unconditionally.
+# --- hermetic-llvm compatibility (mirrored from bazel-orfs's root MODULE.bazel) ---
+# The BCR "llvm" toolchain is zero-sysroot: glibc headers arrive as explicit
+# -isystem dirs that outrank the vendored gnulib/minizip headers these
+# build-time deps ship. Every root that builds OpenROAD from source must repeat
+# these. Keep in sync with the root MODULE.bazel on each bump.
+
+# sed (transitive: abc -> ncurses -> sed): gnulib headers shadow libc headers
+# under hermetic-llvm's explicit -isystem entries (BCR #7642); 4.9.bcr.5 has the
+# upstream fix (BCR #7915).
 single_version_override(
     module_name = "sed",
-    patch_cmds = [
-        "sed -i 's|^#ifdef _LIBC$|#if 1|' lib/memchr.c",
-    ],
     version = "4.9.bcr.5",
+)
+
+# bison (transitive: rules_bison -> bison): gnulib wrapper headers must precede
+# libc via -I, not -isystem (BCR #7642). Proposed upstream as 3.8.2.bcr.8.
+single_version_override(
+    module_name = "bison",
+    patch_strip = 1,
+    patches = [
+        "//patches:0001-gnulib-wrapper-headers-use-I-not-isystem.patch",
+    ],
+    version = "3.8.2.bcr.7",
+)
+
+# boost.icl: exclusive_less_than violates strict weak ordering (boostorg/icl#51);
+# under libc++ this leaves phantom intervals after interval_set subtraction
+# (#55), misplacing pad fillers. Upstream fix (#54) lands after boost 1.90.
+single_version_override(
+    module_name = "boost.icl",
+    patch_strip = 1,
+    patches = [
+        "//patches:0001-refactor-interval-lookup-operations-icl-54.patch",
+    ],
+)
+
+# gawk (transitive: abc -> ncurses -> gawk; yosys -> gawk): same gnulib
+# libc-header shadowing as sed (BCR #7642); 5.3.2.bcr.7 has the fix (BCR #7989).
+single_version_override(
+    module_name = "gawk",
+    version = "5.3.2.bcr.7",
+)
+
+# m4 (transitive: rules_bison/rules_flex -> m4): same gnulib libc-header
+# shadowing under hermetic-llvm (BCR #7642).
+single_version_override(
+    module_name = "m4",
+    version = "1.4.21.bcr.4",
+)
+
+# tcl_lang: tclZipfs.c's #include "crypt.h" resolves to glibc's crypt.h under
+# hermetic-llvm's explicit -isystem glibc dirs; include the vendored minizip
+# header by path instead. Drop when fixed in a tcl_lang BCR release.
+single_version_override(
+    module_name = "tcl_lang",
+    patch_strip = 1,
+    patches = [
+        "//patches:0001-tclZipfs-include-vendored-minizip-crypt.h-by-path.patch",
+    ],
 )
 
 # sv-lang pulls in rules_pycross, whose toolchain extension fails on Python
@@ -88,6 +134,14 @@ git_override(
     commit = "541ebf6df76eef96c4de6343316b1c9d63e296f6",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
+
+# Hermetic C++ toolchain for building OpenROAD (and yosys) from source: the BCR
+# "llvm" module, the same zero-sysroot LLVM the root and gallery workspaces use.
+# Without it this downstream test falls back to the host compiler and breaks on
+# newer glibc (e.g. @scip/tinycthread on glibc 2.41).
+bazel_dep(name = "llvm", version = "0.8.11")
+
+register_toolchains("@llvm//toolchain:all")
 
 bazel_dep(name = "yosys", version = "0.64")
 

--- a/test/downstream/README.md
+++ b/test/downstream/README.md
@@ -45,6 +45,16 @@ would deliver these through its extension.
 bazel-orfs pip deps are locked to Python 3.13. The root module must
 register it as the default toolchain via `python.toolchain(is_default = True)`.
 
+### Hermetic C++ toolchain must be registered by root module
+
+Building OpenROAD (and yosys) from source needs the zero-sysroot BCR `llvm`
+toolchain: `bazel_dep(name = "llvm", …)` + `register_toolchains("@llvm//toolchain:all")`,
+plus the small set of hermetic-llvm compatibility `single_version_override`s
+(sed, bison, boost.icl, gawk, m4, tcl_lang) mirrored from bazel-orfs's root
+MODULE.bazel. Without the toolchain the build falls back to the host compiler
+and breaks on newer glibc (e.g. `@scip`/`tinycthread` on glibc 2.41). These
+overrides are root-module-only, so every downstream repeats them.
+
 ### slang yosys plugin from BCR (sv-elab)
 
 The slang yosys plugin comes from the `sv-elab` module on the Bazel


### PR DESCRIPTION
Two follow-ups that harden the now-merged BCR `sv-elab` migration (#763). Both
validated locally.

### `slang`: blackboxed-module regression test
CI exercised the slang frontend (`//slang:test`) but never a **blackboxed
module** — the exact path that regressed in the sv-elab slang-11 migration
(OpenROAD #10884, where `--ignore-unknown-modules` was rejected). Adds
`//slang:blackbox_synth`: a top instantiating an empty `leaf` blackboxed by name
via `SYNTH_BLACKBOXES` + `--empty-blackboxes` through the slang frontend
(canonicalize + synth only; `save_odb = False`). A future sv-elab bump that
breaks blackboxing now fails **here at bump time** instead of surfacing in a
downstream. Verified: builds green.

### `test/downstream`: build OpenROAD from source with hermetic LLVM
`test/downstream` registered no C++ toolchain, so its from-source OpenROAD build
fell back to the host compiler and broke on newer glibc (`@scip`/`tinycthread`
on glibc 2.41) — it couldn't build locally and didn't faithfully model a real
downstream. Registers the zero-sysroot BCR `llvm` toolchain and mirrors the
hermetic-llvm compatibility overrides from the root `MODULE.bazel` (`sed`
simplified to drop the host-era memchr `patch_cmds`; add `bison`, `boost.icl`,
`gawk`, `m4`, `tcl_lang`). `counter_synth` now builds OpenROAD hermetically like
root/gallery, validating the BCR `sv-elab` plugin end-to-end. Verified: builds
green. README documents the requirement.
