### PR TITLE
Clean up anachronistic stage_sources usage in BUILD files

### DIFF
--- a/gallery/megaboom/BUILD.bazel
+++ b/gallery/megaboom/BUILD.bazel
@@ -109,12 +109,6 @@ SRAM_SOURCES = {
     "IO_CONSTRAINTS": [":io-sram"],
 }
 
-SRAM_STAGE_SOURCES = {
-    "synth": [":constraints-sram.sdc"],
-    "floorplan": [":io-sram"],
-    "place": [":io-sram"],
-}
-
 # ============================================================================
 # All behavioral memory modules to blackbox during synthesis.
 # These are explicit RTL modules with reg arrays — SYNTH_MOCK_LARGE_MEMORIES
@@ -184,7 +178,6 @@ SRAM_OVERRIDES = {
     arguments = SRAM_SETTINGS | {"CORE_ASPECT_RATIO": "4"} | SRAM_OVERRIDES.get(name, {}),
     mock_area = 1.0,
     sources = SRAM_SOURCES,
-    stage_sources = SRAM_STAGE_SOURCES,
     verilog_files = [":boom_sv"],
 ) for name in MEMORY_BLACKBOXES]
 
@@ -223,9 +216,6 @@ orfs_flow(
     sources = {
         "SDC_FILE": [":constraints-sram.sdc"],
     },
-    stage_sources = {
-        "synth": [":constraints-sram.sdc"],
-    },
     verilog_files = [":boom_sv"],
 )
 
