### PR TITLE
skills: OpenROAD/ORFS flow-debugging skills for Claude Code

### DIFF
--- a/.claude/skills/byo-openroad/SKILL.md
+++ b/.claude/skills/byo-openroad/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: byo-openroad
+description: Iterate on local OpenROAD source changes against a bazel-orfs flow by building the OpenROAD checkout binary and injecting it via OPENROAD_EXE (a bring-your-own / BYO loop), instead of encoding the diff as a base64 patch swapped into the archive_override. Use when developing or debugging an OpenROAD C++/TCL change that you need to exercise through an ORFS stage (cts, place, grt, route), when a long edit-build-run loop is taxing turnaround, or when a change "isn't taking effect" and you suspect a silently-rejected patch.
+---
+
+## Goal
+
+When you are changing OpenROAD source and need to see the effect through a
+bazel-orfs flow stage, run the flow against a binary you built directly from
+your OpenROAD checkout — **bring your own OpenROAD** — rather than routing the
+change through the module-graph patch mechanism.
+
+## The two mechanisms, and why BYO wins for a debug loop
+
+There are two ways to get a local OpenROAD change into a flow run:
+
+1. **Patch the archive_override** — encode your `git diff` (often base64) and
+   splice it into the OpenROAD `archive_override` / `git_override` in
+   `MODULE.bazel` so bazel applies it at fetch time with `patch -p1`.
+2. **BYO** — build openroad straight from the checkout and hand the flow that
+   binary via an `OPENROAD_EXE=` override.
+
+The patch mechanism is the right thing for the **final, carried** change (it is
+reproducible and hermetic). It is the wrong thing for an **iteration loop**:
+
+- `patch -p1` **silently rejects hunks** on context drift. The build keeps
+  going, and you end up debugging a binary that does not contain your change —
+  the single most expensive failure mode, because nothing tells you.
+- The regenerate-diff → re-encode → swap → re-fetch → rebuild cycle is applied
+  on every fetch and taxes every iteration.
+
+BYO removes both: the working tree **is** the source, so there is nothing to
+re-encode and nothing to silently reject.
+
+## The BYO loop
+
+```bash
+# 1. Build openroad from your checkout (the working tree is the source).
+cd /path/to/OpenROAD          # your OpenROAD checkout / ORFS tools/OpenROAD
+bazelisk build //:openroad    # (or the checkout's cmake build)
+
+# 2. Point the flow / extracted stage harness at it.
+export OPENROAD_EXE="$(readlink -f bazel-bin/openroad)"
+# ... then run the ORFS stage (make do-<stage>, or an extracted _deps run).
+```
+
+The ODB is compatible across the two binaries as long as your checkout and the
+flow's pinned OpenROAD share a base revision.
+
+## Three-tier test loop — climb only as far as you must
+
+Pick the cheapest tier that can reproduce what you are chasing; escalate only
+when it cannot:
+
+1. **Pure unit gtest (sub-second).** A dependency-free kernel test on the
+   algorithm/math you changed. No STA, no ODB, no relink of the tool library.
+   This catches most logic errors in milliseconds.
+2. **In-checkout regression test (seconds).** OpenROAD ships `//src/<tool>/test:*`
+   targets — real STA on a tiny design. These are maintained and need **no**
+   `OPENROAD_EXE` plumbing, so for anything they cover, prefer them over BYO.
+3. **Flow-level BYO run (minutes+).** The full ORFS stage on a real design with
+   your BYO binary — the final confirm. BYO earns its setup cost only here, for
+   loops the wired tests in tiers 1–2 cannot reach (e.g. a specific placed ODB).
+
+## It is a judgement call, not a rule
+
+Weigh BYO against just using the already-wired tests. Tiers 1–2 are maintained
+and plumbing-free; use them whenever they cover the change. BYO is for the
+long / flow-level loops they can't reach.
+
+## The real fix: make a rejected patch LOUD
+
+The root hazard is that `patch -p1` returns nonzero on a reject but the build
+swallows it. Whatever your carry mechanism, make a mis-applied patch **fail the
+build hard** rather than masquerade as a working binary:
+
+- check the `patch` exit status and abort the build on nonzero, **or**
+- add a post-patch sentinel: grep the patched file for a known unique line from
+  your patch and fail if it is absent.
+
+A loud patch failure turns the worst BYO-motivating failure mode (a silent
+no-op binary) into an immediate, obvious build error — at which point the patch
+path is safe for iteration too.

