### PR TITLE
refactor(stages): unify orfs_run source filtering with orfs_flow

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -660,6 +660,15 @@ def merge_and_filter_arguments(ctx, category, name, original_config, inherited_j
     """
     all_jsons = inherited_jsons + extra_jsons
 
+    # MORATORIUM(filter-branch): the filter branch below builds new_config
+    # PURELY from the filtered jsons and must NOT --include original_config —
+    # doing so would reintroduce the unfiltered base config variables and
+    # defeat the filter. The merge branch (no stages) DOES --include it and
+    # must keep it as an input.
+    # MORATORIUM(filter-parity): the {allowed, known} contract written here
+    # feeds merge_arguments.py's keep/drop, which mirrors stages.bzl's
+    # analysis-time predicate. Keep the three in lockstep — see the
+    # MORATORIUM(filter-parity) block in private/stages.bzl.
     if stages:
         allowed_vars = []
         for s in stages:

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -69,20 +69,22 @@ def _filter_stage_args(stage, **kwargs):
     if stage == "synth":
         kwargs.pop("substeps", None)
 
+    # get_stage_args/get_sources take a LIST of stages (empty = no filtering);
+    # a flow stage target filters by exactly one stage, so wrap [stage].
     return _args(
         arguments = get_stage_args(
-            stage,
+            [stage],
             arguments = arguments,
             sources = sources,
             stage_arguments = stage_arguments,
         ),
-        data = get_sources(stage, sources) +
+        data = get_sources([stage], sources) +
                stage_data.get(stage, []) +
                data,
         extra_arguments = extra_arguments.get(stage, []),
         extra_configs = extra_configs.get(stage, []),
         settings = get_stage_args(
-            stage,
+            [stage],
             arguments = settings,
         ),
         **kwargs
@@ -791,7 +793,7 @@ def _orfs_pass(
         )
 
         test_args = get_stage_args(
-            TEST_STAGE_IMPL.stage,
+            [TEST_STAGE_IMPL.stage],
             stage_arguments,
             arguments,
             sources,
@@ -837,7 +839,7 @@ def _orfs_pass(
     # (rename_data on orfs_generate_metadata).
     if synth_target != None and not mock_area:
         test_args = get_stage_args(
-            TEST_STAGE_IMPL.stage,
+            [TEST_STAGE_IMPL.stage],
             stage_arguments,
             arguments,
             sources,

--- a/private/merge_arguments.py
+++ b/private/merge_arguments.py
@@ -42,6 +42,13 @@ def main():
         known = set()
 
     with open(args.output_path, "w") as out:
+        # MORATORIUM(filter-parity): this drop condition is the EXECUTION-time
+        # mirror of the ANALYSIS-time predicate in stages.bzl
+        # (get_stage_args/get_sources). "drop iff known-but-not-allowed" is
+        # logically identical to "keep iff in-a-requested-stage or unmapped".
+        # If you change one, change the other (and rules.bzl's filter_json).
+        # See the MORATORIUM(filter-parity) block in private/stages.bzl.
+        # Unknown vars (not in `known`) are always kept — the escape hatch.
         for k, v in sorted(result.items()):
             if args.filter:
                 if k in known and k not in allowed:

--- a/private/merge_arguments_test.py
+++ b/private/merge_arguments_test.py
@@ -53,6 +53,27 @@ class TestMergeArguments(unittest.TestCase):
         expected = "export A?=1\n" "export C?=3\n"
         self.assertEqual(content, expected)
 
+    def test_filtering_keeps_unknown(self):
+        # A variable NOT in `known` is the unmapped escape hatch and must
+        # always survive the filter, even when filtering is active. This
+        # mirrors stages.bzl's `arg not in ALL_VARIABLE_TO_STAGES` branch —
+        # see MORATORIUM(filter-parity) in private/stages.bzl.
+        json_data = self.write_json("data.json", {"A": "1", "B": "2", "CUSTOM": "9"})
+        filter_json = self.write_json(
+            "filter.json", {"allowed": ["A"], "known": ["A", "B"]}
+        )
+        out_mk = os.path.join(self.temp_dir.name, "out.mk")
+
+        self.run_script([out_mk, "--filter", filter_json, json_data])
+
+        with open(out_mk) as f:
+            content = f.read()
+
+        # A: known+allowed -> kept. B: known, not allowed -> dropped.
+        # CUSTOM: unknown -> kept (escape hatch).
+        expected = "export A?=1\n" "export CUSTOM?=9\n"
+        self.assertEqual(content, expected)
+
     def test_mk_includes(self):
         json_data = self.write_json("data.json", {"A": "1"})
         out_mk = os.path.join(self.temp_dir.name, "out.mk")

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -63,6 +63,8 @@ load(
     "ALL_STAGE_TO_VARIABLES",
     "ALL_VARIABLE_TO_STAGES",
     "STAGE_SUBSTEPS",
+    "get_sources",
+    "get_stage_args",
 )
 
 # --- Shared helpers ---
@@ -514,21 +516,43 @@ _orfs_run_rule = rule(
 )
 
 def _expand_sources(kwargs):
-    """Processes the 'sources' attribute into 'data' and 'arguments'."""
+    """Processes the 'sources' attribute into 'data' and 'arguments'.
+
+    Runs at MACRO-EXPANSION time: it mutates raw kwargs before the rule is
+    instantiated, so `data`/`arguments` are set as attributes and Bazel
+    expands `$(locations ...)` later.
+
+    Source filtering is done at ANALYSIS time via the shared stages.bzl
+    helpers, keyed by the target's `stages` (empty = no filtering):
+      * sources -> data and sources -> $(locations) args are filtered
+        together, by the same predicate (you cannot emit $(locations X) for a
+        label pruned from data — see MORATORIUM(source-filtering-is-analysis-time)
+        in private/stages.bzl);
+      * plain string `arguments` are left UNTOUCHED here and filtered at
+        EXECUTION time by merge_and_filter_arguments (more code under test).
+        Do NOT route them through get_stage_args.
+    """
     sources = kwargs.pop("sources", {})
     if sources:
+        # Normalize scalar source values to lists; the helpers expect lists.
+        sources = {
+            var: (labels if type(labels) == "list" else [labels])
+            for var, labels in sources.items()
+        }
+        stages = kwargs.get("stages", [])
+
         data = kwargs.pop("data", [])
         if type(data) != "list":
             data = list(data)
-        arguments = dict(kwargs.pop("arguments", {}))
+        for label in get_sources(stages, sources):
+            if label not in data:
+                data.append(label)
 
-        for var, labels in sources.items():
-            if type(labels) != "list":
-                labels = [labels]
-            for label in labels:
-                if label not in data:
-                    data.append(label)
-            locs = " ".join(["$(locations {})".format(label) for label in labels])
+        # get_stage_args(sources=...) returns ONLY the source-derived
+        # $(locations) args, filtered by stage. Plain args stay as-is; append
+        # source locs to any plain arg that shares a variable name.
+        arguments = dict(kwargs.pop("arguments", {}))
+        for var, locs in get_stage_args(stages, sources = sources).items():
             if var in arguments:
                 arguments[var] = arguments[var] + " " + locs
             else:
@@ -1252,6 +1276,9 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
 
     partition_outputs = []
 
+    # MORATORIUM(filter-parity): {allowed, known} contract fed to
+    # merge_arguments.py; mirrors stages.bzl's analysis-time predicate. Keep
+    # all filter sites in lockstep — see MORATORIUM(filter-parity) in stages.bzl.
     filter_json = declare_artifact(ctx, "results", "1_synth_partition.filter.json")
     ctx.actions.write(
         output = filter_json,
@@ -1572,6 +1599,8 @@ def _yosys_impl(ctx):
         content = json.encode(analysis_args),
     )
 
+    # MORATORIUM(filter-parity): keep in lockstep with stages.bzl and
+    # merge_arguments.py — see MORATORIUM(filter-parity) in stages.bzl.
     filter_json = declare_artifact(ctx, "results", "1_synth.filter.json")
     ctx.actions.write(
         output = filter_json,
@@ -2255,6 +2284,8 @@ def _make_impl(
                 break
         allowed_vars = ALL_STAGE_TO_VARIABLES.get(canonical_stage, [])
 
+    # MORATORIUM(filter-parity): keep in lockstep with stages.bzl and
+    # merge_arguments.py — see MORATORIUM(filter-parity) in stages.bzl.
     filter_json = declare_artifact(ctx, "results", stage + ".filter.json")
     ctx.actions.write(
         output = filter_json,

--- a/private/stages.bzl
+++ b/private/stages.bzl
@@ -183,54 +183,126 @@ def check_variables(variables, label):
             "add it to your project's ORFS patch or file a PR against ORFS.",
         )
 
-def get_stage_args(stage, stage_arguments = {}, arguments = {}, sources = {}):
-    """Returns the arguments for a specific stage.
+# ---------------------------------------------------------------------------
+# Stage variable filtering
+#
+# get_stage_args() and get_sources() implement the SAME keep/drop predicate:
+#
+#     keep variable V for stage-set S  iff
+#         S is empty (no filtering)
+#         OR V belongs to some stage in S         # union over stages
+#         OR V is unmapped (not in variables.yaml) # the escape hatch
+#
+# This module is the canonical documentation hub for the filter invariants;
+# other sites point back here by MORATORIUM tag (grep `MORATORIUM(` to
+# enumerate all fences).
+#
+# MORATORIUM(filter-parity): This predicate is mirrored at EXECUTION time by
+# merge_arguments.py (`drop iff k in known and k not in allowed`) and by the
+# inline filter_json in rules.bzl (synth partitions). All three MUST agree —
+# if they drift, a variable can be kept at analysis time but dropped at
+# execution time (or vice-versa), causing missing-input failures or silent
+# variable loss on specific stages. Change them together; the filter-parity
+# behavior is locked by test/stages_filter_test.bzl and merge_arguments_test.py.
+#
+# MORATORIUM(source-filtering-is-analysis-time): get_sources() filters at
+# Bazel ANALYSIS time on purpose, and a source's $(locations) argument is
+# filtered here in lockstep with its data entry. This is not optional:
+#   * it prevents circular dependencies (a source consumed by a downstream
+#     stage must not be wired into an upstream stage's data),
+#   * fewer inputs per action lets the action start sooner, and
+#   * it lets callers declare one DRY sources={} dict in BUILD.bazel and have
+#     each stage take only the subset it needs.
+# Never defer source->data filtering to merge_arguments.py. You also cannot
+# emit $(locations X) for a label pruned from data (location-expansion error),
+# which is why the source-derived args live here and not with plain args.
+#
+# The `stages` parameter is always a LIST (empty = no filtering). flow.bzl
+# wraps its single stage as [stage]; orfs_run passes its stages string_list.
+# ---------------------------------------------------------------------------
+
+def _allowed_predicate(stages):
+    """Returns (filtering, allowed) for the keep/drop predicate.
 
     Args:
-        stage: The stage name.
-        stage_arguments: the dictionary of stages with each stage having a dictionary of arguments
+        stages: list of stage names. Empty means no filtering.
+    Returns:
+      A tuple (filtering, allowed) where `filtering` is True when a non-empty
+      stage list was given, and `allowed` is an O(1)-membership dict of the
+      variables owned by any of those stages.
+    """
+    if not stages:
+        return False, {}
+    allowed = {}
+    for stage in stages:
+        for variable in ALL_STAGE_TO_VARIABLES[stage]:
+            allowed[variable] = True
+    return True, allowed
+
+def _keep(arg, filtering, allowed):
+    # See the MORATORIUM(filter-parity) note above — this is the single
+    # analysis-time keep/drop predicate.
+    return (not filtering) or (arg in allowed) or (arg not in ALL_VARIABLE_TO_STAGES)
+
+def get_stage_args(stages, stage_arguments = {}, arguments = {}, sources = {}):
+    """Returns the arguments for a set of stages.
+
+    Args:
+        stages: list of stage names to keep arguments for (empty = keep all).
+        stage_arguments: dict keyed by stage, each holding a dict of arguments.
+            These are authored per-stage and BYPASS the variable filter on
+            purpose — do not fold them into the filtered dict below.
+            MORATORIUM(stage-arguments-bypass): locked by
+            test/stages_filter_test.bzl.
         arguments: a dictionary of arguments automatically assigned to a stage
         sources: a dictionary of variables and source files
     Returns:
-      A dictionary of arguments for the stage.
+      A dictionary of arguments for the stage(s).
     """
+    filtering, allowed = _allowed_predicate(stages)
+
+    # stage_arguments are pre-scoped by stage key, so they are added AFTER the
+    # filter (MORATORIUM(stage-arguments-bypass)). Merge every requested stage.
+    stage_specific = {}
+    for stage in stages:
+        stage_specific.update(stage_arguments.get(stage, {}))
+
     unsorted_dict = {
+        arg: " ".join(["$(locations {})".format(v) for v in value])
+        for arg, value in sources.items()
+        if _keep(arg, filtering, allowed)
+    }
+    unsorted_dict.update({
         arg: value
-        for arg, value in (
-            {
-                arg: " ".join(["$(locations {})".format(v) for v in value])
-                for arg, value in sources.items()
-                if arg in ALL_STAGE_TO_VARIABLES[stage] or
-                   arg not in ALL_VARIABLE_TO_STAGES
-            } |
-            {
-                arg: value
-                for arg, value in arguments.items()
-                if arg in ALL_STAGE_TO_VARIABLES[stage] or
-                   arg not in ALL_VARIABLE_TO_STAGES
-            }
-        ).items()
-        if arg in ALL_STAGE_TO_VARIABLES[stage] or arg not in ALL_VARIABLE_TO_STAGES
-    } | stage_arguments.get(stage, {})
+        for arg, value in arguments.items()
+        if _keep(arg, filtering, allowed)
+    })
+    unsorted_dict.update(stage_specific)
+
+    # sorted() output is load-bearing for deterministic action command lines
+    # — do not remove.
     return dict(sorted(unsorted_dict.items()))
 
