### PR TITLE
bazel: silence transitive pip.parse warning from protoc-gen-validate

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -149,6 +149,15 @@ single_version_override(
     patches = ["//patches:rules_pycross_no_warning.patch"],
 )
 
+# protoc-gen-validate: requirements.txt is unpinned/unhashed, causing rules_python
+# to emit DEBUG warnings during pip.parse unless quiet = True is set.
+single_version_override(
+    module_name = "protoc-gen-validate",
+    patch_strip = 0,
+    patches = ["//patches:protoc_gen_validate_quiet.patch"],
+    version = "1.0.4.bcr.2",
+)
+
 bazel_dep(name = "rules_pycross", version = "0.8.1")
 
 pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")
@@ -202,7 +211,7 @@ python = use_extension(
     "python",
 )
 python.toolchain(
-    ignore_root_user_error = True,
+    is_default = True,
     python_version = "3.13",
 )
 use_repo(python, "python_3_13_host")

--- a/patches/protoc_gen_validate_quiet.patch
+++ b/patches/protoc_gen_validate_quiet.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -80,6 +80,7 @@
+     pip.parse(
+         hub_name = "pgv_pip_deps",
+         python_version = python_version,
++        quiet = True,
+         requirements_lock = "//python:requirements.txt",
+     )
+     for python_version in PYTHON_VERSIONS


### PR DESCRIPTION
### Summary

- Add a `single_version_override` with `quiet = True` patch for `protoc-gen-validate` (version `1.0.4.bcr.2`), which resolves `DEBUG:` log warnings emitted by `rules_python` during `pip.parse` evaluation when dependency lock files omit hashes.
- Modernize `python.toolchain` in `MODULE.bazel` to set `is_default = True` and drop deprecated `ignore_root_user_error`.