### PR TITLE
core: support stage variable filtering for extra arguments

### DIFF
--- a/private/merge_arguments.py
+++ b/private/merge_arguments.py
@@ -1,20 +1,34 @@
-"""Merge .json argument files into a Makefile-style config."""
-
 import json
 import sys
+import argparse
 
 
 def main():
-    output_path = sys.argv[1]
-    json_paths = sys.argv[2:]
+    parser = argparse.ArgumentParser(description="Merge .json argument files into a Makefile-style config.")
+    parser.add_argument("output_path", help="Path to write the args.mk file")
+    parser.add_argument("--filter", help="Path to JSON file containing 'allowed' and 'known' variables", default=None)
+    parser.add_argument("json_paths", nargs="+", help="Paths to the input .json files")
+    args = parser.parse_args()
 
     result = {}
-    for path in json_paths:
+    for path in args.json_paths:
         with open(path) as f:
             result.update(json.load(f))
 
-    with open(output_path, "w") as out:
+    if args.filter:
+        with open(args.filter) as f:
+            filter_data = json.load(f)
+        allowed = set(filter_data.get("allowed", []))
+        known = set(filter_data.get("known", []))
+    else:
+        allowed = set()
+        known = set()
+
+    with open(args.output_path, "w") as out:
         for k, v in sorted(result.items()):
+            if args.filter:
+                if k in known and k not in allowed:
+                    continue
             out.write("export {}?={}\n".format(k, v))
 
 

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -63,6 +63,8 @@ load(
 )
 load(
     "//private:stages.bzl",
+    "ALL_STAGE_TO_VARIABLES",
+    "ALL_VARIABLE_TO_STAGES",
     "STAGE_SUBSTEPS",
 )
 
@@ -350,10 +352,37 @@ def _run_impl(ctx):
     all_jsons = ctx.files.extra_arguments + (ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else [])
     if all_jsons:
         args_mk = declare_artifact(ctx, "results", ctx.attr.name + ".args.mk")
+
+        args = [ctx.file._merge_arguments.path, args_mk.path]
+        inputs = all_jsons + [ctx.file._merge_arguments]
+
+        if OrfsInfo in ctx.attr.src:
+            stage = ctx.attr.src[OrfsInfo].stage
+            filter_json = declare_artifact(ctx, "results", ctx.attr.name + ".filter.json")
+
+            # Resolve canonical stage name
+            canonical_stage = stage
+            for s in ALL_STAGE_TO_VARIABLES.keys():
+                if stage.endswith("_" + s) or stage == s:
+                    canonical_stage = s
+                    break
+
+            ctx.actions.write(
+                output = filter_json,
+                content = json.encode({
+                    "allowed": ALL_STAGE_TO_VARIABLES.get(canonical_stage, []),
+                    "known": ALL_VARIABLE_TO_STAGES.keys(),
+                }),
+            )
+            args.extend(["--filter", filter_json.path])
+            inputs.append(filter_json)
+
+        args.extend([f.path for f in all_jsons])
+
         ctx.actions.run(
             executable = ctx.executable._python,
-            arguments = [ctx.file._merge_arguments.path, args_mk.path] + [f.path for f in all_jsons],
-            inputs = all_jsons + [ctx.file._merge_arguments],
+            arguments = args,
+            inputs = inputs,
             outputs = [args_mk],
         )
         new_config = declare_artifact(ctx, "results", ctx.attr.name + ".config.mk")
