### PR TITLE
bazel: silence multi-module maven warning from rules_jvm_external

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -158,6 +158,14 @@ single_version_override(
     version = "1.0.4.bcr.2",
 )
 
+# rules_jvm_external emits a DEBUG message when multiple modules contribute
+# to the maven repo.
+single_version_override(
+    module_name = "rules_jvm_external",
+    patch_strip = 0,
+    patches = ["//patches:rules_jvm_external_quiet.patch"],
+)
+
 bazel_dep(name = "rules_pycross", version = "0.8.1")
 
 pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -149,8 +149,8 @@ single_version_override(
     patches = ["//patches:rules_pycross_no_warning.patch"],
 )
 
-# protoc-gen-validate: requirements.txt is unpinned/unhashed, causing rules_python
-# to emit DEBUG warnings during pip.parse unless quiet = True is set.
+# protoc-gen-validate: strip unused python/pip extensions whose unhashed
+# requirements.txt causes rules_python to emit hundreds of DEBUG warnings.
 single_version_override(
     module_name = "protoc-gen-validate",
     patch_strip = 0,

--- a/patches/protoc_gen_validate_quiet.patch
+++ b/patches/protoc_gen_validate_quiet.patch
@@ -1,10 +1,28 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -80,6 +80,7 @@
-     pip.parse(
-         hub_name = "pgv_pip_deps",
-         python_version = python_version,
-+        quiet = True,
-         requirements_lock = "//python:requirements.txt",
-     )
-     for python_version in PYTHON_VERSIONS
+@@ -63,25 +63,0 @@
+-PYTHON_VERSIONS = [
+-    "3.9",
+-    "3.10",
+-    "3.11",
+-    "3.12",
+-    "3.13",
+-]
+-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+-[
+-    python.toolchain(
+-        is_default = python_version == PYTHON_VERSIONS[-1],
+-        python_version = python_version,
+-    )
+-    for python_version in PYTHON_VERSIONS
+-]
+-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+-[
+-    pip.parse(
+-        hub_name = "pgv_pip_deps",
+-        python_version = python_version,
+-        requirements_lock = "//python:requirements.txt",
+-    )
+-    for python_version in PYTHON_VERSIONS
+-]
+-use_repo(pip, "pgv_pip_deps")

--- a/patches/rules_jvm_external_quiet.patch
+++ b/patches/rules_jvm_external_quiet.patch
@@ -1,0 +1,10 @@
+--- private/extensions/maven.bzl
++++ private/extensions/maven.bzl
+@@ -349,7 +349,0 @@
+-    for (repo_name, known_names) in repo_name_2_module_name.items():
+-        if len(known_names) > 1:
+-            print("The maven repository '%s' has contributions from multiple bzlmod modules, and will be resolved together: %s" % (
+-                repo_name,  # e.g. "maven"
+-                sorted(known_names),  # e.g. bzl_module_bar, bzl_module_bar
+-            ))
+-


### PR DESCRIPTION
rules_jvm_external emits an unconditional print statement (rendered as a DEBUG message in Bazel) when multiple bzlmod modules contribute to the maven repo. This patch removes the print statement.