### PR TITLE
rules: restore runnable execution environment extraction for _deps targets

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -140,14 +140,14 @@ def _create_deps_tar(stage_name, **kwargs):
     """
     visibility = kwargs.get("visibility", None)
     orfs_deploy_srcs(
-        name = stage_name + "_deploy_srcs",
+        name = stage_name + "_deps",
         src = ":" + stage_name,
         visibility = visibility,
         tags = ["manual"],
     )
     pkg_tar(
-        name = stage_name + "_deps",
-        srcs = [":" + stage_name + "_deploy_srcs"],
+        name = stage_name + "_deps_tar",
+        srcs = [":" + stage_name + "_deps"],
         extension = "tar.gz",
         include_runfiles = True,
         visibility = visibility,

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -322,17 +322,50 @@ orfs_deps = rule(
 
 def _deploy_srcs_impl(ctx):
     dep = ctx.attr.src[OrfsDepInfo]
+    exe = ctx.actions.declare_file(ctx.attr.name + ".sh")
+    _expand_deploy_template(
+        ctx,
+        exe,
+        config = dep.config,
+        make = dep.make,
+        genfiles = dep.files.to_list(),
+        name = ctx.attr.name,
+        renames = dep.renames,
+    )
+    wrapper = ctx.actions.declare_file(ctx.attr.name + "_run.sh")
+    ctx.actions.write(
+        output = wrapper,
+        is_executable = True,
+        content = """\
+#!/bin/bash
+RUNFILES="${{RUNFILES_DIR:-$0.runfiles}}"
+DEPLOY="$RUNFILES/_main/{deploy}"
+ln -sfn "$RUNFILES" "$DEPLOY.runfiles"
+"$DEPLOY" "$@"
+echo "Reproducer installed to: ${{BUILD_WORKSPACE_DIRECTORY:-$PWD}}/tmp/{package}/{name}"
+""".format(
+            deploy = exe.short_path,
+            package = ctx.label.package,
+            name = ctx.attr.name,
+        ),
+    )
     return [DefaultInfo(
-        files = depset([dep.make, dep.config]),
-        runfiles = dep.runfiles,
+        executable = wrapper,
+        files = depset([exe, wrapper], transitive = [dep.files]),
+        runfiles = ctx.runfiles(files = [exe, wrapper]).merge(dep.runfiles),
     )]
 
 orfs_deploy_srcs = rule(
     implementation = _deploy_srcs_impl,
+    executable = True,
     attrs = {
         "src": attr.label(
             mandatory = True,
             providers = [OrfsDepInfo],
+        ),
+        "_deploy_template": attr.label(
+            default = Label("//:deploy.tpl"),
+            allow_single_file = True,
         ),
     },
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -1300,61 +1300,61 @@ sh_test(
     name = "deps_deploy_synth_test",
     srcs = ["deps_deploy_test.sh"],
     args = [
-        "$(location :lb_32x128_mock_synth_deps.tar.gz)",
+        "$(location :lb_32x128_mock_synth_deps_tar.tar.gz)",
         "dir_exists",
     ],
-    data = [":lb_32x128_mock_synth_deps.tar.gz"],
+    data = [":lb_32x128_mock_synth_deps_tar.tar.gz"],
 )
 
 sh_test(
     name = "deps_deploy_floorplan_test",
     srcs = ["deps_deploy_test.sh"],
     args = [
-        "$(location :lb_32x128_mock_floorplan_deps.tar.gz)",
+        "$(location :lb_32x128_mock_floorplan_deps_tar.tar.gz)",
         "print_flow_home",
     ],
-    data = [":lb_32x128_mock_floorplan_deps.tar.gz"],
+    data = [":lb_32x128_mock_floorplan_deps_tar.tar.gz"],
 )
 
 sh_test(
     name = "deps_deploy_real_floorplan_test",
     srcs = ["deps_deploy_test.sh"],
     args = [
-        "$(location :tag_array_64x184_mock_floorplan_deps.tar.gz)",
+        "$(location :tag_array_64x184_mock_floorplan_deps_tar.tar.gz)",
         "print_flow_home",
     ],
-    data = [":tag_array_64x184_mock_floorplan_deps.tar.gz"],
+    data = [":tag_array_64x184_mock_floorplan_deps_tar.tar.gz"],
 )
 
 sh_test(
     name = "deps_deploy_hierarchy_test",
     srcs = ["deps_deploy_test.sh"],
     args = [
-        "$(location :lb_32x128_top_mock_full_hierarchy_floorplan_deps.tar.gz)",
+        "$(location :lb_32x128_top_mock_full_hierarchy_floorplan_deps_tar.tar.gz)",
         "config_contains",
         "ADDITIONAL_LEFS",
     ],
-    data = [":lb_32x128_top_mock_full_hierarchy_floorplan_deps.tar.gz"],
+    data = [":lb_32x128_top_mock_full_hierarchy_floorplan_deps_tar.tar.gz"],
 )
 
 sh_test(
     name = "deps_deploy_make_passthrough_test",
     srcs = ["deps_deploy_test.sh"],
     args = [
-        "$(location :tag_array_64x184_mock_floorplan_deps.tar.gz)",
+        "$(location :tag_array_64x184_mock_floorplan_deps_tar.tar.gz)",
         "make_passthrough",
     ],
-    data = [":tag_array_64x184_mock_floorplan_deps.tar.gz"],
+    data = [":tag_array_64x184_mock_floorplan_deps_tar.tar.gz"],
 )
 
 sh_test(
     name = "deps_deploy_run_substep_test",
     srcs = ["deps_deploy_test.sh"],
     args = [
-        "$(location :tag_array_64x184_mock_floorplan_deps.tar.gz)",
+        "$(location :tag_array_64x184_mock_floorplan_deps_tar.tar.gz)",
         "run_substep",
     ],
-    data = [":tag_array_64x184_mock_floorplan_deps.tar.gz"],
+    data = [":tag_array_64x184_mock_floorplan_deps_tar.tar.gz"],
 )
 
 # --- Deps pkg_tar tests: verify on-demand deps deployment ---
@@ -1362,19 +1362,19 @@ sh_test(
 # Test deps tarball on synth (yosys) stage
 deps_output_group_test(
     name = "deps_output_group_synth_test",
-    target = ":lb_32x128_synth_deps",
+    target = ":lb_32x128_synth_deps_tar",
 )
 
 # Test deps tarball on floorplan (openroad) stage
 deps_output_group_test(
     name = "deps_output_group_floorplan_test",
-    target = ":lb_32x128_mock_openroad_floorplan_deps",
+    target = ":lb_32x128_mock_openroad_floorplan_deps_tar",
 )
 
 # Test deps tarball on squashed flow stage
 deps_output_group_test(
     name = "deps_output_group_squashed_test",
-    target = ":lb_32x128_squashed_final_final_deps",
+    target = ":lb_32x128_squashed_final_final_deps_tar",
 )
 
 # --- Substep output group tests: verify per-substep .odb caching ---
@@ -1410,7 +1410,7 @@ output_group_test(
 # deps tarball still works alongside substeps=True
 deps_output_group_test(
     name = "deps_output_group_substeps_test",
-    target = ":lb_32x128_substeps_floorplan_deps",
+    target = ":lb_32x128_substeps_floorplan_deps_tar",
 )
 
 # --- Patched external target tests ---

--- a/test/deps_deploy_test.sh
+++ b/test/deps_deploy_test.sh
@@ -35,14 +35,14 @@ if [ -d "$RUNFILES_DIR" ]; then
 fi
 
 # Find the make binary
-MAKE_BIN="$(echo "$DST"/make_*)"
-if [ ! -f "$MAKE_BIN" ]; then
-    echo "FAIL: make binary not found in $DST"
+MAKE_BIN="$(find "$DST/_main" -path "$DST/_main/external" -prune -o -type f -name 'make_*' -print | head -1)"
+if [ -z "$MAKE_BIN" ] || [ ! -f "$MAKE_BIN" ]; then
+    echo "FAIL: make binary not found in $DST/_main"
     exit 1
 fi
 
 # Find the config file (*.short.mk)
-CONFIG="$(echo "$DST"/*.short.mk)"
+CONFIG="$(find "$DST" -type f -name '*.short.mk' | head -1)"
 
 # Create _main/config.mk from the short config
 if [ -f "$CONFIG" ]; then
@@ -50,14 +50,14 @@ if [ -f "$CONFIG" ]; then
 fi
 
 # Create the make wrapper script
-MAKE_REL="$(basename "$MAKE_BIN")"
+MAKE_REL="${MAKE_BIN#$DST/_main/}"
 cat > "$DST/make" <<WRAPPER
 #!/usr/bin/env bash
 set -exuo pipefail
 cd "\$(dirname "\$0")/_main"
 find . -not -perm -u+w -exec chmod u+w {} + 2>/dev/null || true
 export RUNFILES_DIR="\$(pwd)/.."
-exec ../$MAKE_REL "\$@"
+exec "./$MAKE_REL" "\$@"
 WRAPPER
 chmod +x "$DST/make"
 


### PR DESCRIPTION
The migration to pkg_tar for _deps targets removed the executable wrapper that copied runfiles to ./tmp. This restores the executable behavior by wiring orfs_deploy_srcs up to _expand_deploy_template, identical to standard stage wrappers, while preserving _deps_tar for offline archives.