-def get_sources(stage, sources):
-    """Returns the sources for a specific stage.
+def get_sources(stages, sources):
+    """Returns the sources for a set of stages.
 
     Args:
-        stage: The stage name.
+        stages: list of stage names to keep sources for (empty = keep all).
         sources: a dictionary of variable names with a list of sources to a stage
     Returns:
-      A list of sources for the stage.
+      A sorted, de-duplicated list of sources for the stage(s).
     """
+    filtering, allowed = _allowed_predicate(stages)
+
+    # sorted(set(...)) is load-bearing: set() de-duplicates sources shared
+    # across variables, sorted() gives deterministic inputs.
     return sorted(
         set(
             flatten(
                 [
                     source_list
                     for variable, source_list in sources.items()
-                    if variable in ALL_STAGE_TO_VARIABLES[stage] or
-                       variable not in ALL_VARIABLE_TO_STAGES
+                    if _keep(variable, filtering, allowed)
                 ],
             ),
         ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -10,6 +10,7 @@ load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test
 load(":provider_test_rule.bzl", "lib_pre_layout_test")
 load(":quick_pins_test_rule.bzl", "quick_pins_data_dep_test")
 load(":source_input_propagation_test.bzl", "source_input_propagation_test")
+load(":stages_filter_test.bzl", "stages_filter_test_suite")
 
 exports_files(
     glob([
@@ -577,6 +578,9 @@ source_input_propagation_test(
     expected_basename = "dummy_extra.lef",
     target_under_test = ":src_propagation_place",
 )
+
+# Unit tests for the stage variable filtering helpers (stages.bzl).
+stages_filter_test_suite(name = "stages_filter_test")
 
 # Test SYNTH_KEEP_MODULES: skip keep-hierarchy discovery, go straight to
 # parallel partition synthesis with a pre-specified module list.

--- a/test/BUILD
+++ b/test/BUILD
@@ -213,8 +213,14 @@ orfs_flow(
 orfs_floorplan(
     name = "lb_32x128_shared_synth_floorplan",
     src = ":lb_32x128_synth",
-    # Make sure we're not passing in any non-floorplan arguments
-    arguments = get_stage_args("floorplan", {}, LB_ARGS, {}),
+    # Make sure we're not passing in any non-floorplan arguments.
+    # get_stage_args takes a LIST of stages now (empty = no filtering).
+    arguments = get_stage_args(
+        ["floorplan"],
+        {},
+        LB_ARGS,
+        {},
+    ),
     data = LB_SOURCES["IO_CONSTRAINTS"],
     variant = "blah",
 )

--- a/test/stages_filter_test.bzl
+++ b/test/stages_filter_test.bzl
@@ -1,0 +1,121 @@
+"""Unit tests for the stage variable filtering helpers in stages.bzl.
+
+Covers the keep/drop predicate shared by get_stage_args() and get_sources()
+and the invariants documented by the MORATORIUM blocks in private/stages.bzl:
+
+  * empty stages list means "keep everything", not "keep nothing";
+  * unmapped variables (absent from variables.yaml) always survive (the
+    escape hatch);
+  * MORATORIUM(stage-arguments-bypass): stage_arguments bypass the filter;
+  * output is sorted/deterministic;
+  * list union — a variable in ANY requested stage is kept.
+
+Inputs are derived from the live ORFS metadata dicts so the test does not
+hard-code any particular variable-to-stage mapping.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(
+    "//private:stages.bzl",
+    "ALL_STAGE_TO_VARIABLES",
+    "ALL_VARIABLE_TO_STAGES",
+    "get_sources",
+    "get_stage_args",
+)
+
+# A name guaranteed not to be a known ORFS variable (the unmapped escape hatch).
+_UNMAPPED = "ZZ_UNMAPPED_TEST_VAR"
+
+# Pick two distinct stages A and B such that A owns a variable B does not, and
+# B owns a variable A does not. Derived from live metadata for robustness.
+def _pick_stages():
+    stages = sorted(ALL_STAGE_TO_VARIABLES.keys())
+    for a in stages:
+        a_vars = ALL_STAGE_TO_VARIABLES[a]
+        for b in stages:
+            if b == a:
+                continue
+            b_vars = ALL_STAGE_TO_VARIABLES[b]
+            only_a = [v for v in a_vars if v not in b_vars]
+            only_b = [v for v in b_vars if v not in a_vars]
+            if only_a and only_b:
+                return a, only_a[0], b, only_b[0]
+    return None, None, None, None
+
+_STAGE_A, _VAR_A, _STAGE_B, _VAR_B = _pick_stages()
+
+def _empty_stages_keeps_everything_test(ctx):
+    env = unittest.begin(ctx)
+
+    # A mapped variable that WOULD be dropped if filtered by an unrelated
+    # stage, plus an unmapped one — both must survive when stages is empty.
+    sources = {_VAR_A: ["//a:la"], _UNMAPPED: ["//u:lu"]}
+    asserts.equals(env, ["//a:la", "//u:lu"], get_sources([], sources))
+    asserts.equals(
+        env,
+        {_VAR_A: "$(locations //a:la)", _UNMAPPED: "$(locations //u:lu)"},
+        get_stage_args([], sources = sources),
+    )
+    return unittest.end(env)
+
+def _filter_drops_out_of_stage_keeps_unmapped_test(ctx):
+    env = unittest.begin(ctx)
+
+    # _VAR_B belongs to stage B, not A -> dropped when filtering by [A].
+    # _UNMAPPED is unknown -> kept (escape hatch). _VAR_A -> kept.
+    sources = {_VAR_A: ["//a:la"], _VAR_B: ["//b:lb"], _UNMAPPED: ["//u:lu"]}
+    asserts.equals(env, ["//a:la", "//u:lu"], get_sources([_STAGE_A], sources))
+    asserts.equals(
+        env,
+        {_VAR_A: "$(locations //a:la)", _UNMAPPED: "$(locations //u:lu)"},
+        get_stage_args([_STAGE_A], sources = sources),
+    )
+    return unittest.end(env)
+
+def _union_over_stages_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Filtering by [A, B] keeps variables owned by either stage.
+    sources = {_VAR_A: ["//a:la"], _VAR_B: ["//b:lb"]}
+    asserts.equals(
+        env,
+        ["//a:la", "//b:lb"],
+        get_sources([_STAGE_A, _STAGE_B], sources),
+    )
+    return unittest.end(env)
+
+def _stage_arguments_bypass_filter_test(ctx):
+    env = unittest.begin(ctx)
+
+    # _VAR_B is out-of-stage for [A], but a stage_argument keyed to A that
+    # sets it must still appear — MORATORIUM(stage-arguments-bypass).
+    result = get_stage_args(
+        [_STAGE_A],
+        stage_arguments = {_STAGE_A: {_VAR_B: "forced"}},
+    )
+    asserts.equals(env, "forced", result.get(_VAR_B))
+    return unittest.end(env)
+
+def _sorted_output_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Keys come back sorted regardless of insertion order (determinism).
+    result = get_stage_args([], arguments = {"ZED": "1", "ALPHA": "2", "MID": "3"})
+    asserts.equals(env, ["ALPHA", "MID", "ZED"], result.keys())
+    return unittest.end(env)
+
+empty_stages_keeps_everything_test = unittest.make(_empty_stages_keeps_everything_test)
+filter_drops_out_of_stage_keeps_unmapped_test = unittest.make(_filter_drops_out_of_stage_keeps_unmapped_test)
+union_over_stages_test = unittest.make(_union_over_stages_test)
+stage_arguments_bypass_filter_test = unittest.make(_stage_arguments_bypass_filter_test)
+sorted_output_test = unittest.make(_sorted_output_test)
+
+def stages_filter_test_suite(name):
+    unittest.suite(
+        name,
+        empty_stages_keeps_everything_test,
+        filter_drops_out_of_stage_keeps_unmapped_test,
+        union_over_stages_test,
+        stage_arguments_bypass_filter_test,
+        sorted_output_test,
+    )


