### PR TITLE
build: extract sources API from PR 799

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -16,7 +16,6 @@ load(
     "//private:environment.bzl",
     "EXPAND_VERILOG_DIRS",
     "config_arguments",
-    "config_content",
     "config_environment",
     "config_overrides",
     "data_arguments",
@@ -521,7 +520,7 @@ def _run_impl(ctx):
         ),
     ]
 
-orfs_run = rule(
+_orfs_run_rule = rule(
     implementation = _run_impl,
     attrs = yosys_attrs() |
             openroad_attrs() |
@@ -548,6 +547,39 @@ orfs_run = rule(
                 ),
             },
 )
+
+def _expand_sources(kwargs):
+    """Processes the 'sources' attribute into 'data' and 'arguments'."""
+    sources = kwargs.pop("sources", {})
+    if sources:
+        data = kwargs.pop("data", [])
+        if type(data) != "list":
+            data = list(data)
+        arguments = dict(kwargs.pop("arguments", {}))
+
+        for var, labels in sources.items():
+            if type(labels) != "list":
+                labels = [labels]
+            for label in labels:
+                if label not in data:
+                    data.append(label)
+            locs = " ".join(["$(locations {})".format(label) for label in labels])
+            if var in arguments:
+                arguments[var] = arguments[var] + " " + locs
+            else:
+                arguments[var] = locs
+
+        kwargs["data"] = data
+        kwargs["arguments"] = arguments
+    return kwargs
+
+def orfs_run(**kwargs):
+    """Rule wrapper for orfs_run to populate data dependencies and CLI arguments from explicitly specified sources.
+
+    Args:
+        **kwargs: The keyword arguments to pass to the underlying _orfs_run_rule.
+    """
+    _orfs_run_rule(**_expand_sources(kwargs))
 
 def _variables_impl(ctx):
     out = ctx.actions.declare_file(ctx.attr.name + ".json")
@@ -678,6 +710,18 @@ def _test_impl(ctx):
             work_home = "/".join(parts)
         else:
             work_home = None
+
+        tool_env = {
+            "ABC": ctx.executable._abc.short_path,
+            "FLOW_HOME": ctx.file._makefile.dirname,
+            "KLAYOUT_CMD": ctx.executable._klayout.short_path if hasattr(ctx.executable, "_klayout") and ctx.executable._klayout else "",
+            "OPENROAD_EXE": ctx.executable.openroad.short_path,
+            "OPENSTA_EXE": ctx.executable.opensta.short_path,
+            "PYTHON_EXE": ctx.executable._python.short_path,
+            "STDBUF_CMD": "",
+            "YOSYS_EXE": ctx.executable.yosys.short_path,
+        }
+
         ctx.actions.write(
             output = test,
             is_executable = True,
@@ -695,7 +739,7 @@ fi
                 makefile = ctx.file._makefile.path,
                 moreargs = environment_string(
                     hack_away_prefix(
-                        arguments = odb_arguments(ctx) | sdc_arguments(ctx) | data_arguments(ctx),
+                        arguments = odb_arguments(ctx) | sdc_arguments(ctx) | data_arguments(ctx) | tool_env,
                         prefix = config.root.path,
                     ) |
                     {"DESIGN_CONFIG": config.short_path} |
@@ -716,13 +760,15 @@ fi
                         test_inputs(ctx),
                         data_inputs(ctx),
                         source_inputs(ctx),
+                        flow_inputs(ctx),
+                        yosys_inputs(ctx),
                     ],
                 ),
             ),
         ),
     ]
 
