### PR TITLE
WIP/RFC: Explicit dependency and sources model for orfs_run

### DIFF
--- a/docs/rfc_orfs_run_sources.md
+++ b/docs/rfc_orfs_run_sources.md
@@ -1,0 +1,29 @@
+# RFC: Explicit Dependency & Sources Model for `orfs_run()`
+
+## Context & Problem Statement
+In Bazel's execution model, dependencies are strictly additive. It is straightforward to add dependencies and variables to an action, but nearly impossible to safely subtract or filter them out once inherited transitively.
+
+Previously, `orfs_run()` attempted to provide a "convenient story" where pointing `src` to an upstream stage target (e.g. `_synth`) would cause `orfs_run` to automatically inherit all variables and configuration from the full `orfs_flow()`. An execution-time JSON filtering mechanism (`merge_arguments.py` with `ALL_STAGE_TO_VARIABLES`) attempted to prune irrelevant stage variables.
+
+### Failure Mode: Circular Dependencies & Brittle DAGs
+In realistic physical design flows, downstream stage inputs frequently feed back or depend on earlier stage artifacts:
+- A custom floorplan generator or macro placer may depend on synthesis netlists/metrics.
+- If `orfs_run()` automatically pulls in the full flow's variables, configs, and inputs for `synth`, any floorplan tool participating in that flow creates an unresolvable cycle in Bazel's dependency graph:
+  `synth -> floorplan script -> orfs_run -> flow variables / floorplan deps`
+
+## Proposed Strategy: Explicit `orfs_run()` with `sources`
+
+1. **Explicit over Implicit**:
+   - `orfs_run()` will no longer attempt to magically gather or filter full-flow variables from `src`.
+   - `src` provides the primary input artifact, `PdkInfo`, and `TopInfo`.
+
+2. **Add `sources` Attribute to `orfs_run()`**:
+   - `orfs_run()` grows the `sources` dictionary attribute (matching `orfs_flow()`).
+   - Maps variable names directly to input files/labels, expanding them into action inputs and config paths cleanly.
+
+3. **DRY / Single Source of Truth (SSOT) at the Starlark Level**:
+   - Instead of rule internals guessing dependencies, users define shared configuration dictionaries and sources in `BUILD.bazel` / `.bzl` files.
+   - Multi-stage estimation ladders can be cleanly expressed as list comprehensions over `orfs_run()` targets without cyclic dependency risks.
+
+4. **Example Usage**:
+   See `test/estimation_ladder/BUILD.bazel` and `test/estimation_ladder/multiplier.sv`.

--- a/test/estimation_ladder/BUILD.bazel
+++ b/test/estimation_ladder/BUILD.bazel
@@ -1,0 +1,51 @@
+load("//:openroad.bzl", "orfs_flow", "orfs_run")
+
+package(default_visibility = ["//visibility:public"])
+
+# Base flow target synthesizing the pipelined multiplier
+orfs_flow(
+    name = "multiplier_nangate45",
+    srcs = ["multiplier.sv"],
+    design = "multiplier",
+    pdk = "@nangate45//:nangate45",
+    sdc = "constraints.sdc",
+    stage_sources = {
+        "synth": ["multiplier.sv", "constraints.sdc"],
+    },
+)
+
+# Common configuration shared across the estimation ladder (DRY & SSOT)
+COMMON_ESTIMATE_ARGS = {
+    "DESIGN_NAME": "multiplier",
+}
+
+COMMON_ESTIMATE_SOURCES = {
+    "ESTIMATOR_TCL": ["estimator.tcl"],
+}
+
+ESTIMATION_LADDER_STAGES = {
+    "synth": ["synth"],
+    "floorplan": ["synth", "floorplan"],
+    "place": ["synth", "floorplan", "place"],
+    "grt": ["synth", "floorplan", "place", "grt"],
+}
+
+# Composable estimation ladder expressed via list comprehension of orfs_run targets
+[
+    orfs_run(
+        name = "multiplier_estimate_{}".format(stage),
+        src = ":multiplier_nangate45_synth",
+        script = "estimator.tcl",
+        cmd = "run",
+        stages = stages_up_to,
+        arguments = COMMON_ESTIMATE_ARGS | {
+            "ESTIMATION_STAGE": stage,
+            "OUTPUT_YAML": "$(location :multiplier_{}_estimate.yaml)".format(stage),
+        },
+        sources = COMMON_ESTIMATE_SOURCES,
+        outs = [
+            "multiplier_{}_estimate.yaml".format(stage),
+        ],
+    )
+    for stage, stages_up_to in ESTIMATION_LADDER_STAGES.items()
+]