### PR DESCRIPTION
## What

`orfs_flow` (via `stages.bzl`) filtered `sources` into per-stage `data`
deps and `$(locations)` args at **analysis time**, while the
`orfs_run` / `orfs_test` / `orfs_run_executable` family (via
`_expand_sources`) expanded **every** source unconditionally. This routes
both through the shared `stages.bzl` helpers so the source-filtering
predicate lives in one place.

## Why analysis-time source filtering matters (Chesterton's Fence)

It is load-bearing, not incidental:

- **Avoids circular dependencies** — a source consumed by a *downstream*
  stage must not be wired into an *upstream* stage's `data`.
- **Starts the action sooner** — fewer inputs means the action is runnable
  as soon as *its* inputs are ready.
- **DRY / single-source-of-truth** — callers declare one `sources = {}`
  dict in `BUILD.bazel` and each stage automatically takes only the subset
  it needs.

## Changes

- `get_stage_args()` / `get_sources()` take a **list** of stages (empty =
  no filtering) instead of a single stage string; the keep/drop predicate
  is collapsed into one computation. `flow.bzl` wraps its single stage as
  `[stage]`.
- `_expand_sources()` filters `sources → data` and `sources → $(locations)`
  args **together** at analysis time (you cannot emit `$(locations X)` for
  a label pruned from `data`), but leaves plain string `arguments`
  untouched so they keep being filtered at **execution time** by
  `merge_arguments.py` (more code under test).
