### PR TITLE
rules: stage yosys data= files in bazel run deploy runfiles

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1642,7 +1642,7 @@ def _yosys_impl(ctx):
         name = ctx.attr.name + "_deps",
     )
 
-    _runfiles_files = [config_short, make] + outputs + canon_logs + synth_logs + synth_jsons + ctx.files.extra_configs
+    _runfiles_files = [config_short, make] + outputs + canon_logs + synth_logs + synth_jsons + ctx.files.extra_configs + ctx.files.data
     _runfiles_common = depset(
         transitive = [
             deps_inputs(ctx),


### PR DESCRIPTION
The `_yosys_impl` runfiles omit `ctx.files.data`, so files passed via `data =` to the synth stage are missing from the `bazel run` deploy tree. Any script the deploy sources behind a `[file exists ...]` guard is then silently skipped, making interactive `open_*`/`gui_*` sessions behave differently from the build. Stage `ctx.files.data` alongside `extra_configs`.

Carried and proven in a downstream consumer for a couple of weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)