--- a/test/estimation_ladder/constraints.sdc
+++ b/test/estimation_ladder/constraints.sdc
@@ -1,0 +1,4 @@
+current_design multiplier
+create_clock [get_ports clk] -name core_clock -period 1.000
+set_input_delay -clock core_clock 0.200 [get_ports {valid_in a[*] b[*]}]
+set_output_delay -clock core_clock 0.200 [get_ports {valid_out product[*]}]

--- a/test/estimation_ladder/estimator.tcl
+++ b/test/estimation_ladder/estimator.tcl
@@ -1,0 +1,21 @@
+# Fast estimation script demonstrating multi-stage estimation in OpenROAD
+set output_yaml [expr {[info exists env(OUTPUT_YAML)] ? $env(OUTPUT_YAML) : "estimate.yaml"}]
+set stage_name [expr {[info exists env(ESTIMATION_STAGE)] ? $env(ESTIMATION_STAGE) : "unknown"}]
+
+puts "Running estimation ladder step for stage: $stage_name"
+
+# Extract basic timing metrics if timing graph is loaded
+set wns "0.0"
+set tns "0.0"
+catch {
+    set wns [sta::worst_slack -max]
+    set tns [sta::total_negative_slack -max]
+}
+
+set fp [open $output_yaml "w"]
+puts $fp "stage: $stage_name"
+puts $fp "wns: $wns"
+puts $fp "tns: $tns"
+close $fp
+
+puts "Wrote estimation metrics to $output_yaml"

--- a/test/estimation_ladder/multiplier.sv
+++ b/test/estimation_ladder/multiplier.sv
@@ -1,0 +1,57 @@
+// Generic parameterizable pipelined multiplier for estimation ladder testing.
+// Zero-leakage, standard SystemVerilog implementation.
+
+module multiplier #(
+    parameter int WIDTH = 32
+) (
+    input  logic                 clk,
+    input  logic                 rst,
+    input  logic                 valid_in,
+    input  logic [WIDTH-1:0]     a,
+    input  logic [WIDTH-1:0]     b,
+    output logic                 valid_out,
+    output logic [2*WIDTH-1:0]   product
+);
+
+    // Stage 1: Register inputs
+    logic [WIDTH-1:0] a_reg, b_reg;
+    logic             v1_reg;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            a_reg   <= '0;
+            b_reg   <= '0;
+            v1_reg  <= 1'b0;
+        end else begin
+            a_reg   <= a;
+            b_reg   <= b;
+            v1_reg  <= valid_in;
+        end
+    end
+
+    // Stage 2: Multiply
+    logic [2*WIDTH-1:0] prod_reg;
+    logic               v2_reg;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            prod_reg <= '0;
+            v2_reg   <= 1'b0;
+        end else begin
+            prod_reg <= a_reg * b_reg;
+            v2_reg   <= v1_reg;
+        end
+    end
+
+    // Stage 3: Output register
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            product   <= '0;
+            valid_out <= 1'b0;
+        end else begin
+            product   <= prod_reg;
+            valid_out <= v2_reg;
+        end
+    end
+
+endmodule


### PR DESCRIPTION
### Summary & RFC Plan

This draft PR captures the architectural plan and test fixtures to introduce an **explicit dependency and `sources` model** for `orfs_run()`.

#### Background & Problem
In Bazel's execution model, dependencies are strictly additive. It is straightforward to add dependencies and variables to an action, but nearly impossible to safely subtract or filter them out once inherited transitively.

Previously, attempts to have `orfs_run()` implicitly inherit all flow variables from an upstream stage (e.g. `_synth`) and prune them via execution-time JSON filters created complex cyclic dependencies when intermediate tools (such as floorplan/macro placement generators) depended on stage artifacts.

#### Proposed Solution
1. **Explicit `orfs_run()` Dependencies**: Remove automatic full-flow variable harvesting from `src[OrfsInfo].arguments`.
2. **Grow `sources` Attribute**: Enable `orfs_run()` to accept `sources = {...}` (mapping variable names to input files/labels), matching `orfs_flow()`.
3. **DRY Estimation Ladders**: Enable clean composition of custom estimation ladders (e.g., fast synth QoR -> floorplan -> place -> grt) via list comprehensions in `BUILD.bazel` using shared Starlark dictionaries without risking circular DAGs.

#### Fixtures Included
- `test/estimation_ladder/multiplier.sv`: Generic parameterizable pipelined multiplier with minimal complexity to show timing and placement signals.
- `test/estimation_ladder/constraints.sdc`: Standard clock constraints.
- `test/estimation_ladder/estimator.tcl`: Sample estimation script.
- `test/estimation_ladder/BUILD.bazel`: Estimation ladder demonstration.
- `docs/rfc_orfs_run_sources.md`: Architectural RFC.

*Draft PR opened to capture plan and test fixtures before reseating development to a more powerful machine.*