### PR TITLE
cleanup: retire stage_sources

### DIFF
--- a/.claude/commands/demo-debug.md
+++ b/.claude/commands/demo-debug.md
@@ -299,8 +299,7 @@ intermediate step is verified.
    BUILD.bazel setting, or Tcl script, understand why it was set that way.
    Check `variables.yaml` in bazel-orfs for per-stage variable routing —
    `sources` variables like `IO_CONSTRAINTS` are automatically distributed
-   to the correct stage. Don't use `stage_sources` unless you have a
-   specific reason to override the automatic routing.
+   to the correct stage.
 
    **Substep targets vs `_deps`**: Substep targets (`bazel run ..._<substep>`)
    are the primary iteration tool — one command, automatic dependency chain,

--- a/README.md
+++ b/README.md
@@ -452,10 +452,9 @@ orfs_flow(
         "CORE_UTILIZATION": "40",
         "PLACE_DENSITY": "0.65",
     },
-    stage_sources = {
-        "floorplan": [":io-sram"],
-        "place": [":io-sram"],
-        "synth": [":constraints-sram"],
+    sources = {
+        "IO_CONSTRAINTS": [":io-sram"],
+        "SDC_FILE": [":constraints-sram"],
     },
     verilog_files = ["//another:tag_array_64x184.sv"],
     visibility = [":__subpackages__"],
@@ -487,7 +486,7 @@ orfs_flow(
     name = "lb_32x128",
     arguments = LB_ARGS,
     mock_area = 0.5,
-    stage_sources = LB_STAGE_SOURCES,
+    sources = LB_SOURCES,
     verilog_files = LB_VERILOG_FILES,
 )
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -175,12 +175,8 @@ Override `IO_CONSTRAINTS` and add the pin file to floorplan sources:
 
 ```starlark
 orfs_flow(
-    arguments = LB_ARGS | {
-        "IO_CONSTRAINTS": "$(location :lb_32x128_io-placement.tcl)",
-    },
-    stage_sources = {
-        "floorplan": [":lb_32x128_io-placement.tcl"],
-        ...
+    sources = {
+        "IO_CONSTRAINTS": [":lb_32x128_io-placement.tcl"],
     },
 )
 ```

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -58,7 +58,6 @@ def _filter_stage_args(stage, **kwargs):
     extra_configs = kwargs.pop("extra_configs", {})
     sources = kwargs.pop("sources", {})
     stage_arguments = kwargs.pop("stage_arguments", {})
-    stage_sources = kwargs.pop("stage_sources", {})
     stage_data = kwargs.pop("stage_data", {})
 
     # yosys attribute only applies to synth stage
@@ -76,7 +75,7 @@ def _filter_stage_args(stage, **kwargs):
             sources = sources,
             stage_arguments = stage_arguments,
         ),
-        data = get_sources(stage, stage_sources, sources) +
+        data = get_sources(stage, sources) +
                stage_data.get(stage, []) +
                data,
         extra_arguments = extra_arguments.get(stage, []),
