### PR TITLE
Make the stage SDC a first-class OrfsInfo output

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -18,6 +18,12 @@ def odb_arguments(ctx, short = False):
         return {"ODB_FILE": file_path(odb, short)}
     return {}
 
+def sdc_arguments(ctx, short = False):
+    if ctx.attr.src[OrfsInfo].sdc:
+        sdc = ctx.attr.src[OrfsInfo].sdc
+        return {"SDC_FILE": file_path(sdc, short)}
+    return {}
+
 def _work_home(ctx):
     # For external repo targets, declared files are placed under
     # bin/external/<repo>/<package>, but genfiles_dir.path is just bin/.

--- a/private/providers.bzl
+++ b/private/providers.bzl
@@ -7,6 +7,7 @@ OrfsInfo = provider(
         "config",
         "variant",
         "odb",
+        "sdc",
         "gds",
         "lef",
         "lib",

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -40,6 +40,7 @@ load(
     "renames",
     "required_arguments",
     "run_arguments",
+    "sdc_arguments",
     "source_inputs",
     "test_inputs",
     "verilog_arguments",
@@ -252,6 +253,7 @@ def _macro_impl(ctx):
         ),
         OrfsInfo(
             odb = info.get("odb"),
+            sdc = info.get("sdc"),
             gds = info.get("gds"),
             lef = info.get("lef"),
             lib = info.get("lib"),
@@ -359,6 +361,7 @@ def _run_impl(ctx):
             yosys_environment(ctx) |
             config_environment(config) |
             odb_arguments(ctx) |
+            sdc_arguments(ctx) |
             data_arguments(ctx) |
             run_arguments(ctx),
         ),
@@ -389,6 +392,7 @@ def _run_impl(ctx):
                             '"$@"': environment_string(
                                         hack_away_prefix(
                                             arguments = odb_arguments(ctx) |
+                                                        sdc_arguments(ctx) |
                                                         data_arguments(ctx) |
                                                         run_arguments(ctx),
                                             prefix = config.root.path,
@@ -478,6 +482,7 @@ def _arguments_impl(ctx):
             yosys_environment(ctx) |
             config_environment(src_info.config) |
             odb_arguments(ctx) |
+            sdc_arguments(ctx) |
             data_arguments(ctx) |
             run_arguments(ctx) |
             {"OUTPUT": computed_json.path},
@@ -505,6 +510,7 @@ def _arguments_impl(ctx):
             config = src_info.config,
             variant = src_info.variant,
             odb = src_info.odb,
+            sdc = src_info.sdc,
             gds = src_info.gds,
             lef = src_info.lef,
             lib = src_info.lib,
@@ -579,7 +585,7 @@ fi
                 makefile = ctx.file._makefile.path,
                 moreargs = environment_string(
                     hack_away_prefix(
-                        arguments = odb_arguments(ctx) | data_arguments(ctx),
+                        arguments = odb_arguments(ctx) | sdc_arguments(ctx) | data_arguments(ctx),
                         prefix = config.root.path,
                     ) |
                     {"DESIGN_CONFIG": config.short_path} |
@@ -662,7 +668,7 @@ def _run_executable_impl(ctx):
 
     moreargs = environment_string(
         hack_away_prefix(
-            arguments = odb_arguments(ctx) | data_arguments(ctx),
+            arguments = odb_arguments(ctx) | sdc_arguments(ctx) | data_arguments(ctx),
             prefix = config.root.path,
         ) |
         {
@@ -1608,6 +1614,7 @@ def _yosys_impl(ctx):
             config = config,
             variant = ctx.attr.variant,
             odb = synth_outputs.get("1_synth.odb"),
+            sdc = synth_outputs.get("1_synth.sdc"),
             gds = None,
             lef = None,
             lib = None,
@@ -1983,6 +1990,7 @@ def _make_impl(
             config = config,
             variant = ctx.attr.variant,
             odb = info.get("odb"),
+            sdc = info.get("sdc"),
             gds = info.get("gds"),
             lef = info.get("lef"),
             lib = info.get("lib"),


### PR DESCRIPTION
## Motivation

Every flow stage produces both a `.odb` and a `.sdc` — the `.sdc` is declared in each stage's `result_names` and staged into consumers via `DefaultInfo.files` — but `OrfsInfo` only exposed the `.odb`. `odb_arguments()` sets `ODB_FILE` from `OrfsInfo.odb`; there was no `SDC_FILE` counterpart.

So a rule that opens a stage ODB (`orfs_run`, `orfs_test`, `orfs_run_executable`, `gui_*`) got a handle on the ODB but **not** its matching SDC. `open.tcl` then had to rediscover the SDC by globbing `RESULTS_DIR` (`find_sdc_file`). That fails when the consumer's `RESULTS_DIR` doesn't coincide with where the stage results were staged — e.g. a report target in a different package than its `src` stage — forcing a fall-through to the design's `SDC_FILE`.

## Change

Surface the SDC symmetrically to the ODB:

- add an `sdc` field to `OrfsInfo` (`private/providers.bzl`)
- populate it in every `OrfsInfo` constructor: `info.get("sdc")` for the make/macro stage impls, `synth_outputs.get("1_synth.sdc")` for synth, passthrough for `orfs_arguments`
- add `sdc_arguments(ctx)` mirroring `odb_arguments(ctx)` (`private/environment.bzl`), wired in everywhere `odb_arguments` already sets `ODB_FILE` (the run/arguments/test/run_executable action env, and the `bazel run` deploy template)

`info["sdc"]` is already computed by the `info[file.extension] = file` loop and the `.sdc` is already an action input, so no new file wiring is needed. `find_sdc_file` stays — still needed for intermediate sub-stage ODBs (`3_3_place_gp.odb`, …) and arbitrary `ABSTRACT_SOURCE` targets that have no matching SDC.

## Validation

- `buildifier` clean; full analysis (`build --nobuild`) of place/cts/test stage targets OK.
- `aquery` on a place-stage report consumer (`//test:L1MetadataArray_place_html_gen`) now shows `SDC_FILE=.../3_place.sdc` alongside `ODB_FILE=.../3_place.odb` (previously only `ODB_FILE`), in both the build action env and the `bazel run` deploy string.
- That report builds end-to-end (exit 0), i.e. `open.tcl` reads the staged stage SDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)