@@ -1898,11 +1927,27 @@ def _make_impl(
     extra_arg_files = ctx.files.extra_arguments
     all_jsons = inherited_jsons + [stage_json] + extra_arg_files
     args_mk = declare_artifact(ctx, "results", stage + ".args.mk")
+
+    canonical_stage = stage
+    for s in ALL_STAGE_TO_VARIABLES.keys():
+        if stage.endswith("_" + s) or stage == s:
+            canonical_stage = s
+            break
+
+    filter_json = declare_artifact(ctx, "results", stage + ".filter.json")
+    ctx.actions.write(
+        output = filter_json,
+        content = json.encode({
+            "allowed": ALL_STAGE_TO_VARIABLES.get(canonical_stage, []),
+            "known": ALL_VARIABLE_TO_STAGES.keys(),
+        }),
+    )
+
     ctx.actions.run(
         executable = ctx.executable._python,
-        arguments = [ctx.file._merge_arguments.path, args_mk.path] +
+        arguments = [ctx.file._merge_arguments.path, args_mk.path, "--filter", filter_json.path] +
                     [f.path for f in all_jsons],
-        inputs = all_jsons + [ctx.file._merge_arguments],
+        inputs = all_jsons + [ctx.file._merge_arguments, filter_json],
         outputs = [args_mk],
     )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -1499,4 +1500,38 @@ sh_test(
     srcs = ["verify_my_var.sh"],
     args = ["$(location :my_run_test.txt)"],
     data = [":my_run_test.txt"],
+)
+
+write_file(
+    name = "dump_floorplan_vars_tcl",
+    out = "dump_floorplan_vars.tcl",
+    content = ["""
+set out_file $env(OUT_vars_txt)
+set fp [open $out_file w]
+foreach var {CORE_UTILIZATION CORE_MARGIN PLACE_DENSITY} {
+    if {[info exists env($var)]} {
+        puts $fp "$var=$env($var)"
+    } else {
+        puts $fp "$var=MISSING"
+    }
+}
+close $fp
+"""],
+)
+
+orfs_run(
+    name = "verify_synth_propagated_vars",
+    src = ":lb_32x128_synth",
+    outs = ["propagated_vars.txt"],
+    arguments = {
+        "OUT_vars_txt": "$(location :propagated_vars.txt)",
+    },
+    script = ":dump_floorplan_vars_tcl",
+)
+
+sh_test(
+    name = "orfs_run_info_propagation_test",
+    srcs = ["verify_orfs_run_vars.sh"],
+    args = ["$(location :propagated_vars.txt)"],
+    data = [":propagated_vars.txt"],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -1521,7 +1521,7 @@ close $fp
 
 orfs_run(
     name = "verify_synth_propagated_vars",
-    src = ":lb_32x128_synth",
+    src = ":lb_32x128_shared_synth_floorplan",
     outs = ["propagated_vars.txt"],
     arguments = {
         "OUT_vars_txt": "$(location :propagated_vars.txt)",

--- a/test/verify_orfs_run_vars.sh
+++ b/test/verify_orfs_run_vars.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+output_file="$1"
+
+fail=0
+for var in CORE_UTILIZATION CORE_MARGIN PLACE_DENSITY; do
+    if ! grep -q "$var=" "$output_file"; then
+        echo "FAIL: Missing $var in $output_file"
+        fail=1
+    elif grep -q "$var=MISSING" "$output_file"; then
+        echo "FAIL: $var was MISSING in $output_file"
+        fail=1
+    fi
+done
+
+if [ $fail -eq 1 ]; then
+    echo "Output contents:"
+    cat "$output_file"
+    exit 1
+fi
+echo "PASS: All required variables found."
+exit 0


### PR DESCRIPTION
This prevents variables mapped exclusively to other stages (like floorplan arguments) from improperly leaking into downstream stages via extra_arguments json propagation.

<!-- START_COST_TAXONOMY -->
### Cost taxonomy

| Category | What happened | Actionable Fix | Wall-clock | Main Tokens | Subagent Tokens |
|---|---|---|---:|---:|---:|
| **thinking** | Traced `mutually exclusive` crash to `synth.args.json` leaking `CORE_AREA` into `pin_placement` floorplan target because static filtering was removed in `stages.bzl` | Retained static filtering in `stages.bzl` and correctly implemented dynamic filtering in `rules.bzl` (`_run_impl` and `_make_impl`) | 30m | 60k | 0 |
| **Total** | | | **30m** | **60k** | **0** |

Scope: this PR.
<!-- END_COST_TAXONOMY -->
