### PR TITLE
ci: merge build and run tests steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,8 @@ jobs:
           git diff --exit-code
 
       # --- Unit tests ---
-      - name: Build tests
-        run: bazelisk build ... --build_tests_only --profile=build.profile
-      - name: Analyze build
-        if: always()
-        run: bazelisk analyze-profile build.profile
-
       - name: Run tests
-        run: bazelisk test ... --keep_going --build_tests_only --test_output=errors --profile=test.profile
+        run: bazelisk test ... --build_tests_only --test_output=errors --profile=test.profile
       - name: Analyze test
         if: always()
         run: bazelisk analyze-profile test.profile


### PR DESCRIPTION
Merge build and run tests steps into a single bazelisk test command without --keep_going to fail early and speed up builds.