### PR TITLE
Merge stage JSON argument files at execution time with filtering into .mk config

### DIFF
--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -3,7 +3,13 @@ package(default_visibility = [
     "//private:__subpackages__",
 ])
 
-exports_files([
-    "merge_arguments.py",
-    "tuner.py.tpl",
-])
+exports_files(
+    glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "merge_arguments_test",
+    srcs = ["merge_arguments_test.py"],
+    data = ["merge_arguments.py"],
+)

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -453,20 +453,7 @@ def _prefix_include_dirs(dirs_value, prefix):
         if p.strip()
     ])
 
-def config_content(ctx, arguments, paths, pre_paths = []):
-    """Generate Makefile-style config content for an ORFS stage.
-
-    Args:
-      ctx: The rule context.
-      arguments: Dictionary of config variables.
-      paths: List of additional config file paths to include at the end.
-      pre_paths: List of config file paths to include at the top, before
-        the export lines. Included files set with ?= take precedence over
-        the export lines that follow.
-
-    Returns:
-      A string with export VAR?=value lines and include directives.
-    """
+def config_arguments(ctx, arguments):
     workaround = {
         # https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3907
         "LEC_CHECK": "0",
@@ -481,12 +468,30 @@ def config_content(ctx, arguments, paths, pre_paths = []):
             prefix,
         )
 