--- a/.claude/skills/orfs-deps-preflight/SKILL.md
+++ b/.claude/skills/orfs-deps-preflight/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: orfs-deps-preflight
+description: Pre-flight an hours-long ORFS _deps / make-extract stage run (grt, place, route, SAIF) by dumping the stage's effective variables and mentally dry-running the flow TCL to confirm the code path you are testing will actually execute. Use before committing to any long OpenROAD flow-stage run, especially when a SKIP_* flag, an *_EFFORT setting, or a setup/hold selector could silently route around what you intend to measure.
+---
+
+## Goal
+
+Never discover *after* an hours-long run that a `SKIP_*` flag or a helper default
+routed around the exact code path you were trying to exercise. Spend a few
+minutes up front proving the run will hit it.
+
+## The core move: mentally dry-run the flow TCL
+
+ORFS flow scripts read only a handful of env vars — stepping through
+`global_route.tcl` / `util.tcl` (or the relevant stage script) by hand is quick.
+Trace which vars gate your target code path, plug in your intended settings, and
+**predict the exact command the run will emit** and whether your path executes.
+If the prediction is wrong, adjust the invocation **before** launching. This is
+minutes of reading that saves hours of runtime.
+
+## Know how each var reaches the tool — cmdline vs export
+
+This is the subtlety that bites: a `make` command-line variable does **not**
+reach openroad's process env unless the Makefile explicitly `export`s it (make
+does not auto-export cmdline vars).
+
+- A var the stage's `args.mk` marks `export` **does** propagate when you override
+  it on the make command line (e.g. `SKIP_INCREMENTAL_REPAIR=...`).
+- A var that is only read from the TCL's `::env(...)` but is **not** exported by
+  the flow **will not** see your make-cmdline override — you must pass it as a
+  real exported ENV var.
+
+Worked example of the failure mode: a repair helper selects `-setup` vs `-hold`
+from `::env(REPAIR_SETUP_ONLY)`, defaulting to setup-only unless it equals `0`.
+If that var is neither in the `args.mk` nor blanket-exported, a make-cmdline
+`REPAIR_SETUP_ONLY=0` never reaches openroad → the run silently does setup-only
+and tests nothing about hold. The fix is to export it as an ENV var, not pass it
+on the make line.
+
+## The pre-flight checklist
+
+1. **Dump the stage's effective vars.** Grep the stage `*.args.mk` (e.g.
+   `<stage>.args.mk`) for the gating vars — `SKIP_*`, `*_EFFORT`,
+   `*_SLACK_MARGIN`, setup/hold selectors — and note your command-line
+   overrides, remembering cmdline beats `?=`/`export` **only for exported vars**.
+2. **Read the flow TCL to see how those vars gate your target.** e.g.
+   `global_route.tcl`'s `if { !$SKIP_INCREMENTAL_REPAIR } { ... repair_timing_helper }`,
+   and the helper's `-setup`/`-hold`/`-effort` logic. Write down the exact
+   command your run should emit (the flow echoes it back).
+3. **Prove the path fires.** Once running, check the log for the invocation and
+   its markers before trusting the result (e.g. `repair_timing`, the RSZ hold-
+   endpoint / hold-buffer messages, `Took N seconds: <command>`). If a phase is
+   absent, a flag routed around it — stop and fix the invocation.
+4. **Only then commit to the hours-long run.**
+
+## Not every log tag matches the stage name
+
+OpenROAD passes call into each other's code, so a stage log naturally interleaves
+message tags from other modules — e.g. a global-route (`grt`) run emits
+detailed-router (`DRT-*`) messages during `pin_access`, which is drt code that
+grt pulls on as slow prep *before* `repair_timing`. Seeing another module's tag
+is not evidence of a mis-run stage; check the actual command sequence, not the
+tag prefixes.
+
+Pairs with `repair-timing-grt` (a skip-repair grt measures nothing about repair)
+and `byo-openroad`.