-orfs_test = rule(
+_orfs_rule_test = rule(
     implementation = _test_impl,
     attrs = yosys_attrs() |
             openroad_attrs() |
@@ -734,6 +780,14 @@ orfs_test = rule(
             },
     test = True,
 )
+
+def orfs_test(**kwargs):
+    """Rule wrapper for orfs_test to populate data dependencies and CLI arguments from explicitly specified sources.
+
+    Args:
+        **kwargs: The keyword arguments to pass to the underlying _orfs_rule_test.
+    """
+    _orfs_rule_test(**_expand_sources(kwargs))
 
 # --- Run-executable rule ---
 #
@@ -1144,7 +1198,6 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
     # Base arguments common to every partition config (data + required;
     # ADDITIONAL_* gets layered on per-partition).
     base_arguments = data_arguments(ctx) | required_arguments(ctx)
-    extra_config_paths = [file.path for file in ctx.files.extra_configs]
 
     # kept_modules_list is computed earlier (before Action 2c per-module
     # canonicalize) so we don't recompute it here.

--- a/test/BUILD
+++ b/test/BUILD
@@ -3,7 +3,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load("//:openroad.bzl", "get_stage_args", "orfs_arguments", "orfs_floorplan", "orfs_flow", "orfs_gds", "orfs_macro", "orfs_place", "orfs_run", "orfs_run_executable", "orfs_synth", "orfs_variables")
+load("//:openroad.bzl", "get_stage_args", "orfs_arguments", "orfs_floorplan", "orfs_flow", "orfs_gds", "orfs_macro", "orfs_place", "orfs_run", "orfs_run_executable", "orfs_synth", "orfs_test", "orfs_variables")
 load("//:orfs_genrule.bzl", "orfs_genrule")
 load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
@@ -1518,4 +1518,75 @@ py_test(
     name = "mock_optuna_test",
     srcs = ["mock_optuna_test.py"],
     data = [":mock_tuner_executable"],
+)
+
+write_file(
+    name = "test_source_1",
+    out = "test_source_1.txt",
+    content = ["test_source_content"],
+)
+
+write_file(
+    name = "test_source_2",
+    out = "test_source_2.txt",
+    content = ["second_source_content"],
+)
+
+write_file(
+    name = "dump_sources_tcl",
+    out = "dump_sources.tcl",
+    content = ["""
+set fp [open $::env(OUT_vars_txt) w]
+set fd1 [open $::env(TEST_SOURCE_1) r]
+puts $fp [read $fd1]
+close $fd1
+foreach src $::env(TEST_SOURCES) {
+    set fdn [open $src r]
+    puts $fp [read $fdn]
+    close $fdn
+}
+close $fp
+"""],
+)
+
+orfs_run(
+    name = "test_orfs_run_sources",
+    src = ":lb_32x128_synth",
+    outs = ["test_orfs_run_sources.txt"],
+    arguments = {
+        "OUT_vars_txt": "$(location :test_orfs_run_sources.txt)",
+    },
+    script = ":dump_sources_tcl",
+    sources = {
+        "TEST_SOURCE_1": ":test_source_1",
+        "TEST_SOURCES": [
+            ":test_source_1",
+            ":test_source_2",
+        ],
+    },
+)
+
+sh_test(
+    name = "orfs_run_sources_test",
+    srcs = ["verify_orfs_run_sources.sh"],
+    args = ["$(location :test_orfs_run_sources.txt)"],
+    data = [":test_orfs_run_sources.txt"],
+)
+
+orfs_test(
+    name = "test_orfs_test_sources",
+    src = ":lb_32x128_mock_openroad_floorplan",
+    arguments = {
+        "SCRIPT": "$(location :verify_orfs_test_sources.tcl)",
+    },
+    cmd = "run",
+    data = [":verify_orfs_test_sources.tcl"],
+    openroad = "//mock/openroad/src/bin:openroad",
+    sources = {
+        "TEST_SOURCE_1": ":test_source_1",
+        "TEST_SOURCES": [
+            ":test_source_1",
+            ":test_source_2",
+        ],
+    },
 )

--- a/test/verify_orfs_run_sources.sh
+++ b/test/verify_orfs_run_sources.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+# The test takes the generated file path as the first argument
+output_file=$1
+
+content=$(cat "$output_file")
+if [[ "$content" == *"test_source_content"* ]]; then
+    echo "PASS: found 'test_source_content' in output."
+else
+    echo "FAIL: content mismatch in $output_file:"
+    cat "$output_file"
+    exit 1
+fi
+
+if [[ "$content" == *"second_source_content"* ]]; then
+    echo "PASS: found 'second_source_content' in output."
+else
+    echo "FAIL: content mismatch in $output_file (second source missing):"
+    cat "$output_file"
+    exit 1
+fi

--- a/test/verify_orfs_test_sources.tcl
+++ b/test/verify_orfs_test_sources.tcl
@@ -1,0 +1,24 @@
+set fd1 [open $::env(TEST_SOURCE_1) r]
+set content1 [read $fd1]
+close $fd1
+if {![string match "*test_source_content*" $content1]} {
+    puts "FAIL: TEST_SOURCE_1 content mismatch: $content1"
+    exit 1
+}
+
+set found_second 0
+foreach src $::env(TEST_SOURCES) {
+    set fdn [open $src r]
+    set contentn [read $fdn]
+    close $fdn
+    if {[string match "*second_source_content*" $contentn]} {
+        set found_second 1
+    }
+}
+if {!$found_second} {
+    puts "FAIL: TEST_SOURCES did not contain second_source_content"
+    exit 1
+}
+
+puts "PASS: orfs_test sources mapped correctly"
+exit 0


### PR DESCRIPTION
This extracts the purely additive `sources` API from PR #799 so it can be merged independently. It introduces the `sources` dict for explicit dependency tracking without breaking backward compatibility.