### PR TITLE
bazel: silence warnings from bzlmod, pip, and external headers

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -9,3 +9,4 @@ lec
 naja
 test/docker
 test/downstream
+bazel-orfs-bazel-dev

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,12 @@
 build --incompatible_strict_action_env
 
+# Treat include paths into external/ (bzlmod/BCR deps) as -isystem to silence third-party warnings
+build --features=external_include_paths
+
+# For 3rd party code: Disable warnings entirely.
+build --per_file_copt=.*external/.*@-w
+build --host_per_file_copt=.*external/.*@-w
+
 # Required by OpenROAD (STA uses std::format_string from C++20)
 build --cxxopt "-std=c++20" --host_cxxopt "-std=c++20"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -143,6 +143,12 @@ single_version_override(
 # from rules_python 2.0.0's MINOR_MAPPING). pycross.configure_environments
 # is root-honored only, so the workaround must live here (mirrored from
 # upstream OpenROAD's MODULE.bazel, which can't apply it from non-root).
+single_version_override(
+    module_name = "rules_pycross",
+    patch_strip = 0,
+    patches = ["//patches:rules_pycross_no_warning.patch"],
+)
+
 bazel_dep(name = "rules_pycross", version = "0.8.1")
 
 pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")
@@ -188,7 +194,7 @@ register_toolchains(
 
 bazel_dep(
     name = "rules_python",
-    version = "1.9.0",
+    version = "2.0.0",
 )
 
 python = use_extension(
@@ -203,16 +209,24 @@ use_repo(python, "python_3_13_host")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
+    extra_pip_args = [
+        "--index-url=https://pypi.org/simple",
+    ],
     hub_name = "bazel-orfs-pip",
     python_version = "3.13",
+    quiet = True,
     requirements_lock = "//:requirements_lock_3_13.txt",
 )
 use_repo(pip, "bazel-orfs-pip")
 
 pip_features = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip_features.parse(
+    extra_pip_args = [
+        "--index-url=https://pypi.org/simple",
+    ],
     hub_name = "bazel-orfs-features-pip",
     python_version = "3.13",
+    quiet = True,
     requirements_lock = "//:requirements_features_lock_3_13.txt",
 )
 use_repo(pip_features, "bazel-orfs-features-pip")

--- a/patches/rules_pycross_no_warning.patch
+++ b/patches/rules_pycross_no_warning.patch
@@ -1,0 +1,10 @@
+--- pycross/private/bzlmod/pycross.bzl
++++ pycross/private/bzlmod/pycross.bzl
+@@ -17,7 +17,6 @@
+ 
+     for module in module_ctx.modules:
+         if module.name != "rules_pycross" and not module.is_root:
+-            _print_warn("Ignoring `pycross` extension usage from non-root, non-rules_pycross module {}".format(module.name))
+             continue
+ 
+         if not environments_tag:


### PR DESCRIPTION
### Summary

This PR silences several sources of warnings in `bazel-orfs` using patterns established in OpenROAD and downstream:

- **Direct Dependency Mismatch**: Bumped `rules_python` from `1.9.0` to `2.0.0` in `MODULE.bazel`.
- **Bzlmod `rules_pycross` Warning**: Applied single version override patch to silence non-root `pycross` extension usage warning.
- **Pip Extension Output**: Enabled `quiet = True` and set `--index-url=https://pypi.org/simple` in `extra_pip_args` for `pip.parse` and `pip_features.parse`.
- **External / 3rd-Party Diagnostics**: Added `build --features=external_include_paths` and `--per_file_copt=.*external/.*@-w` to `.bazelrc`.
- **Clean Pattern Parsing**: Added `bazel-orfs-bazel-dev` to `.bazelignore`.

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>