- Added `MORATORIUM(...)` admonitions marking the three filter sites that
  must stay in lockstep (`stages.bzl`, `merge_arguments.py`,
  `rules.bzl`'s synth-partition `filter_json`) and the
  `merge_and_filter_arguments` branch asymmetry, so the invariants survive
  future "simplifications". `grep MORATORIUM(` enumerates the fences.

## Behavior change

- Callers that **omit** `stages`: unaffected (empty = keep all).
- Callers that **set** `stages`: now get stage-filtered sources.
- Plain string `arguments` filtering: unchanged.

## ⚠️ API change

`get_stage_args` / `get_sources` are re-exported via `openroad.bzl`, so the
string → list signature change is a **public-API break**: downstream
callers passing a bare stage string must wrap it as `[stage]`.

## Tests

- `test/stages_filter_test.bzl` — unit tests for the helpers: empty-stages
  keep-all, unmapped-variable survival, `stage_arguments` filter bypass,
  list union across stages, sorted output. Inputs are derived from live
  ORFS metadata (no hard-coded variable→stage mapping).
- `merge_arguments_test.py` — unknown variables always survive `--filter`
  (execution-time half of `MORATORIUM(filter-parity)`).
- Existing integration tests pass: `orfs_run_sources_test`,
  `test_orfs_test_sources`, `test_leak_{single,two,empty}_stages`,
  `test_platform_not_filtered`, `test_macro_{synth,floorplan}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)