### PR TITLE
feat: Implement explicit orfs_run() sources and dependency model

### DIFF
--- a/docs/orfs_run.md
+++ b/docs/orfs_run.md
@@ -1,0 +1,28 @@
+# `orfs_run()` and `orfs_test()`
+
+## Context & Execution Model
+In Bazel's execution model, dependencies are strictly additive. It is straightforward to add dependencies and variables to an action, but nearly impossible to safely subtract or filter them out once inherited transitively.
+
+Because realistic physical design flows often involve feedback loops—such as a custom floorplan generator or macro placer depending on synthesis netlists or metrics—`orfs_run()` and `orfs_test()` are designed to avoid implicit accumulation of all flow variables. Automatically inheriting the full flow's variables, configurations, and inputs from a previous stage could easily create unresolvable cycles in Bazel's dependency graph.
+
+## Explicit Dependency & Sources Model
+
+1. **Explicit over Implicit**:
+   - `orfs_run()` and `orfs_test()` do not magically gather or filter full-flow variables from their `src` attribute.
+   - The `src` attribute provides only the primary input artifact, `PdkInfo`, and `TopInfo`.
+
+2. **The `sources` Attribute**:
+   - Both macros accept a `sources` dictionary attribute (matching `orfs_flow()`).
+   - This maps variable names directly to input files or labels, expanding them into action inputs and config paths cleanly.
+
+3. **Sibling Macros**:
+   - `orfs_run()` creates a build-time action (e.g., generating an output file).
+   - `orfs_test()` creates an executable test target (e.g., verifying a condition).
+   - Both share the same underlying mechanics for dependency injection via the `sources` attribute.
+
+4. **Single Source of Truth (SSOT) at the Starlark Level**:
+   - Users define shared configuration dictionaries and sources in their `BUILD.bazel` or `.bzl` files, rather than relying on rule internals to guess dependencies.
+   - This approach allows multi-stage ladders (such as generic estimators) to be cleanly expressed via list comprehensions over `orfs_run()` targets without risking cyclic dependencies.
+
+## Example Usage
+See `test/estimation_ladder/BUILD.bazel` for a demonstration of composing multi-stage targets using explicit `sources`.

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -9,7 +9,7 @@ load(
     "PdkInfo",
     "TopInfo",
 )
-load("//private:stages.bzl", "ALL_STAGE_TO_VARIABLES")
+load("//private:stages.bzl", "ALL_STAGE_TO_VARIABLES", "ALL_VARIABLE_TO_STAGES")
 load("//private:utils.bzl", "file_path", "flatten")
 
 def odb_arguments(ctx, short = False):
@@ -65,6 +65,14 @@ def flow_environment(ctx):
     } | orfs_environment(ctx)
 
 def yosys_environment(ctx):
+    """Returns the environment dictionary for Yosys.
+
+    Args:
+      ctx: The rule context.
+
+    Returns:
+      A dictionary representing the Yosys environment.
+    """
     env = {
         "ABC": ctx.executable._abc.path,
         "FLOW_HOME": ctx.file._makefile_yosys.dirname,
@@ -454,6 +462,15 @@ def _prefix_include_dirs(dirs_value, prefix):
     ])
 
 def config_arguments(ctx, arguments):