+    return config_overrides(ctx, workaround)
+
+def config_content(ctx, arguments, paths, pre_paths = []):
+    """Generate Makefile-style config content for an ORFS stage.
+
+    Args:
+      ctx: The rule context.
+      arguments: Dictionary of config variables.
+      paths: List of additional config file paths to include at the end.
+      pre_paths: List of config file paths to include at the top, before
+        the export lines. Included files set with ?= take precedence over
+        the export lines that follow.
+
+    Returns:
+      A string with export VAR?=value lines and include directives.
+    """
+    final_args = config_arguments(ctx, arguments)
+
     return "".join(
         ["include {}\n".format(path) for path in pre_paths] +
         sorted(
             [
                 "export {}?={}\n".format(*pair)
-                for pair in config_overrides(ctx, workaround).items()
+                for pair in final_args.items()
             ],
         ) +
         ["include {}\n".format(path) for path in paths],

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -334,6 +334,11 @@ def orfs_flow(
     orfs_variables(
         name = _step_name(name, variant, "variables"),
         arguments = arguments | user_arguments,
+        data = depset(
+            kwargs.get("data", []) +
+            [v for vs in (sources | user_sources).values() for v in vs] +
+            [v for vs in stage_sources.values() for v in vs],
+        ).to_list(),
     )
 
     if not mock_area:
@@ -614,6 +619,7 @@ def _orfs_pass(
             orfs_squashed(
                 name = squash_name,
                 stage_name = last_meta.stage_name,
+                stages = [s.stage for s in squash_steps],
                 make_targets = all_make_targets,
                 log_names = all_log_names,
                 json_names = all_json_names,

--- a/private/merge_arguments.py
+++ b/private/merge_arguments.py
@@ -4,10 +4,27 @@ import argparse
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Merge .json argument files into a Makefile-style config.")
+    parser = argparse.ArgumentParser(
+        description="Merge .json argument files into a Makefile-style config."
+    )
     parser.add_argument("output_path", help="Path to write the args.mk file")
-    parser.add_argument("--filter", help="Path to JSON file containing 'allowed' and 'known' variables", default=None)
-    parser.add_argument("json_paths", nargs="+", help="Paths to the input .json files")
+    parser.add_argument(
+        "--filter",
+        help="Path to JSON file containing 'allowed' and 'known' variables",
+        default=None,
+    )
+    parser.add_argument(
+        "--include",
+        "--mk-include",
+        "--mk-includes",
+        action="append",
+        dest="mk_includes",
+        help="Path to .mk file to include at the end",
+        default=[],
+    )
+    parser.add_argument(
+        "json_paths", nargs="*", help="Paths to the input .json files", default=[]
+    )
     args = parser.parse_args()
 
     result = {}
@@ -30,6 +47,9 @@ def main():
                 if k in known and k not in allowed:
                     continue
             out.write("export {}?={}\n".format(k, v))
+
+        for inc in args.mk_includes:
+            out.write("include {}\n".format(inc))
 
 
 if __name__ == "__main__":

--- a/private/merge_arguments_test.py
+++ b/private/merge_arguments_test.py
@@ -1,0 +1,72 @@
+import json
+import os
+import tempfile
+import unittest
+import subprocess
+import sys
+
+
+class TestMergeArguments(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        # Determine the path to merge_arguments.py relative to this test
+        self.script_path = os.path.join(os.path.dirname(__file__), "merge_arguments.py")
+
+    def write_json(self, name, data):
+        path = os.path.join(self.temp_dir.name, name)
+        with open(path, "w") as f:
+            json.dump(data, f)
+        return path
+
+    def run_script(self, args):
+        cmd = [sys.executable, self.script_path] + args
+        subprocess.check_call(cmd)
+
+    def test_basic_merge_precedence(self):
+        json1 = self.write_json("1.json", {"A": "1", "B": "1"})
+        json2 = self.write_json("2.json", {"B": "2", "C": "2"})
+        out_mk = os.path.join(self.temp_dir.name, "out.mk")
+
+        self.run_script([out_mk, json1, json2])
+
+        with open(out_mk) as f:
+            content = f.read()
+
+        expected = "export A?=1\n" "export B?=2\n" "export C?=2\n"
+        self.assertEqual(content, expected)
+
+    def test_filtering(self):
+        json_data = self.write_json("data.json", {"A": "1", "B": "2", "C": "3"})
+        filter_json = self.write_json(
+            "filter.json", {"allowed": ["A", "C"], "known": ["A", "B", "C"]}
+        )
+        out_mk = os.path.join(self.temp_dir.name, "out.mk")
+
+        self.run_script([out_mk, "--filter", filter_json, json_data])
+
+        with open(out_mk) as f:
+            content = f.read()
+
+        expected = "export A?=1\n" "export C?=3\n"
+        self.assertEqual(content, expected)
+
+    def test_mk_includes(self):
+        json_data = self.write_json("data.json", {"A": "1"})
+        out_mk = os.path.join(self.temp_dir.name, "out.mk")
+
+        self.run_script(
+            [out_mk, "--include", "file1.mk", "--include", "file2.mk", json_data]
+        )
+
+        with open(out_mk) as f:
+            content = f.read()
+
+        expected = "export A?=1\n" "include file1.mk\n" "include file2.mk\n"
+        self.assertEqual(content, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -15,6 +15,7 @@ load(
 load(
     "//private:environment.bzl",
     "EXPAND_VERILOG_DIRS",
+    "config_arguments",
     "config_content",
     "config_environment",
     "config_overrides",
@@ -384,9 +385,9 @@ def _run_impl(ctx):
     original_config = config
     all_jsons = ctx.files.extra_arguments + (ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else [])
     if all_jsons:
-        args_mk = declare_artifact(ctx, "results", ctx.attr.name + ".args.mk")
+        new_config = declare_artifact(ctx, "results", ctx.attr.name + ".config.mk")
 
-        args = [ctx.file._merge_arguments.path, args_mk.path]
+        args = [ctx.file._merge_arguments.path, new_config.path]
         inputs = all_jsons + [ctx.file._merge_arguments]
 
         if OrfsInfo in ctx.attr.src:
@@ -417,21 +418,18 @@ def _run_impl(ctx):
             args.extend(["--filter", filter_json.path])
             inputs.append(filter_json)
 
+        args.extend(["--include", original_config.path])
+        inputs.append(original_config)
         args.extend([f.path for f in all_jsons])
 
         ctx.actions.run(
             executable = ctx.executable._python,
             arguments = args,
             inputs = inputs,
-            outputs = [args_mk],
-        )
-        new_config = declare_artifact(ctx, "results", ctx.attr.name + ".config.mk")
-        ctx.actions.write(
-            output = new_config,
-            content = "include {args}\ninclude {config}\n".format(args = args_mk.path, config = original_config.path),
+            outputs = [new_config],
         )
         config = new_config
-        extra_files = [args_mk, original_config]
+        extra_files = [original_config]
     else:
         extra_files = [original_config]
 
@@ -1156,6 +1154,16 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
     )
 
     partition_outputs = []
+
+    filter_json = declare_artifact(ctx, "results", "1_synth_partition.filter.json")
+    ctx.actions.write(
+        output = filter_json,
+        content = json.encode({
+            "allowed": ALL_STAGE_TO_VARIABLES.get("synth", []),
+            "known": ALL_VARIABLE_TO_STAGES.keys(),
+        }),
+    )
+
     for i in range(num_partitions):
         # Build a human-readable progress message showing which modules
         # this partition will synthesize.
@@ -1196,14 +1204,35 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 base_arguments,
                 orfs_additional_arguments(my_deps_infos, use_pre_layout = True),
             )
+            my_analysis_args = config_arguments(ctx, my_arguments)
+            my_analysis_json = declare_artifact(ctx, "results", "1_synth_partition_{}.analysis.json".format(i))
+            ctx.actions.write(
+                output = my_analysis_json,
+                content = json.encode(my_analysis_args),
+            )
+
             my_config = declare_artifact(
                 ctx,
                 "results",
                 "1_synth_partition_{}.mk".format(i),
             )
-            ctx.actions.write(
-                output = my_config,
-                content = config_content(ctx, my_arguments, extra_config_paths),
+            my_jsons = [my_analysis_json] + ctx.files.extra_arguments
+
+            my_args = [
+                ctx.file._merge_arguments.path,
+                my_config.path,
+                "--filter",
+                filter_json.path,
+            ]
+            for f in ctx.files.extra_configs:
+                my_args.extend(["--include", f.path])
+            my_args.extend([f.path for f in my_jsons])
+
+            ctx.actions.run(
+                executable = ctx.executable._python,
+                arguments = my_args,
+                inputs = my_jsons + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
+                outputs = [my_config],
             )
             extra_partition_config = [my_config]
             partition_env_override = {"DESIGN_CONFIG": my_config.path}
@@ -1375,14 +1404,41 @@ def _yosys_impl(ctx):
             use_pre_layout = True,
         ),
     )
-    config = declare_artifact(ctx, "results", "1_synth.mk")
+
+    analysis_args = config_arguments(ctx, all_arguments)
+    analysis_json = declare_artifact(ctx, "results", "1_synth.analysis.json")
     ctx.actions.write(
-        output = config,
-        content = config_content(
-            ctx,
-            all_arguments,
-            [file.path for file in ctx.files.extra_configs],
-        ),
+        output = analysis_json,
+        content = json.encode(analysis_args),
+    )
+
+    filter_json = declare_artifact(ctx, "results", "1_synth.filter.json")
+    ctx.actions.write(
+        output = filter_json,
+        content = json.encode({
+            "allowed": ALL_STAGE_TO_VARIABLES.get("synth", []),
+            "known": ALL_VARIABLE_TO_STAGES.keys(),
+        }),
+    )
+
+    config = declare_artifact(ctx, "results", "1_synth.mk")
+    all_jsons = [analysis_json] + ctx.files.extra_arguments
+
+    args = [
+        ctx.file._merge_arguments.path,
+        config.path,
+        "--filter",
+        filter_json.path,
+    ]
+    for f in ctx.files.extra_configs:
+        args.extend(["--include", f.path])
+    args.extend([f.path for f in all_jsons])
+
+    ctx.actions.run(
+        executable = ctx.executable._python,
+        arguments = args,
+        inputs = all_jsons + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
+        outputs = [config],
     )
 
     # Canonicalize only needs each macro's port interface to blackbox it, not
@@ -1441,14 +1497,31 @@ def _yosys_impl(ctx):
                 "SYNTH_SLANG_ARGS": (existing_slang + " " + blackbox_slang) if existing_slang else blackbox_slang,
             }
 
-            canon_config = declare_artifact(ctx, "results", "1_1_yosys_canonicalize.mk")
+            canon_analysis_args = config_arguments(ctx, canon_arguments)
+            canon_analysis_json = declare_artifact(ctx, "results", "1_1_yosys_canonicalize.analysis.json")
             ctx.actions.write(
-                output = canon_config,
-                content = config_content(
-                    ctx,
-                    canon_arguments,
-                    [file.path for file in ctx.files.extra_configs],
-                ),
+                output = canon_analysis_json,
+                content = json.encode(canon_analysis_args),
+            )
+
+            canon_config = declare_artifact(ctx, "results", "1_1_yosys_canonicalize.mk")
+            canon_jsons = [canon_analysis_json] + ctx.files.extra_arguments
+
+            canon_args = [
+                ctx.file._merge_arguments.path,
+                canon_config.path,
+                "--filter",
+                filter_json.path,
+            ]
+            for f in ctx.files.extra_configs:
+                canon_args.extend(["--include", f.path])
+            canon_args.extend([f.path for f in canon_jsons])
+
+            ctx.actions.run(
+                executable = ctx.executable._python,
+                arguments = canon_args,
+                inputs = canon_jsons + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
+                outputs = [canon_config],
             )
             canon_deps = depset(
                 [info.gds for info in soft_infos if info.gds] +
@@ -1685,23 +1758,38 @@ def _yosys_impl(ctx):
     )
 
     config_short = declare_artifact(ctx, "results", "1_synth.short.mk")
-    ctx.actions.write(
-        output = config_short,
-        content = config_content(
-            ctx,
-            arguments = hack_away_prefix(
-                arguments = merge_arguments(
-                    data_arguments(ctx) |
-                    required_arguments(ctx),
-                    orfs_additional_arguments(
-                        [dep[OrfsInfo] for dep in ctx.attr.deps],
-                        use_pre_layout = True,
-                    ),
-                ) | verilog_arguments(ctx.files.verilog_files),
-                prefix = config_short.root.path,
-            ),
-            paths = [file.short_path for file in ctx.files.extra_configs],
+    short_all_args = merge_arguments(
+        data_arguments(ctx) |
+        required_arguments(ctx),
+        orfs_additional_arguments(
+            [dep[OrfsInfo] for dep in ctx.attr.deps],
+            use_pre_layout = True,
         ),
+    ) | verilog_arguments(ctx.files.verilog_files)
+
+    short_analysis_args = config_arguments(ctx, hack_away_prefix(short_all_args, config_short.root.path))
+    short_analysis_json = declare_artifact(ctx, "results", "1_synth.short.analysis.json")
+    ctx.actions.write(
+        output = short_analysis_json,
+        content = json.encode(short_analysis_args),
+    )
+
+    short_args = [
+        ctx.file._merge_arguments.path,
+        config_short.path,
+        "--filter",
+        filter_json.path,
+    ]
+    for f in ctx.files.extra_configs:
+        short_args.extend(["--include", f.short_path])
+    short_args.append(short_analysis_json.path)
+    short_args.extend([f.path for f in ctx.files.extra_arguments])
+
+    ctx.actions.run(
+        executable = ctx.executable._python,
+        arguments = short_args,
+        inputs = [short_analysis_json] + ctx.files.extra_arguments + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
+        outputs = [config_short],
     )
 
     make = _create_make_script(
@@ -1965,52 +2053,58 @@ def _make_impl(
         ),
     )
 
-    # Write this stage's arguments to .json for downstream stages, then
-    # merge inherited .json files and this stage's .json into a .mk that
-    # the stage config includes via pre_paths. Precedence (later wins in
-    # merge_arguments.py): inherited < stage < extra.
-    stage_json = declare_artifact(ctx, "results", stage + ".args.json")
+    # Write this stage's analysis arguments to .json for downstream stages, then
+    # merge inherited .json files and this stage's .json into the final .mk.
+    # Precedence (later wins in merge_arguments.py): inherited < stage < extra.
+    analysis_args = config_arguments(ctx, all_arguments)
+    analysis_json = declare_artifact(ctx, "results", stage + ".analysis.json")
     ctx.actions.write(
-        output = stage_json,
-        content = json.encode(data_arguments(ctx)),
+        output = analysis_json,
+        content = json.encode(analysis_args),
     )
     inherited_jsons = ctx.attr.src[OrfsInfo].arguments.to_list()
     extra_arg_files = ctx.files.extra_arguments
-    all_jsons = inherited_jsons + [stage_json] + extra_arg_files
-    args_mk = declare_artifact(ctx, "results", stage + ".args.mk")
+    all_jsons = inherited_jsons + [analysis_json] + extra_arg_files
 
-    canonical_stage = stage
-    for s in ALL_STAGE_TO_VARIABLES.keys():
-        if stage.endswith("_" + s) or stage == s:
-            canonical_stage = s
-            break
+    if hasattr(ctx.attr, "stages") and ctx.attr.stages:
+        allowed_vars = []
+        for s in ctx.attr.stages:
+            allowed_vars.extend(ALL_STAGE_TO_VARIABLES.get(s, []))
+    elif hasattr(ctx.attr, "_stage") and ctx.attr._stage in ALL_STAGE_TO_VARIABLES:
+        allowed_vars = ALL_STAGE_TO_VARIABLES[ctx.attr._stage]
+    else:
+        canonical_stage = stage
+        for s in ALL_STAGE_TO_VARIABLES.keys():
+            if stage.endswith("_" + s) or stage == s or (s == "generate_abstract" and "abstract" in stage):
+                canonical_stage = s
+                break
+        allowed_vars = ALL_STAGE_TO_VARIABLES.get(canonical_stage, [])
 
     filter_json = declare_artifact(ctx, "results", stage + ".filter.json")
     ctx.actions.write(
         output = filter_json,
         content = json.encode({
-            "allowed": ALL_STAGE_TO_VARIABLES.get(canonical_stage, []),
+            "allowed": allowed_vars,
             "known": ALL_VARIABLE_TO_STAGES.keys(),
         }),
     )
 
+    config = declare_artifact(ctx, "results", stage + ".mk")
+    args = [
+        ctx.file._merge_arguments.path,
+        config.path,
+        "--filter",
+        filter_json.path,
+    ]
+    for f in ctx.files.extra_configs:
+        args.extend(["--include", f.path])
+    args.extend([f.path for f in all_jsons])
+
     ctx.actions.run(
         executable = ctx.executable._python,
-        arguments = [ctx.file._merge_arguments.path, args_mk.path, "--filter", filter_json.path] +
-                    [f.path for f in all_jsons],
-        inputs = all_jsons + [ctx.file._merge_arguments, filter_json],
-        outputs = [args_mk],
-    )
-
-    config = declare_artifact(ctx, "results", stage + ".mk")
-    ctx.actions.write(
-        output = config,
-        content = config_content(
-            ctx,
-            arguments = all_arguments,
-            pre_paths = [args_mk.path],
-            paths = [file.path for file in ctx.files.extra_configs],
-        ),
+        arguments = args,
+        inputs = all_jsons + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
+        outputs = [config],
     )
 
     results = declare_artifacts(ctx, "results", result_names)
@@ -2056,7 +2150,7 @@ def _make_impl(
             command = " && ".join(commands),
             env = config_overrides(ctx, flow_environment(ctx) | config_environment(config)),
             inputs = depset(
-                [config, args_mk] + ctx.files.extra_configs + all_jsons,
+                [config] + ctx.files.extra_configs + all_jsons,
                 transitive = [
                     data_inputs(ctx),
                     source_inputs(ctx),
@@ -2068,25 +2162,30 @@ def _make_impl(
         )
 
     config_short = declare_artifact(ctx, "results", stage + ".short.mk")
+    short_analysis_args = config_arguments(ctx, hack_away_prefix(all_arguments, config_short.root.path))
+    short_analysis_json = declare_artifact(ctx, "results", stage + ".short.analysis.json")
     ctx.actions.write(
-        output = config_short,
-        content = config_content(
-            ctx,
-            arguments = hack_away_prefix(
-                arguments = merge_arguments(
-                    extra_arguments |
-                    data_arguments(ctx) |
-                    required_arguments(ctx),
-                    orfs_additional_arguments(
-                        [ctx.attr.src[OrfsInfo]],
-                        use_pre_layout = use_pre_layout,
-                    ),
-                ),
-                prefix = config_short.root.path,
-            ),
-            pre_paths = [args_mk.short_path],
-            paths = [file.short_path for file in ctx.files.extra_configs],
-        ),
+        output = short_analysis_json,
+        content = json.encode(short_analysis_args),
+    )
+
+    short_args = [
+        ctx.file._merge_arguments.path,
+        config_short.path,
+        "--filter",
+        filter_json.path,
+    ]
+    for f in ctx.files.extra_configs:
+        short_args.extend(["--include", f.short_path])
+    short_args.extend([f.path for f in inherited_jsons])
+    short_args.append(short_analysis_json.path)
+    short_args.extend([f.path for f in extra_arg_files])
+
+    ctx.actions.run(
+        executable = ctx.executable._python,
+        arguments = short_args,
+        inputs = inherited_jsons + [short_analysis_json] + extra_arg_files + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
+        outputs = [config_short],
     )
 
     make = _create_make_script(
@@ -2110,7 +2209,7 @@ def _make_impl(
     # DefaultInfo.runfiles below so `bazelisk run :stage gui_<stage>` works.
     stage_renames = renames(ctx, ctx.files.src, short = True)
     deploy_files = depset(
-        [config_short, make, args_mk] + ctx.files.src + ctx.files.extra_configs + all_jsons,
+        [config_short, make] + ctx.files.src + ctx.files.extra_configs + all_jsons,
         transitive = [
             flow_inputs(ctx),
             data_inputs(ctx),
@@ -2141,7 +2240,7 @@ def _make_impl(
     )
 
     _runfiles_files = (
-        [config_short, make, args_mk] +
+        [config_short, make] +
         forwards +
         results +
         logs +
@@ -2164,7 +2263,7 @@ def _make_impl(
     return [
         DefaultInfo(
             executable = exe,
-            files = depset(forwards + results + reports + [args_mk]),
+            files = depset(forwards + results + reports),
             # default_runfiles includes openroad_qt so `bazelisk run
             # :stage gui_<stage>` finds the Qt-linked binary in the
             # deployed temp folder. data_runfiles deliberately omits
@@ -2207,7 +2306,7 @@ def _make_impl(
             config = config_short,
             renames = stage_renames,
             files = depset(
-                [config_short, args_mk] +
+                [config_short] +
                 ctx.files.src +
                 ctx.files.data +
                 ctx.files.extra_configs,
@@ -2229,7 +2328,7 @@ def _make_impl(
             additional_libs = ctx.attr.src[OrfsInfo].additional_libs,
             additional_libs_pre_layout = ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
             arguments = depset(
-                [stage_json],
+                [analysis_json],
                 transitive = [ctx.attr.src[OrfsInfo].arguments] +
                              ([depset(extra_arg_files)] if extra_arg_files else []),
             ),
@@ -2329,6 +2428,7 @@ orfs_squashed = rule(
             renamed_inputs_attr() |
             {
                 "stage_name": attr.string(mandatory = True),
+                "stages": attr.string_list(default = []),
                 "make_targets": attr.string_list(mandatory = True),
                 "log_names": attr.string_list(default = []),
                 "json_names": attr.string_list(default = []),
@@ -2585,7 +2685,9 @@ orfs_generate_metadata = rule(
         # staged under the parent variant's tree.
         rename_data = True,
     ),
-    attrs = openroad_attrs() | renamed_inputs_attr(),
+    attrs = openroad_attrs() | renamed_inputs_attr() | {
+        "_stage": attr.string(default = "generate_metadata"),
+    },
     provides = flow_provides(),
     executable = True,
 )
@@ -2601,7 +2703,9 @@ orfs_update_rules = rule(
         report_names = ["rules.json"],
         result_names = [],
     ),
-    attrs = openroad_attrs() | renamed_inputs_attr(),
+    attrs = openroad_attrs() | renamed_inputs_attr() | {
+        "_stage": attr.string(default = "update_rules"),
+    },
     provides = flow_provides(),
     executable = True,
 )

--- a/tools/memory_macro_scaler/test/dual_char_content_test.sh
+++ b/tools/memory_macro_scaler/test/dual_char_content_test.sh
@@ -25,8 +25,10 @@ extract_ck () {
     awk '
         /timing_type *: *max_clock_tree_path/ { flag = 1; next }
         flag && /values/ {
-            match($0, /values *\(\s*"([-0-9.e+]+)"/, arr)
-            if (arr[1] != "") { print arr[1]; exit }
+            sub(/.*values[ \t]*\([ \t]*"/, "")
+            sub(/".*/, "")
+            print $0
+            exit
         }
     ' "$1"
 }


### PR DESCRIPTION
### Summary

- Merges multiple stage JSON argument files at execution time using `merge_arguments.py` into a single stage `.mk` config using `export VAR?=VAL` syntax.
- Filters variables at execution time per-stage based on `ALL_STAGE_TO_VARIABLES` and `ALL_VARIABLE_TO_STAGES` so stage-irrelevant variables (such as `DIE_AREA` during synthesis) do not invalidate or trigger unnecessary re-runs of preceding stages.
- Replaces static analysis-time Makefile config concatenation with direct JSON merging.
- Adds comprehensive unit tests for `merge_arguments.py` in `//private:merge_arguments_test`.
- Fixes POSIX `awk` compatibility issue in `tools/memory_macro_scaler/test/dual_char_content_test.sh`.

### Validation
- All 82 test targets pass locally with `bazelisk test //...`.