@@ -182,7 +181,6 @@ def orfs_flow(
         canon_blackbox_macros = [],
         sources = {},
         user_sources = {},
-        stage_sources = {},
         stage_arguments = {},
         renamed_inputs = {},
         arguments = {},
@@ -220,7 +218,6 @@ def orfs_flow(
         non-empty dict to scope each partition's macro inputs — partitions that
         don't need a macro no longer wait on that macro's upstream PnR.
       sources: dictionary keyed by ORFS variables with lists of sources
-      stage_sources: dictionary keyed by ORFS stages with lists of stage-specific sources
       stage_arguments: dictionary keyed by ORFS stages with lists of stage-specific arguments.
         Prefer 'arguments' which automatically assigns variables to the correct stages.
         Use stage_arguments only to override the automatic stage assignment.
@@ -309,7 +306,6 @@ def orfs_flow(
         kept_macros = kept_macros,
         canon_blackbox_macros = canon_blackbox_macros,
         sources = sources | user_sources,
-        stage_sources = stage_sources,
         stage_arguments = stage_arguments,
         renamed_inputs = renamed_inputs,
         arguments = arguments | user_arguments,
@@ -353,7 +349,6 @@ def orfs_flow(
         kept_macros = kept_macros,
         canon_blackbox_macros = canon_blackbox_macros,
         sources = sources | user_sources,
-        stage_sources = stage_sources,
         stage_arguments = stage_arguments,
         renamed_inputs = {},
         arguments = arguments | {"SYNTH_GUT": "1"},
@@ -451,7 +446,6 @@ def _orfs_pass(
         verilog_files,
         macros,
         sources,
-        stage_sources,
         stage_arguments,
         renamed_inputs,
         arguments,
@@ -533,7 +527,6 @@ def _orfs_pass(
                 variant = variant,
                 verilog_files = verilog_files,
                 pdk = pdk,
-                stage_sources = stage_sources,
                 settings = settings,
                 extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
@@ -593,7 +586,6 @@ def _orfs_pass(
                     stage_arguments = dict(stage_arguments),
                     arguments = dict(arguments),
                     sources = dict(sources),
-                    stage_sources = dict(stage_sources),
                     settings = dict(settings),
                     extra_arguments = dict(extra_arguments),
                     extra_configs = dict(extra_configs),
@@ -654,7 +646,6 @@ def _orfs_pass(
                         stage_arguments = stage_arguments,
                         arguments = arguments,
                         sources = sources,
-                        stage_sources = stage_sources,
                         settings = settings,
                         extra_arguments = extra_arguments,
                         extra_configs = extra_configs,
@@ -680,7 +671,6 @@ def _orfs_pass(
                 stage_arguments = stage_arguments,
                 arguments = arguments,
                 sources = sources,
-                stage_sources = stage_sources,
                 settings = settings,
                 extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
@@ -737,7 +727,6 @@ def _orfs_pass(
                 stage_arguments = stage_arguments,
                 arguments = arguments,
                 sources = sources,
-                stage_sources = stage_sources,
                 settings = settings,
                 extra_arguments = extra_arguments,
                 extra_configs = extra_configs,

--- a/private/stages.bzl
+++ b/private/stages.bzl
@@ -221,19 +221,17 @@ def get_stage_args(stage, stage_arguments = {}, arguments = {}, sources = {}):
     } | stage_arguments.get(stage, {})
     return dict(sorted(unsorted_dict.items()))
 
-def get_sources(stage, stage_sources, sources):
+def get_sources(stage, sources):
     """Returns the sources for a specific stage.
 
     Args:
         stage: The stage name.
-        stage_sources: the dictionary of stages with each stage having a list of sources
         sources: a dictionary of variable names with a list of sources to a stage
     Returns:
       A list of sources for the stage.
     """
     return sorted(
         set(
-            stage_sources.get(stage, []) +
             flatten(
                 [
                     source_list

--- a/sweep.bzl
+++ b/sweep.bzl
@@ -18,7 +18,6 @@ def orfs_sweep(
         sweep,
         verilog_files,
         top = None,
-        stage_sources = {},
         sources = {},
         other_variants = {},
         stage = "floorplan",
@@ -37,12 +36,11 @@ def orfs_sweep(
         sweep: The dictionary describing the variables to sweep
         other_variants: Dictionary with other variants to generate, but not as part of the sweep.
             Per-variant keys: arguments, dissolve, macros, openroad, previous_stage,
-            renamed_inputs, stage_arguments, stage_sources, description, sources, yosys,
+            renamed_inputs, stage_arguments, description, sources, yosys,
             abstract_stage, last_stage, tags
         stage: The stage to do the sweep on
         macros: name of modules to use as macros
         verilog_files: The Verilog files to build
-        stage_sources: dictionary with list of sources to use for the stage
         abstract_stage: generate abstract from this stage
         visibility: list of visibility labels
         sources: forwarded to orfs_flow
@@ -77,7 +75,6 @@ def orfs_sweep(
                 "previous_stage",
                 "renamed_inputs",
                 "stage_arguments",
-                "stage_sources",
                 "description",
                 "sources",
                 "yosys",
@@ -112,16 +109,6 @@ def orfs_sweep(
             previous_stage = all_variants[variant].get("previous_stage", {}),
             renamed_inputs = all_variants[variant].get("renamed_inputs", {}),
             stage_arguments = all_variants[variant].get("stage_arguments", {}),
-            stage_sources = {
-                stage: set(
-                    stage_sources.get(stage, []) +
-                    all_variants[variant].get("stage_sources", {}).get(stage, []),
-                )
-                for stage in set(
-                    stage_sources.keys() +
-                    all_variants[variant].get("stage_sources", {}).keys(),
-                )
-            },
             variant = variant,
             verilog_files = verilog_files,
             sources = sources | all_variants[variant].get("sources", {}),


### PR DESCRIPTION
Retire deprecated stage_sources attribute from orfs_flow, _orfs_pass, orfs_sweep, and related internal stages plumbing and documentation. sources is the standard way to provide stage sources.

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>