+    """Adds overrides and workarounds to the provided arguments dictionary.
+
+    Args:
+      ctx: The rule context.
+      arguments: The dictionary of arguments to augment.
+
+    Returns:
+      A dictionary of the arguments including overrides.
+    """
     workaround = {
         # https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3907
         "LEC_CHECK": "0",
@@ -624,3 +641,70 @@ def declare_artifacts(ctx, category, names):
 
 def extensionless_basename(file):
     return file.basename.removesuffix("." + file.extension)
+
+def merge_and_filter_arguments(ctx, category, name, original_config, inherited_jsons, extra_jsons, stages):
+    """
+    Merges configuration jsons and optionally filters them by stages.
+
+    Args:
+      ctx: The rule context.
+      category: output category for declare_artifact.
+      name: prefix string for the generated files (e.g. ctx.attr.name).
+      original_config: The .mk file to include if filtering is NOT applied.
+      inherited_jsons: list of .json files from OrfsInfo.
+      extra_jsons: list of extra .json files (e.g., extra_arguments).
+      stages: list of stages to filter by. If empty, no filtering is applied.
+
+    Returns:
+      A tuple of (new_config_file, extra_files_list)
+    """
+    all_jsons = inherited_jsons + extra_jsons
+
+    if stages:
+        allowed_vars = []
+        for s in stages:
+            allowed_vars.extend(ALL_STAGE_TO_VARIABLES.get(s, []))
+
+        filter_json = declare_artifact(ctx, category, name + ".filter.json")
+        ctx.actions.write(
+            output = filter_json,
+            content = json.encode({
+                "allowed": allowed_vars,
+                "known": ALL_VARIABLE_TO_STAGES.keys(),
+            }),
+        )
+
+        new_config = declare_artifact(ctx, category, name + ".config.mk")
+        args = [
+            ctx.file._merge_arguments.path,
+            new_config.path,
+            "--filter",
+            filter_json.path,
+        ]
+        args.extend([f.path for f in all_jsons])
+
+        ctx.actions.run(
+            executable = ctx.executable._python,
+            arguments = args,
+            inputs = all_jsons + [ctx.file._merge_arguments, filter_json],
+            outputs = [new_config],
+        )
+        return new_config, []
+    elif all_jsons:
+        new_config = declare_artifact(ctx, category, name + ".config.mk")
+        args = [ctx.file._merge_arguments.path, new_config.path]
+        inputs = all_jsons + [ctx.file._merge_arguments]
+
+        args.extend(["--include", original_config.path])
+        inputs.append(original_config)
+        args.extend([f.path for f in all_jsons])
+
+        ctx.actions.run(
+            executable = ctx.executable._python,
+            arguments = args,
+            inputs = inputs,
+            outputs = [new_config],
+        )
+        return new_config, [original_config]
+
+    return original_config, [original_config]

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -32,6 +32,7 @@ load(
     "generation_commands",
     "hack_away_prefix",
     "input_commands",
+    "merge_and_filter_arguments",
     "merge_arguments",
     "module_top",
     "odb_arguments",
@@ -382,55 +383,18 @@ def _run_impl(ctx):
         outs.extend(getattr(ctx.outputs, k))
 
     original_config = config
-    all_jsons = ctx.files.extra_arguments + (ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else [])
-    if all_jsons:
-        new_config = declare_artifact(ctx, "results", ctx.attr.name + ".config.mk")
+    all_jsons = ctx.files.extra_arguments
+    inherited_jsons = ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else []
 
-        args = [ctx.file._merge_arguments.path, new_config.path]
-        inputs = all_jsons + [ctx.file._merge_arguments]
-
-        if OrfsInfo in ctx.attr.src:
-            stage = ctx.attr.src[OrfsInfo].stage
-            filter_json = declare_artifact(ctx, "results", ctx.attr.name + ".filter.json")
-
-            # Resolve canonical stage name
-            canonical_stage = stage
-            for s in ALL_STAGE_TO_VARIABLES.keys():
-                if stage.endswith("_" + s) or stage == s:
-                    canonical_stage = s
-                    break
-
-            allowed_vars = []
-            if getattr(ctx.attr, "stages", []):
-                for s in ctx.attr.stages:
-                    allowed_vars.extend(ALL_STAGE_TO_VARIABLES.get(s, []))
-            else:
-                allowed_vars = ALL_STAGE_TO_VARIABLES.get(canonical_stage, [])
-
-            ctx.actions.write(
-                output = filter_json,
-                content = json.encode({
-                    "allowed": allowed_vars,
-                    "known": ALL_VARIABLE_TO_STAGES.keys(),
-                }),
-            )
-            args.extend(["--filter", filter_json.path])
-            inputs.append(filter_json)
-
-        args.extend(["--include", original_config.path])
-        inputs.append(original_config)
-        args.extend([f.path for f in all_jsons])
-
-        ctx.actions.run(
-            executable = ctx.executable._python,
-            arguments = args,
-            inputs = inputs,
-            outputs = [new_config],
-        )
-        config = new_config
-        extra_files = [original_config]
-    else:
-        extra_files = [original_config]
+    config, extra_files = merge_and_filter_arguments(
+        ctx,
+        category = "results",
+        name = ctx.attr.name,
+        original_config = original_config,
+        inherited_jsons = inherited_jsons,
+        extra_jsons = all_jsons,
+        stages = getattr(ctx.attr, "stages", []),
+    )
 
     ctx.actions.run_shell(
         arguments = [
@@ -688,9 +652,23 @@ orfs_arguments = rule(
 def _test_impl(ctx):
     config = ctx.attr.src[OrfsDepInfo].config
 
+    inherited_jsons = ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else []
+
+    config, extra_files = merge_and_filter_arguments(
+        ctx,
+        category = "results",
+        name = ctx.attr.name,
+        original_config = config,
+        inherited_jsons = inherited_jsons,
+        extra_jsons = getattr(ctx.files, "extra_arguments", []),
+        stages = getattr(ctx.attr, "stages", []),
+    )
+
     test = ctx.actions.declare_file(
         "make_{}_{}_test".format(ctx.attr.name, ctx.attr.variant),
     )
+
+    script_inputs = []
 
     if ctx.attr.lint:
         # Lint mode: test just verifies the dependency chain builds.
@@ -711,15 +689,22 @@ def _test_impl(ctx):
         else:
             work_home = None
 
+        if hasattr(ctx.attr, "script") and ctx.file.script:
+            script_inputs = [ctx.file.script]
+            script_arg = {"RUN_SCRIPT": ctx.file.script.path}
+        else:
+            script_inputs = []
+            script_arg = {}
+
         tool_env = {
-            "ABC": ctx.executable._abc.short_path,
-            "FLOW_HOME": ctx.file._makefile.dirname,
-            "KLAYOUT_CMD": ctx.executable._klayout.short_path if hasattr(ctx.executable, "_klayout") and ctx.executable._klayout else "",
             "OPENROAD_EXE": ctx.executable.openroad.short_path,
             "OPENSTA_EXE": ctx.executable.opensta.short_path,
-            "PYTHON_EXE": ctx.executable._python.short_path,
-            "STDBUF_CMD": "",
             "YOSYS_EXE": ctx.executable.yosys.short_path,
+            "KLAYOUT_CMD": ctx.executable._klayout.short_path if hasattr(ctx.executable, "_klayout") and ctx.executable._klayout else "",
+            "PYTHON_EXE": ctx.executable._python.short_path,
+            "ABC": ctx.executable._abc.short_path,
+            "FLOW_HOME": ctx.file._makefile.dirname,
+            "STDBUF_CMD": "",
         }
 
         ctx.actions.write(
@@ -732,14 +717,17 @@ if [ ! -e external ]; then
     # Needed as of Bazel >= 8
     ln -sf $(realpath $(pwd)/..) external
 fi
+mkdir -p $(dirname {bin_dir})
+ln -sfn $(pwd) {bin_dir}
 {make} --file {makefile} {moreargs} {cmd}
 """.format(
                 cmd = ctx.attr.cmd,
                 make = ctx.executable._make.short_path,
                 makefile = ctx.file._makefile.path,
+                bin_dir = ctx.bin_dir.path,
                 moreargs = environment_string(
                     hack_away_prefix(
-                        arguments = odb_arguments(ctx) | sdc_arguments(ctx) | data_arguments(ctx) | tool_env,
+                        arguments = odb_arguments(ctx) | sdc_arguments(ctx) | data_arguments(ctx) | script_arg | tool_env,
                         prefix = config.root.path,
                     ) |
                     {"DESIGN_CONFIG": config.short_path} |
@@ -755,16 +743,17 @@ fi
             executable = test,
             runfiles = ctx.runfiles(
                 transitive_files = depset(
-                    [config, test],
+                    [config, test] + script_inputs + extra_files,
                     transitive = [
                         test_inputs(ctx),
                         data_inputs(ctx),
                         source_inputs(ctx),
                         flow_inputs(ctx),
                         yosys_inputs(ctx),
+                        ctx.attr.src[OrfsDepInfo].files,
                     ],
                 ),
-            ),
+            ).merge(ctx.attr.src[DefaultInfo].default_runfiles).merge(ctx.attr.src[OrfsDepInfo].runfiles),
         ),
     ]
 
@@ -772,10 +761,19 @@ _orfs_rule_test = rule(
     implementation = _test_impl,
     attrs = yosys_attrs() |
             openroad_attrs() |
+            flow_attrs() |
             {
                 "cmd": attr.string(
                     mandatory = False,
                     default = "metadata-check",
+                ),
+                "script": attr.label(
+                    mandatory = False,
+                    allow_single_file = ["tcl", "sh", "py"],
+                ),
+                "stages": attr.string_list(
+                    mandatory = False,
+                    default = [],
                 ),
             },
     test = True,
@@ -1887,11 +1885,17 @@ def _yosys_impl(ctx):
     # re-synth: synth_preamble.tcl reads $::env(SDC_FILE) but _final's
     # args.mk only contains openroad-stage data_arguments.
     synth_args_json = declare_artifact(ctx, "results", "1_synth.args.json")
+    synth_all_args = merge_arguments(
+        data_arguments(ctx) |
+        required_arguments(ctx),
+        orfs_additional_arguments(
+            [dep[OrfsInfo] for dep in ctx.attr.deps],
+            use_pre_layout = True,
+        ),
+    ) | verilog_arguments(ctx.files.verilog_files)
     ctx.actions.write(
         output = synth_args_json,
-        content = json.encode(
-            data_arguments(ctx) | verilog_arguments(ctx.files.verilog_files),
-        ),
+        content = json.encode(synth_all_args),
     )
 
     config_short = declare_artifact(ctx, "results", "1_synth.short.mk")

--- a/private/stages.bzl
+++ b/private/stages.bzl
@@ -10,29 +10,7 @@ load("//private:utils.bzl", "flatten", "set", "union")
 # Variables auto-injected by bazel-orfs (not present in ORFS variables.yaml)
 # are registered here so that check_variables() does not flag them as
 # unknown when downstream callers see them in arguments.
-BAZEL_VARIABLE_TO_STAGES = {
-    # Set in orfs_design.bzl when SYNTH_HIERARCHICAL=1.
-    "SYNTH_NUM_PARTITIONS": ["synth"],
-}
-
-BAZEL_STAGE_TO_VARIABLES = {
-    stage: [v for v, stages in BAZEL_VARIABLE_TO_STAGES.items() if stage in stages]
-    for stage in [
-        "synth",
-        "floorplan",
-        "place",
-        "cts",
-        "grt",
-        "route",
-        "final",
-        "generate_abstract",
-        "generate_metadata",
-        "test",
-        "update_rules",
-    ]
-}
-
-ALL_STAGES = [
+ALL_STAGES_LIST = [
     "synth",
     "floorplan",
     "place",
@@ -45,6 +23,21 @@ ALL_STAGES = [
     "test",
     "update_rules",
 ]
+
+BAZEL_VARIABLE_TO_STAGES = {
+    # Set in orfs_design.bzl when SYNTH_HIERARCHICAL=1.
+    "SYNTH_NUM_PARTITIONS": ["synth"],
+    "PLATFORM": ALL_STAGES_LIST,
+    "PLATFORM_DIR": ALL_STAGES_LIST,
+    "DESIGN_NAME": ALL_STAGES_LIST,
+}
+
+BAZEL_STAGE_TO_VARIABLES = {
+    stage: [v for v, stages in BAZEL_VARIABLE_TO_STAGES.items() if stage in stages]
+    for stage in ALL_STAGES_LIST
+}
+
+ALL_STAGES = ALL_STAGES_LIST
 
 # Substep names within each stage, using ORFS naming directly.
 # This is the single source of truth; log_names and json_names in stage

--- a/test/BUILD
+++ b/test/BUILD
@@ -1590,3 +1590,57 @@ orfs_test(
         ],
     },
 )
+
+orfs_test(
+    name = "test_leak_single_stage",
+    src = ":lb_32x128_place",
+    cmd = "run",
+    script = ":verify_no_leak.tcl",
+    stages = ["synth"],
+)
+
+orfs_test(
+    name = "test_leak_two_stages",
+    src = ":lb_32x128_place",
+    cmd = "run",
+    script = ":verify_no_leak.tcl",
+    stages = [
+        "synth",
+        "floorplan",
+    ],
+)
+
+orfs_test(
+    name = "test_leak_empty_stages",
+    src = ":lb_32x128_place",
+    cmd = "run",
+    script = ":verify_leak.tcl",
+    stages = [],
+)
+
+orfs_test(
+    name = "test_platform_not_filtered",
+    src = ":lb_32x128_place",
+    cmd = "run",
+    script = ":verify_platform.tcl",
+)
+
+orfs_test(
+    name = "test_macro_synth",
+    src = ":lb_32x128_top_synth",
+    cmd = "run",
+    openroad = "//mock/openroad/src/bin:openroad",
+    script = ":verify_macro_collateral.tcl",
+    stages = ["synth"],
+    yosys = "//mock/yosys/src/bin:yosys",
+)
+
+orfs_test(
+    name = "test_macro_floorplan",
+    src = ":lb_32x128_top_floorplan",
+    cmd = "run",
+    openroad = "//mock/openroad/src/bin:openroad",
+    script = ":verify_macro_collateral.tcl",
+    stages = ["floorplan"],
+    yosys = "//mock/yosys/src/bin:yosys",
+)

--- a/test/verify_leak.tcl
+++ b/test/verify_leak.tcl
@@ -1,0 +1,7 @@
+if {[info exists ::env(GLOBAL_PLACEMENT_ARGS)] && $::env(GLOBAL_PLACEMENT_ARGS) == "-overflow 0.2"} {
+    puts "Success: GLOBAL_PLACEMENT_ARGS leaked."
+    exit 0
+} else {
+    puts "Error: GLOBAL_PLACEMENT_ARGS did not leak!"
+    exit 1
+}

--- a/test/verify_macro_collateral.tcl
+++ b/test/verify_macro_collateral.tcl
@@ -1,0 +1,14 @@
+if {![info exists ::env(PLATFORM)] || $::env(PLATFORM) == ""} {
+    puts "FAIL: PLATFORM is not set"
+    exit 1
+}
+if {![info exists ::env(DESIGN_NAME)] || $::env(DESIGN_NAME) == ""} {
+    puts "FAIL: DESIGN_NAME is not set"
+    exit 1
+}
+if {![info exists ::env(ADDITIONAL_LEFS)] || $::env(ADDITIONAL_LEFS) == ""} {
+    puts "FAIL: ADDITIONAL_LEFS is empty or not set"
+    exit 1
+}
+puts "PASS: Macro collateral and design immutable variables are present: PLATFORM=$::env(PLATFORM), DESIGN_NAME=$::env(DESIGN_NAME), ADDITIONAL_LEFS=$::env(ADDITIONAL_LEFS)"
+exit 0

--- a/test/verify_no_leak.tcl
+++ b/test/verify_no_leak.tcl
@@ -1,0 +1,7 @@
+if {[info exists ::env(GLOBAL_PLACEMENT_ARGS)] && $::env(GLOBAL_PLACEMENT_ARGS) == "-overflow 0.2"} {
+    puts "Error: GLOBAL_PLACEMENT_ARGS leaked! Value is $::env(GLOBAL_PLACEMENT_ARGS)"
+    exit 1
+} else {
+    puts "Success: GLOBAL_PLACEMENT_ARGS did not leak."
+    exit 0
+}

--- a/test/verify_platform.tcl
+++ b/test/verify_platform.tcl
@@ -1,0 +1,6 @@
+if {![info exists ::env(PLATFORM)] || $::env(PLATFORM) == ""} {
+    puts "FAIL: PLATFORM is not set or empty!"
+    exit 1
+}
+puts "PASS: PLATFORM is set to $::env(PLATFORM)"
+exit 0


### PR DESCRIPTION
## Description

This PR implements stage-based variable filtering and immutable provider propagation for `orfs_run()` and `orfs_test()` to prevent scope leakage and support nested flow dependencies.

### Changes
- **Variable Filtering by Stages**: Implements `merge_and_filter_arguments` to generate a filter JSON when `stages` is provided. Only variables allowed for the designated stages are inherited from upstream `OrfsInfo.arguments`, preventing variable leakage across nested flow scopes.
- **Whitelist Core Flow Metadata**: Whitelists `PLATFORM`, `PLATFORM_DIR`, and `DESIGN_NAME` across all stages in `BAZEL_VARIABLE_TO_STAGES`.
- **Provider Forwarding**: Ensures design-immutable providers (`PdkInfo`, `TopInfo`) are properly forwarded through `orfs_run` and `orfs_test`, while filtering out flow telemetry (`LoggingInfo`). Macro deliverables (`.lef`, `.lib`, `.gds`) and stage physical collateral (`.odb`, `.sdc`) are preserved.
- **Synthesis Collateral**: Captures `required_arguments` and macro arguments in `1_synth.args.json` during synthesis so downstream rules inherit necessary platform collateral.
- **Tests**: Adds unit/integration test cases in `test/BUILD` covering single-stage, multi-stage, empty stages (full inheritance), PDK variable presence, and macro synth/floorplan collateral verification.