@@ -247,10 +237,7 @@ orfs_flow(
     macros = [":{}_behavioral".format(m) for m in MEMORY_BLACKBOXES],
     sources = {
         "SDC_FILE": [":constraints.sdc"],
-    },
-    stage_sources = {
-        "floorplan": [":io-boomtile"],
-        "place": [":io-boomtile"],
+        "IO_CONSTRAINTS": [":io-boomtile"],
     },
     tags = ["manual"],
     top = "BoomTile",

--- a/sram/BUILD
+++ b/sram/BUILD
@@ -22,11 +22,10 @@ orfs_flow(
         "MACRO_PLACE_HALO": "30 30",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
         "PLACE_DENSITY": "0.40",
-        "SDC_FILE": "$(location :fakeram/constraints-sram.sdc)",
     },
     mock_area = 0.95,
-    stage_sources = {
-        "synth": [":fakeram/constraints-sram.sdc"],
+    sources = {
+        "SDC_FILE": [":fakeram/constraints-sram.sdc"],
     },
     verilog_files = [":fakeram/sdq_17x64.sv"],
 )
@@ -40,11 +39,10 @@ orfs_flow(
         "DIE_AREA": "0 0 80 80",
         "MACRO_PLACE_HALO": "2 2",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
-        "SDC_FILE": "$(location :fakeram/constraints-sram.sdc)",
     },
     macros = [":sdq_17x64_generate_abstract"],
-    stage_sources = {
-        "synth": [":fakeram/constraints-sram.sdc"],
+    sources = {
+        "SDC_FILE": [":fakeram/constraints-sram.sdc"],
     },
     verilog_files = [":fakeram/top.v"],
 )
@@ -65,7 +63,6 @@ orfs_flow(
         "CORE_MARGIN": "2",
         "DIE_AREA": "0 0 30 30",
         "MACRO_PLACE_HALO": "2 2",
-        "SDC_FILE": "$(location :fakeram/constraints-sram.sdc)",
     },
     macros = [":fakeram"],
     sources = {
@@ -118,9 +115,7 @@ orfs_flow(
     name = "top",
     abstract_stage = "cts",
     arguments = FAST_SETTINGS | {
-        "MACRO_PLACEMENT_TCL": "$(location :macro_placement.tcl)",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
-        "SDC_FILE": "$(location :fakeram/constraints-sram.sdc)",
     },
     extra_configs = {"floorplan": [":floorplan.config"]},
     macros = [
@@ -144,11 +139,10 @@ orfs_flow(
         "MACRO_PLACE_HALO": "30 30",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
         "PLACE_DENSITY": "0.40",
-        "SDC_FILE": "$(location :megaboom/constraints-sram.sdc)",
     },
     mock_area = 0.95,
-    stage_sources = {
-        "synth": [":megaboom/constraints-sram.sdc"],
+    sources = {
+        "SDC_FILE": [":megaboom/constraints-sram.sdc"],
     },
     variant = "megaboom",
     verilog_files = [":megaboom/sdq_17x64.sv"],
@@ -164,11 +158,10 @@ orfs_flow(
         "DIE_AREA": "0 0 100 100",
         "MACRO_PLACE_HALO": "2 2",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
-        "SDC_FILE": "$(location :megaboom/constraints-top.sdc)",
     },
     macros = [":sdq_17x64_megaboom_generate_abstract"],
-    stage_sources = {
-        "synth": [":megaboom/constraints-top.sdc"],
+    sources = {
+        "SDC_FILE": [":megaboom/constraints-top.sdc"],
     },
     variant = "megaboom",
     verilog_files = [":megaboom/top.v"],

--- a/subpackage/BUILD
+++ b/subpackage/BUILD
@@ -1,9 +1,5 @@
 load("//:openroad.bzl", "orfs_flow")
 
-FLOOR_PLACE_ARGUMENTS = {
-    "IO_CONSTRAINTS": "$(location //test:io)",
-}
-
 FAST_SETTINGS = {
     "FILL_CELLS": "",
     "GLOBAL_PLACEMENT_ARGS": "-overflow 0.2",
@@ -21,7 +17,7 @@ FAST_SETTINGS = {
 orfs_flow(
     name = "L1MetadataArray",
     abstract_stage = "place",
-    arguments = FAST_SETTINGS | FLOOR_PLACE_ARGUMENTS | {
+    arguments = FAST_SETTINGS | {
         "CORE_AREA": "2 2 20 80",
         "CORE_MARGIN": "2",
         "DIE_AREA": "0 0 22 82",
@@ -29,14 +25,12 @@ orfs_flow(
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
         "PLACE_DENSITY": "0.40",
         "PLACE_PINS_ARGS": "-annealing",
-        "SDC_FILE": "$(location //test:constraints-top.sdc)",
         "SYNTH_HIERARCHICAL": "1",
     },
     macros = ["//test:tag_array_64x184_generate_abstract"],
-    stage_sources = {
-        "floorplan": ["//test:io"],
-        "place": ["//test:io"],
-        "synth": ["//test:constraints-top.sdc"],
+    sources = {
+        "IO_CONSTRAINTS": ["//test:io"],
+        "SDC_FILE": ["//test:constraints-top.sdc"],
     },
     verilog_files = ["//test:rtl/L1MetadataArray.sv"],
 )
@@ -47,16 +41,13 @@ orfs_flow(
     arguments = FAST_SETTINGS | {
         "CORE_AREA": "1.026 1.080 7.560 50.220",
         "DIE_AREA": "0 0 8.586 51.300",
-        "IO_CONSTRAINTS": "$(location //test:io-sram)",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
         "PLACE_DENSITY": "0.65",
         "PLACE_PINS_ARGS": "-min_distance 2 -min_distance_in_tracks",
-        "SDC_FILE": "$(location //test:constraints-sram)",
     },
-    stage_sources = {
-        "floorplan": ["//test:io-sram"],
-        "place": ["//test:io-sram"],
-        "synth": ["//test:constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": ["//test:io-sram"],
+        "SDC_FILE": ["//test:constraints-sram"],
     },
     verilog_files = ["//test:mock/tag_array_64x184.sv"],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -99,10 +99,8 @@ FAST_SETTINGS = {
 }
 
 SRAM_ARGUMENTS = FAST_SETTINGS | {
-    "IO_CONSTRAINTS": "$(location :io-sram)",
     "PLACE_DENSITY": "0.65",
     "PLACE_PINS_ARGS": "-min_distance 2 -min_distance_in_tracks",
-    "SDC_FILE": "$(location :constraints-sram)",
 }
 
 BLOCK_FLOORPLAN = {
@@ -126,29 +124,26 @@ orfs_sweep(
         "pin_placement": {
             "last_stage": "floorplan",
             "previous_stage": {"floorplan": "tag_array_64x184_synth"},
-            "stage_sources": {
-                "floorplan": [":io-sram"],
+            "sources": {
+                "IO_CONSTRAINTS": [":io-sram"],
             },
             "tags": ["manual"],
         },
     },
-    stage_sources = {
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":io-sram"],
+        "SDC_FILE": [":constraints-sram"],
     },
     sweep = {
         "base": {
-            "arguments": {
-                "IO_CONSTRAINTS": "$(location :tag_array_64x184_io-placement.tcl)",
+            "sources": {
+                "IO_CONSTRAINTS": [":tag_array_64x184_io-placement.tcl"],
             },
             # CI regression test for stage_arguments override of automatic stage assignment
             "stage_arguments": {
                 "floorplan": {
                     "SKIP_REPORT_METRICS": "1",
                 },
-            },
-            "stage_sources": {
-                "floorplan": [":tag_array_64x184_io-placement.tcl"],
             },
         },
     },
@@ -187,10 +182,9 @@ LB_ARGS = SRAM_ARGUMENTS | {
     "PLACE_PINS_ARGS": "-min_distance 1 -min_distance_in_tracks",
 }
 
-LB_STAGE_SOURCES = {
-    "floorplan": [":io-sram"],
-    "place": [":io-sram"],
-    "synth": [":constraints-sram"],
+LB_SOURCES = {
+    "IO_CONSTRAINTS": [":io-sram"],
+    "SDC_FILE": [":constraints-sram"],
 }
 
 LB_VERILOG_FILES = ["mock/lb_32x128.sv"]
@@ -204,14 +198,12 @@ orfs_flow(
         "CORE_ASPECT_RATIO": "",
         "CORE_UTILIZATION": "",
         "DIE_AREA": "0 0 7.400 4.700",
-        "IO_CONSTRAINTS": "$(location :lb_32x128_io-placement.tcl)",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
     },
     mock_area = 0.7,
-    stage_sources = {
-        "floorplan": [":lb_32x128_io-placement.tcl"],
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":lb_32x128_io-placement.tcl"],
+        "SDC_FILE": [":constraints-sram"],
     },
     verilog_files = LB_VERILOG_FILES,
     visibility = [],
@@ -223,7 +215,7 @@ orfs_floorplan(
     src = ":lb_32x128_synth",
     # Make sure we're not passing in any non-floorplan arguments
     arguments = get_stage_args("floorplan", {}, LB_ARGS, {}),
-    data = LB_STAGE_SOURCES["floorplan"],
+    data = LB_SOURCES["IO_CONSTRAINTS"],
     variant = "blah",
 )
 
@@ -236,7 +228,6 @@ orfs_flow(
         "DIE_AREA": "0 0 25 25",
         "GDS_ALLOW_EMPTY": "lb_32x128",
         "GND_NETS_VOLTAGES": "",
-        "IO_CONSTRAINTS": "$(location :lb_32x128_top_io-placement.tcl)",
         "MACRO_PLACE_HALO": "5 5",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
         "PLACE_DENSITY": "0.65",
@@ -245,10 +236,9 @@ orfs_flow(
         "PWR_NETS_VOLTAGES": "",
     },
     macros = ["lb_32x128_generate_abstract"],
-    stage_sources = {
-        "floorplan": [":lb_32x128_top_io-placement.tcl"],
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":lb_32x128_top_io-placement.tcl"],
+        "SDC_FILE": [":constraints-sram"],
     },
     verilog_files = ["rtl/lb_32x128_top.v"],
 )
@@ -267,7 +257,7 @@ orfs_flow(
     last_stage = "floorplan",
     macros = ["lb_32x128_generate_abstract"],
     previous_stage = {"floorplan": ":lb_32x128_top_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     tags = ["manual"],
     variant = "pin_placement",
     verilog_files = ["rtl/lb_32x128_top.v"],
@@ -304,7 +294,7 @@ orfs_flow(
     abstract_stage = "cts",
     arguments = LB_ARGS,
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "test",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -319,7 +309,7 @@ orfs_flow(
     last_stage = "floorplan",
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     user_arguments = {
         "ARRAY_COLS": "4",
         "USER_PROJECT_KNOB": "42",
@@ -340,7 +330,7 @@ orfs_flow(
     arguments = LB_ARGS,
     last_stage = "floorplan",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     tags = ["manual"],
     variant = "pin_placement",
     verilog_files = LB_VERILOG_FILES,
@@ -385,7 +375,7 @@ orfs_flow(
     arguments = LB_ARGS,
     extra_arguments = {"floorplan": [":lb_32x128_auto_utilization"]},
     last_stage = "floorplan",
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     tags = ["manual"],
     variant = "auto_util",
     verilog_files = LB_VERILOG_FILES,
@@ -449,27 +439,17 @@ orfs_sweep(
     },
     sweep = {
         "1": {
-            "arguments": {
-                "IO_CONSTRAINTS": "$(location :L1MetadataArray_io-placement.tcl)",
-            },
             "macros": ["amalgam"],
             "sources": {
+                "IO_CONSTRAINTS": [":L1MetadataArray_io-placement.tcl"],
                 "SDC_FILE": [":constraints-top.sdc"],
-            },
-            "stage_sources": {
-                "floorplan": [":L1MetadataArray_io-placement.tcl"],
             },
         },
         "base": {
-            "arguments": {
-                "IO_CONSTRAINTS": "$(location :L1MetadataArray_io-placement.tcl)",
-            },
             "macros": ["tag_array_64x184_generate_abstract"],
             "sources": {
+                "IO_CONSTRAINTS": [":L1MetadataArray_io-placement.tcl"],
                 "SDC_FILE": [":constraints-top.sdc"],
-            },
-            "stage_sources": {
-                "floorplan": [":L1MetadataArray_io-placement.tcl"],
             },
         },
     },
@@ -625,23 +605,20 @@ orfs_sweep(
         "pin_placement": {
             "last_stage": "floorplan",
             "previous_stage": {"floorplan": "regfile_128x65_synth"},
-            "stage_sources": {
-                "floorplan": [":io-sram"],
+            "sources": {
+                "IO_CONSTRAINTS": [":io-sram"],
             },
             "tags": ["manual"],
         },
     },
-    stage_sources = {
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":io-sram"],
+        "SDC_FILE": [":constraints-sram"],
     },
     sweep = {
         "base": {
-            "arguments": {
-                "IO_CONSTRAINTS": "$(location :regfile_128x65_io-placement.tcl)",
-            },
-            "stage_sources": {
-                "floorplan": [":regfile_128x65_io-placement.tcl"],
+            "sources": {
+                "IO_CONSTRAINTS": [":regfile_128x65_io-placement.tcl"],
             },
         },
     },
@@ -687,12 +664,11 @@ orfs_sweep(
             "tags": ["manual"],
         },
     },
-    stage = "cts",
-    stage_sources = {
-        "floorplan": [":io-sram"],
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":io-sram"],
+        "SDC_FILE": [":constraints-sram"],
     },
+    stage = "cts",
     sweep = {
         "1": {
             "arguments": {
@@ -700,12 +676,11 @@ orfs_sweep(
                 "CORE_ASPECT_RATIO": "",
                 "CORE_UTILIZATION": "",
                 "DIE_AREA": "0 0 4.700 7.400",
-                "IO_CONSTRAINTS": "$(location :lb_32x128_sweep_io-placement.tcl)",
                 "PLACE_DENSITY": "0.65",
             },
             "previous_stage": {"floorplan": "lb_32x128_synth"},
-            "stage_sources": {
-                "floorplan": [":lb_32x128_sweep_io-placement.tcl"],
+            "sources": {
+                "IO_CONSTRAINTS": [":lb_32x128_sweep_io-placement.tcl"],
             },
         },
         "2": {
@@ -859,7 +834,7 @@ orfs_flow(
     last_stage = "floorplan",
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "mock_openroad",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -876,7 +851,7 @@ orfs_flow(
     last_stage = "floorplan",
     openroad = "@openroad//:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     tags = ["manual"],
     variant = "openroad_gui",
     verilog_files = LB_VERILOG_FILES,
@@ -891,8 +866,8 @@ orfs_flow(
     arguments = LB_ARGS,
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
+    sources = LB_SOURCES,
     squash = True,
-    stage_sources = LB_STAGE_SOURCES,
     variant = "squashed",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -906,8 +881,8 @@ orfs_flow(
     last_stage = "final",
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
+    sources = LB_SOURCES,
     squash = True,
-    stage_sources = LB_STAGE_SOURCES,
     variant = "squashed_final",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -1011,7 +986,7 @@ orfs_flow(
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
     quick_pins = True,
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "quick_pins",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -1058,7 +1033,7 @@ orfs_flow(
     arguments = LB_ARGS | BLOCK_FLOORPLAN,
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "mock_abstract",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -1080,7 +1055,7 @@ orfs_flow(
     macros = ["lb_32x128_mock_abstract_generate_abstract"],
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_top_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "mock_hierarchy",
     verilog_files = ["rtl/lb_32x128_top.v"],
 )
@@ -1110,10 +1085,9 @@ orfs_flow(
     macros = ["lb_32x128_mock_abstract_generate_abstract"],
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_top_synth"},
-    sources = {
+    sources = LB_SOURCES | {
         "ADDITIONAL_LEFS": [":dummy_extra.lef"],
     },
-    stage_sources = LB_STAGE_SOURCES,
     variant = "mock_hierarchy_merge",
     verilog_files = ["rtl/lb_32x128_top.v"],
 )
@@ -1131,7 +1105,7 @@ orfs_sweep(
     abstract_stage = "cts",
     arguments = LB_ARGS,
     openroad = "//mock/openroad/src/bin:openroad",
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     sweep = {
         "sweep": {
             "macros": ["lb_32x128_mock_abstract_generate_abstract"],
@@ -1162,7 +1136,7 @@ orfs_flow(
     lint = True,
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "lite",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -1216,7 +1190,7 @@ orfs_flow(
     arguments = LB_ARGS,
     last_stage = "floorplan",
     openroad = "//mock/openroad/src/bin:openroad",
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "mock",
     verilog_files = LB_VERILOG_FILES,
     yosys = "//mock/yosys/src/bin:yosys",
@@ -1229,10 +1203,9 @@ orfs_flow(
     arguments = TAG_ARRAY_ARGUMENTS,
     last_stage = "floorplan",
     openroad = "//mock/openroad/src/bin:openroad",
-    stage_sources = {
-        "floorplan": [":io-sram"],
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":io-sram"],
+        "SDC_FILE": [":constraints-sram"],
     },
     variant = "mock",
     verilog_files = ["//another:tag_array_64x184.sv"],
@@ -1248,7 +1221,7 @@ orfs_flow(
     arguments = LB_ARGS | BLOCK_FLOORPLAN,
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_mock_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "mock_full_abstract",
     verilog_files = LB_VERILOG_FILES,
 )
@@ -1286,7 +1259,7 @@ orfs_flow(
     last_stage = "floorplan",
     macros = ["lb_32x128_mock_full_abstract_generate_abstract"],
     openroad = "//mock/openroad/src/bin:openroad",
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     variant = "mock_full_hierarchy",
     verilog_files = ["rtl/lb_32x128_top.v"],
     yosys = "//mock/yosys/src/bin:yosys",
@@ -1387,7 +1360,7 @@ orfs_flow(
     last_stage = "floorplan",
     openroad = "//mock/openroad/src/bin:openroad",
     previous_stage = {"floorplan": ":lb_32x128_synth"},
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     substeps = True,
     variant = "substeps",
     verilog_files = LB_VERILOG_FILES,


### PR DESCRIPTION
Replaced 'arguments' + 'stage_sources' combinations with just 'sources' where SDC files and IO constraints were manually replicated across both properties. The 'sources' property handles adding these files to both attributes automatically.