### PR TITLE
pin: verify the pin upload before writing the lock

### DIFF
--- a/tools/pin/pin.py
+++ b/tools/pin/pin.py
@@ -182,7 +182,16 @@ def main():
 
         dir, _ = os.path.splitext(args.lock)
         name = os.path.join(args.package, dir, sha256.hexdigest() + ".tar")
-        subprocess.run(["gsutil", "mv", "-n", "-Z", tar_path, gs(args.bucket, name)])
+        # A failed upload must never yield a lock file pointing at a
+        # missing object: check=True makes the mv fatal, and the stat
+        # proves the object is actually fetchable before the lock is
+        # written. A no-clobber (-n) skip of an already-present object
+        # still exits 0, so legitimate content-addressed re-pins pass.
+        subprocess.run(
+            ["gsutil", "mv", "-n", "-Z", tar_path, gs(args.bucket, name)],
+            check=True,
+        )
+        subprocess.run(["gsutil", "stat", gs(args.bucket, name)], check=True)
 
         with open(
             os.path.join(


### PR DESCRIPTION
The pin tool uploaded the tarball with an unchecked `gsutil mv`:

```python
subprocess.run(["gsutil", "mv", "-n", "-Z", tar_path, gs(args.bucket, name)])
# ...then unconditionally writes the lock file with the computed sha256
```

When the upload failed (transient GCS/network/auth blip, quota), the non-zero exit was swallowed and `main()` still wrote the lock file with the sha it *intended* to upload. Consumers of that lock then fetch a URL whose object was never stored and get `GET 404 Not Found` — reproduced downstream where a nightly pin PR bumped a lock to a tarball that was never uploaded.

**Fix.** Make the `mv` fatal (`check=True`) and `gsutil stat` the object before the lock is written, so a failed upload aborts before the lock changes. A no-clobber (`-n`) skip of an already-present object still exits 0, so legitimate content-addressed re-pins pass unaffected.

Verified: `pin.py` still parses; a behavioral check confirms the hardened tail raises `CalledProcessError` and leaves the lock untouched when `gsutil` exits non-zero.