### PR TITLE
bazel: strip unused python/pip extensions from protoc-gen-validate to silence warnings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -149,8 +149,8 @@ single_version_override(
     patches = ["//patches:rules_pycross_no_warning.patch"],
 )
 
-# protoc-gen-validate: requirements.txt is unpinned/unhashed, causing rules_python
-# to emit DEBUG warnings during pip.parse unless quiet = True is set.
+# protoc-gen-validate: strip unused python/pip extensions whose unhashed
+# requirements.txt causes rules_python to emit hundreds of DEBUG warnings.
 single_version_override(
     module_name = "protoc-gen-validate",
     patch_strip = 0,

--- a/patches/protoc_gen_validate_quiet.patch
+++ b/patches/protoc_gen_validate_quiet.patch
@@ -1,10 +1,28 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -80,6 +80,7 @@
-     pip.parse(
-         hub_name = "pgv_pip_deps",
-         python_version = python_version,
-+        quiet = True,
-         requirements_lock = "//python:requirements.txt",
-     )
-     for python_version in PYTHON_VERSIONS
+@@ -63,25 +63,0 @@
+-PYTHON_VERSIONS = [
+-    "3.9",
+-    "3.10",
+-    "3.11",
+-    "3.12",
+-    "3.13",
+-]
+-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+-[
+-    python.toolchain(
+-        is_default = python_version == PYTHON_VERSIONS[-1],
+-        python_version = python_version,
+-    )
+-    for python_version in PYTHON_VERSIONS
+-]
+-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+-[
+-    pip.parse(
+-        hub_name = "pgv_pip_deps",
+-        python_version = python_version,
+-        requirements_lock = "//python:requirements.txt",
+-    )
+-    for python_version in PYTHON_VERSIONS
+-]
+-use_repo(pip, "pgv_pip_deps")


### PR DESCRIPTION
The transitive dependency protoc-gen-validate defined pip.parse across 5 Python versions against an unhashed requirements.txt, causing rules_python to emit hundreds of DEBUG warnings during bzlmod evaluation. This patch strips those unused extensions to eliminate the warnings.