### PR TITLE
Fix flow.bzl typo and prune unused CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           libxcb-render-util0
           libxcb-shape0
           libxcb-util1
-          libxcb-xinput0
           libxcb-xkb1
           libxkbcommon-x11-0
 

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -333,7 +333,7 @@ def orfs_flow(
         data = depset(
             kwargs.get("data", []) +
             [v for vs in (sources | user_sources).values() for v in vs] +
-            [v for vs in stage_sources.values() for v in vs],
+            [v for vs in sources.values() for v in vs],
         ).to_list(),
     )
 


### PR DESCRIPTION
This PR fixes a Starlark evaluation typo in `private/flow.bzl` (stage_sources -> sources) and removes the unused `libxcb-xinput0` dependency from the CI.