### PR TITLE
feat: Add orfs_variables rule and extra_arguments to orfs_run

### DIFF
--- a/openroad.bzl
+++ b/openroad.bzl
@@ -58,6 +58,7 @@ load(
     _orfs_run_executable = "orfs_run_executable",
     _orfs_test = "orfs_test",
     _orfs_update_rules = "orfs_update_rules",
+    _orfs_variables = "orfs_variables",
 )
 load(
     "//private:stages.bzl",
@@ -106,6 +107,7 @@ flow_provides = _flow_provides
 orfs_pdk = _orfs_pdk
 orfs_macro = _orfs_macro
 orfs_run = _orfs_run
+orfs_variables = _orfs_variables
 orfs_run_executable = _orfs_run_executable
 orfs_test = _orfs_test
 orfs_floorplan = _orfs_floorplan

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -18,6 +18,7 @@ load(
     "orfs_run",
     "orfs_squashed",
     "orfs_synth_rule",
+    "orfs_variables",
 )
 load(
     "//private:stages.bzl",
@@ -339,6 +340,11 @@ def orfs_flow(
         **kwargs
     )
 
+    orfs_variables(
+        name = _step_name(name, variant, "variables"),
+        arguments = arguments | user_arguments,
+    )
+
     if not mock_area:
         return
 
@@ -374,7 +380,6 @@ def orfs_flow(
         blender = blender,
         **kwargs
     )
-
     orfs_arguments(
         name = mock_area_name,
         src = _step_name(name, variant, "floorplan"),

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -6,6 +6,7 @@ load(
     "flow_provides",
     "openroad_attrs",
     "openroad_only_attrs",
+    "orfs_attrs",
     "renamed_inputs_attr",
     "synth_attrs",
     "yosys_attrs",
@@ -337,10 +338,33 @@ orfs_deploy_srcs = rule(
 # --- Run rule ---
 
 def _run_impl(ctx):
-    config = ctx.attr.src[OrfsInfo].config
+    if OrfsInfo in ctx.attr.src:
+        config = ctx.attr.src[OrfsInfo].config
+    else:
+        config = ctx.attr.src[OrfsDepInfo].config
     outs = []
     for k in dir(ctx.outputs):
         outs.extend(getattr(ctx.outputs, k))
+
+    original_config = config
+    all_jsons = ctx.files.extra_arguments + (ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else [])
+    if all_jsons:
+        args_mk = declare_artifact(ctx, "results", ctx.attr.name + ".args.mk")
+        ctx.actions.run(
+            executable = ctx.executable._python,
+            arguments = [ctx.file._merge_arguments.path, args_mk.path] + [f.path for f in all_jsons],
+            inputs = all_jsons + [ctx.file._merge_arguments],
+            outputs = [args_mk],
+        )
+        new_config = declare_artifact(ctx, "results", ctx.attr.name + ".config.mk")
+        ctx.actions.write(
+            output = new_config,
+            content = "include {args}\ninclude {config}\n".format(args = args_mk.path, config = original_config.path),
+        )
+        config = new_config
+        extra_files = [args_mk, original_config]
+    else:
+        extra_files = [original_config]
 
     ctx.actions.run_shell(
         arguments = [
@@ -366,7 +390,7 @@ def _run_impl(ctx):
             run_arguments(ctx),
         ),
         inputs = depset(
-            [config, ctx.file.script],
+            [config, ctx.file.script] + extra_files,
             transitive = [
                 data_inputs(ctx),
                 source_inputs(ctx),
@@ -414,12 +438,12 @@ def _run_impl(ctx):
         OutputGroupInfo(**{f.basename: depset([f]) for f in outs}),
         OrfsDepInfo(
             make = make,
-            config = ctx.attr.src[OrfsDepInfo].config,
+            config = config,
             renames = [],
-            files = depset([ctx.attr.src[OrfsDepInfo].config, ctx.file.script]),
+            files = depset([config, ctx.file.script] + extra_files),
             runfiles = ctx.runfiles(
                 transitive_files = depset(
-                    [ctx.attr.src[OrfsDepInfo].config, make, ctx.file.script],
+                    [config, make, ctx.file.script] + extra_files,
                     transitive = [
                         flow_inputs(ctx),
                         data_inputs(ctx),
@@ -452,6 +476,16 @@ orfs_run = rule(
                     allow_single_file = ["tcl"],
                 ),
             },
+)
+
+def _variables_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".json")
+    ctx.actions.write(out, json.encode(data_arguments(ctx)))
+    return [DefaultInfo(files = depset([out]))]
+
+orfs_variables = rule(
+    implementation = _variables_impl,
+    attrs = orfs_attrs(),
 )
 
 # --- Arguments rule ---
@@ -2077,7 +2111,7 @@ def _make_impl(
             config = config_short,
             renames = stage_renames,
             files = depset(
-                [config_short] +
+                [config_short, args_mk] +
                 ctx.files.src +
                 ctx.files.data +
                 ctx.files.extra_configs,

--- a/test/BUILD
+++ b/test/BUILD
@@ -1473,3 +1473,30 @@ sh_test(
         "@yosys",
     ],
 )
+
+load("//:openroad.bzl", "orfs_variables")
+
+orfs_variables(
+    name = "my_variables",
+    arguments = {
+        "MY_CUSTOM_VAR": "42",
+    },
+)
+
+orfs_run(
+    name = "my_run_test",
+    src = ":lb_32x128_synth",
+    outs = ["my_run_test.txt"],
+    arguments = {
+        "OUTPUT": "$(location :my_run_test.txt)",
+    },
+    extra_arguments = [":my_variables"],
+    script = "write_my_var.tcl",
+)
+
+sh_test(
+    name = "extra_arguments_test",
+    srcs = ["verify_my_var.sh"],
+    args = ["$(location :my_run_test.txt)"],
+    data = [":my_run_test.txt"],
+)

--- a/test/verify_my_var.sh
+++ b/test/verify_my_var.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+output_file="$1"
+
+if grep -q "MY_CUSTOM_VAR is 42" "$output_file"; then
+    echo "PASS: Found expected variable value in $output_file"
+    exit 0
+else
+    echo "FAIL: Did not find expected variable value in $output_file"
+    cat "$output_file"
+    exit 1
+fi

--- a/test/write_my_var.tcl
+++ b/test/write_my_var.tcl
@@ -1,0 +1,7 @@
+set f [open $::env(OUTPUT) w]
+if {[info exists ::env(MY_CUSTOM_VAR)]} {
+    puts $f "MY_CUSTOM_VAR is $::env(MY_CUSTOM_VAR)"
+} else {
+    puts $f "MY_CUSTOM_VAR is MISSING"
+}
+close $f


### PR DESCRIPTION
Allows injecting external variables into an orfs_run environment without vendoring fallback values.