### PR TITLE
bump: preserve custom comments in archive_override

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -91,6 +91,18 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+py_library(
+    name = "bump_impl_lib",
+    srcs = ["bump_impl.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "bump_impl_test",
+    srcs = ["bump_impl_test.py"],
+    deps = [":bump_impl_lib"],
+)
+
 # Run `bazelisk run //:monitor-test` to run tests with stage monitoring.
 # Usage: bazelisk run //:monitor-test -- //test/...
 py_binary(

--- a/bump_impl.py
+++ b/bump_impl.py
@@ -791,11 +791,15 @@ def update_openroad_archive_override(
             and not line_stripped.startswith("# Extracted from")
         ):
             current_comments.append(line_stripped)
-        elif line_stripped.startswith('"//') and ".patch" in line_stripped:
-            m = re.search(r'"(//[^"]*\.patch)"', line_stripped)
-            if m:
-                patches_with_comments.append((current_comments, m.group(1)))
-                current_comments = []
+        elif '"//' in line_stripped and '.patch' in line_stripped:
+            matches = re.findall(r'"(//[^"]*\.patch)"', line_stripped)
+            if matches:
+                for idx, match in enumerate(matches):
+                    if idx == 0:
+                        patches_with_comments.append((current_comments, match))
+                        current_comments = []
+                    else:
+                        patches_with_comments.append(([], match))
         elif line_stripped == ")" or line_stripped == "],":
             trailing_comments.extend(current_comments)
             current_comments = []

--- a/bump_impl.py
+++ b/bump_impl.py
@@ -560,6 +560,7 @@ def _format_openroad_archive_override(
     patches,
     patch_cmds_suffix="",
     submodule_patch_cmds=None,
+    trailing_comments=None,
 ):
     """Render the openroad archive_override block as Starlark source text.
 
@@ -575,6 +576,7 @@ def _format_openroad_archive_override(
     parent_url = f"https://github.com/{OPENROAD_REPO}/archive/{openroad_commit}.tar.gz"
     parent_strip = f"OpenROAD-{openroad_commit}"
     submodule_patch_cmds = submodule_patch_cmds or []
+    trailing_comments = trailing_comments or []
 
     lines = [
         "archive_override(",
@@ -604,7 +606,9 @@ def _format_openroad_archive_override(
         r"""        "sed -i 's|defines = \\[|copts = [\"-include\", \"fmt/format.h\"],\\n    defines = [|' src/syn/src/elab/BUILD third-party/slang-elab/src/BUILD","""
     )
 
-    for label, cmd in submodule_patch_cmds:
+    for comments, label, cmd in submodule_patch_cmds:
+        for c in comments:
+            lines.append(f"        {c}")
         lines.append(f"        # Extracted from {label}")
         lines.append(f"        {cmd},")
 
@@ -616,9 +620,13 @@ def _format_openroad_archive_override(
     if patches:
         lines.append("    patch_strip = 1,")
         lines.append("    patches = [")
-        for p in patches:
+        for comments, p in patches:
+            for c in comments:
+                lines.append(f"        {c}")
             lines.append(f'        "{p}",')
         lines.append("    ],")
+    for c in trailing_comments:
+        lines.append(f"    {c}")
     lines.append(f'    strip_prefix = "{parent_strip}",')
     lines.append(f'    urls = ["{parent_url}"],')
     lines.append(")")
@@ -771,7 +779,10 @@ def update_openroad_archive_override(
         "# by bump.py on every commit bump; do not edit by hand.",
         "# by bump.py on every commit bump.",
     }
-    custom_comments = []
+    patches_with_comments = []
+    trailing_comments = []
+    current_comments = []
+    
     for line in old_block.splitlines():
         line_stripped = line.strip()
         if (
@@ -779,21 +790,21 @@ def update_openroad_archive_override(
             and line_stripped not in generated_comments
             and not line_stripped.startswith("# Extracted from")
         ):
-            custom_comments.append(line_stripped)
+            current_comments.append(line_stripped)
+        elif line_stripped.startswith('"//') and ".patch" in line_stripped:
+            m = re.search(r'"(//[^"]*\.patch)"', line_stripped)
+            if m:
+                patches_with_comments.append((current_comments, m.group(1)))
+                current_comments = []
+        elif line_stripped == ")" or line_stripped == "],":
+            trailing_comments.extend(current_comments)
+            current_comments = []
 
-    if custom_comments:
-        raise BumpError(
-            f"Custom comments found in archive_override(openroad). "
-            f"bump.py would silently delete them. Please move them "
-            f"outside the block. Found: {custom_comments}"
-        )
-
-    patches = _extract_patches(old_block)
     top_patches = []
     submodule_patch_cmds = []
 
     if workspace_dir:
-        for p in patches:
+        for comments, p in patches_with_comments:
             # e.g. "//orfs-patches:foo.patch" -> "orfs-patches/foo.patch"
             if p.startswith("//"):
                 parts = p[2:].split(":")
@@ -803,7 +814,7 @@ def update_openroad_archive_override(
                 full_path = os.path.join(workspace_dir, p)
 
             if not os.path.exists(full_path):
-                top_patches.append(p)
+                top_patches.append((comments, p))
                 continue
 
             with open(full_path, "r", encoding="utf-8", errors="replace") as f:
@@ -828,11 +839,11 @@ def update_openroad_archive_override(
                     normalized += "\n"
                 b64 = base64.b64encode(normalized.encode("utf-8")).decode("ascii")
                 cmd = f"echo {b64} | base64 -d | patch -p1 || (echo 'ERROR: Patch {p} failed to apply to submodule. Please rebase the source of truth patch at {p}.' && exit 1)"
-                submodule_patch_cmds.append((p, f'"{cmd}"'))
+                submodule_patch_cmds.append((comments, p, f'"{cmd}"'))
             else:
-                top_patches.append(p)
+                top_patches.append((comments, p))
     else:
-        top_patches = patches
+        top_patches = patches_with_comments
 
     parent_url = f"https://github.com/{OPENROAD_REPO}/archive/{openroad_commit}.tar.gz"
     parent_integrity = fetch_integrity_fn(parent_url)
@@ -850,6 +861,7 @@ def update_openroad_archive_override(
         top_patches,
         patch_cmds_suffix,
         submodule_patch_cmds,
+        trailing_comments,
     )
     return content[:start] + new_block + content[end:]
 

--- a/bump_impl_test.py
+++ b/bump_impl_test.py
@@ -1,0 +1,90 @@
+import unittest
+import bump_impl
+
+class TestUpdateOpenroadArchiveOverride(unittest.TestCase):
+    def test_preserves_custom_comments(self):
+        content = """git_override(
+    module_name = "openroad",
+    integrity = "sha256-foo",
+    patch_cmds = [],
+    patches = [
+        # This is a custom comment for foo
+        "//orfs-patches:foo.patch",
+        # This is a custom comment for bar
+        # another line of comment
+        "//orfs-patches:bar.patch",
+    ],
+    strip_prefix = "OpenROAD-12345",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/12345.tar.gz"],
+)
+"""
+        # Mocking the fetch functions and workspace_dir = None (no file check)
+        def mock_fetch_integrity(url):
+            return "sha256-bar"
+        
+        def mock_fetch_sha256_hex(url):
+            return "bar_hex"
+
+        def mock_fetch_submodule(repo, commit, path):
+            return ("new_sub_sha", "new_sub_sha256_hex")
+
+        new_content = bump_impl.update_openroad_archive_override(
+            content=content,
+            openroad_commit="67890",
+            fetch_integrity_fn=mock_fetch_integrity,
+            fetch_sha256_hex_fn=mock_fetch_sha256_hex,
+            fetch_submodule_sha_fn=mock_fetch_submodule,
+            workspace_dir=None,
+        )
+
+        self.assertIn("archive_override", new_content)
+        self.assertIn("# This is a custom comment for foo", new_content)
+        self.assertIn("# This is a custom comment for bar", new_content)
+        self.assertIn("# another line of comment", new_content)
+
+        # Check association: foo comment should appear before foo.patch
+        foo_comment_idx = new_content.find("# This is a custom comment for foo")
+        foo_patch_idx = new_content.find('"//orfs-patches:foo.patch"')
+        self.assertLess(foo_comment_idx, foo_patch_idx)
+
+        # Check association: bar comments should appear before bar.patch
+        bar_comment1_idx = new_content.find("# This is a custom comment for bar")
+        bar_comment2_idx = new_content.find("# another line of comment")
+        bar_patch_idx = new_content.find('"//orfs-patches:bar.patch"')
+        self.assertLess(bar_comment1_idx, bar_patch_idx)
+        self.assertLess(bar_comment2_idx, bar_patch_idx)
+
+    def test_preserves_trailing_comments(self):
+        content = """archive_override(
+    module_name = "openroad",
+    integrity = "sha256-foo",
+    patch_cmds = [],
+    patches = [
+        "//orfs-patches:foo.patch",
+    ],
+    # This is a trailing comment
+    # Another trailing comment
+    strip_prefix = "OpenROAD-12345",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/12345.tar.gz"],
+)
+"""
+        def mock_fetch_integrity(url):
+            return "sha256-bar"
+
+        new_content = bump_impl.update_openroad_archive_override(
+            content=content,
+            openroad_commit="67890",
+            fetch_integrity_fn=mock_fetch_integrity,
+            fetch_sha256_hex_fn=lambda u: "bar_hex",
+            fetch_submodule_sha_fn=lambda r, c, p: ("new_sub_sha", "new_sub_sha256_hex"),
+            workspace_dir=None,
+        )
+
+        self.assertIn("# This is a trailing comment", new_content)
+        self.assertIn("# Another trailing comment", new_content)
+        trailing_idx = new_content.find("# This is a trailing comment")
+        strip_idx = new_content.find('strip_prefix = "OpenROAD-67890"')
+        self.assertLess(trailing_idx, strip_idx)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/bump/bump_test.py
+++ b/test/bump/bump_test.py
@@ -1076,22 +1076,6 @@ class TestUpdateOpenroadArchiveOverrideAroundComments(unittest.TestCase):
 
 
 class TestUpdateOpenroadArchiveOverrideFailEarly(unittest.TestCase):
-    def test_custom_comments_fail_early(self):
-        content = """archive_override(
-    module_name = "openroad",
-    # My custom comment
-    patch_cmds = [],
-)"""
-        with self.assertRaisesRegex(
-            bump.BumpError, "Custom comments found in archive_override"
-        ):
-            bump.update_openroad_archive_override(
-                content,
-                "new_commit",
-                lambda x: "int",
-                lambda x: "hex",
-                lambda x, y, z: "sha",
-            )
 
     def test_custom_patch_cmds_fail_early(self):
         content = """archive_override(


### PR DESCRIPTION
When regenerating the openroad archive_override, preserve custom comments and associate them with their respective patches or trailing section rather than discarding them or failing.