--- a/.claude/skills/repair-timing-grt/SKILL.md
+++ b/.claude/skills/repair-timing-grt/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: repair-timing-grt
+description: Investigate OpenROAD global-route repair_timing correctly — the grt "grind"/timeout, hold- and setup-buffer insertion. Covers why a skip-repair (fast) grt measures nothing about repair, why repair_timing must run inside global_route.tcl on the pre-GR ODB, and how to split the grind into setup vs hold before blaming either. Use when a grt stage times out or runs for hours, when a change is meant to affect repair_timing, or when reasoning about hold vs setup buffer insertion at global route.
+---
+
+## Goal
+
+Get a *trustworthy* answer about `repair_timing` at global route: whether it
+grinds, why, and whether a proposed change moves it. Three traps below have each
+wasted hours-long runs; avoid all three before drawing any conclusion.
+
+## Trap 1 — a skip-repair / fast grt measures nothing about repair
+
+When the question is about **repair_timing** (the grt grind/timeout, hold- or
+setup-buffer insertion), do NOT use a fast/skip-repair grt flow
+(`SKIP_INCREMENTAL_REPAIR=1`, `SKIP_CTS_REPAIR_TIMING=1`, or a
+`grt_skiprepair`-style extract). It skips `repair_design` / `repair_timing`
+entirely — it only global-routes and estimates parasitics — so a clean, fast
+exit tells you **nothing** about whether repair grinds. Using it to "test the
+grind" is structurally meaningless.
+
+The fast-grt flow is built for clock **skew / parasitic re-measurement**, where
+skipping repair is exactly what you want. For anything about repair, run the
+FULL grt with repair enabled (`SKIP_INCREMENTAL_REPAIR=0`).
+
+## Trap 2 — repair_timing needs the live global-route structures
+
+`repair_timing` must run **inside `global_route.tcl`, on the pre-GR ODB.** It
+needs the live global-route structures (GR grid, congestion, routing guides)
+that are **not** persisted in the saved post-GR ODB. So you cannot bolt
+`repair_timing` onto a saved post-GR ODB in a fresh session — it must happen in
+the same openroad session as `global_route`, which is exactly what
+`global_route.tcl` does:
+
+```tcl
+# (shape of the flow script)
+global_route
+if { !$SKIP_INCREMENTAL_REPAIR } {
+  repair_design_helper
+  repair_timing_helper
+}
+```
+
+To test repair on a **modified netlist**, stage the PRE-GR ODB (the CTS-stage
+output) into the grt extract and run the grt stage with
+`SKIP_INCREMENTAL_REPAIR=0`, so `global_route` rebuilds the structures and
+repair runs live. Do NOT reuse a saved post-GR ODB.
+
+## Trap 3 — split the grind into setup vs hold before blaming either
+
+The grind can be **setup-dominated** (a large count of setup-violated endpoints
+at negative clock slack — a design far from setup closure) or **hold-dominated**
+(many hold endpoints → many hold buffers), and the two want completely different
+fixes. A hold-side fix does not touch a setup-dominated grind, and vice versa.
+
+Before trusting any grt result about repair, always:
+
+1. **Confirm `repair_timing` actually ran** — grep the log for `repair_timing`,
+   `RSZ-` messages, and `Took N seconds: repair_timing`. If absent, a `SKIP_*`
+   flag routed around it (Trap 1).
+2. **Split setup vs hold** — read the setup-violated vs hold-violated endpoint
+   counts and the setup- vs hold-buffer counts from the RSZ messages. Attribute
+   the runtime to whichever dominates.
+3. **Reconcile your hypothesis against the split.** If you framed the problem as
+   a "hold pathology" but the measured grind is setup, the framing is wrong —
+   fix the attribution before proposing a hold fix.
+
+## Note on the effort dial
+
+`repair_timing -effort low|medium|high` instruments the **setup** phase's
+marginal-progress stop (it bails out of a non-convergent setup grind early). It
+does not currently have an equivalent knob for the hold phase, and hold repair
+is generally harder to bound than setup — so do not expect `-effort low` to
+shorten a hold-dominated grind. See the deps-preflight skill for confirming
+which effort actually reaches the tool.
+
+Pairs with `byo-openroad` (iterate on a repair change) and `orfs-deps-preflight`
+(validate the code path before the hours-long run).


### PR DESCRIPTION
Adds three generic, design-agnostic Claude Code skills under `.claude/skills/`,
distilled from real OpenROAD/ORFS flow-debugging sessions. They encode technique
only — no design names, no numbers, no project-specific pins.

## Skills

- **`byo-openroad`** — iterate on local OpenROAD source changes by building the
  checkout binary and injecting it via `OPENROAD_EXE` (a bring-your-own loop),
  instead of encoding the diff as a base64 `archive_override` patch that
  `patch -p1` can silently reject on context drift (leaving you debugging a
  binary that lacks your change). Includes the three-tier
  gtest → in-checkout regression test → flow-level BYO loop, when BYO is worth
  its cost vs. the already-wired tests, and how to make a rejected patch fail the
  build loud.

- **`repair-timing-grt`** — investigate global-route `repair_timing` correctly.
  A skip-repair/fast grt measures nothing about repair; `repair_timing` must run
  inside `global_route.tcl` on the pre-GR ODB (it needs the live GR structures
  that the saved post-GR ODB doesn't carry); and the grind must be split into
  setup vs hold before blaming either, since the two want different fixes.

- **`orfs-deps-preflight`** — before an hours-long `_deps`/make-extract stage
  run, dump the stage's effective vars and mentally dry-run the flow TCL to
  confirm the code path you're testing will actually execute. Covers the
  make-cmdline-vs-`export` propagation gotcha and that cross-module log tags
  (e.g. `DRT-*` during a grt `pin_access`) are normal, not a mis-run stage.

All three are self-contained SKILL.md files following the standard skill
frontmatter format.