### PR TITLE
agents: Expose SOT commands to Antigravity as skills

### DIFF
--- a/.claude/skills/odb-to-cpp/SKILL.md
+++ b/.claude/skills/odb-to-cpp/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: odb-to-cpp
+description: >-
+  Convert an .odb file into a C++ header that reconstructs the design using odb API calls. Turn a whittled .odb into a self-contained C++ unit test.
+---
+
+# odb-to-cpp
+
+The instructions for this skill are maintained in the shared Claude slash command.
+Please read and follow the single source of truth:
+[../../../.claude/commands/odb-to-cpp.md](../../../.claude/commands/odb-to-cpp.md)

--- a/.claude/skills/openroad-debug/SKILL.md
+++ b/.claude/skills/openroad-debug/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: openroad-debug
+description: >-
+  Diagnose and iterate on an OpenROAD/ORFS failure (crash, hang, race, nondeterministic result) 
+  and set up a fast edit/measure loop before you package a reproducer.
+---
+
+# openroad-debug
+
+The instructions for this skill are maintained in the shared Claude slash command.
+Please read and follow the single source of truth:
+[../../../.claude/commands/openroad-debug.md](../../../.claude/commands/openroad-debug.md)

--- a/.claude/skills/openroad-issue/SKILL.md
+++ b/.claude/skills/openroad-issue/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: openroad-issue
+description: >-
+  Create a copy-paste-ready GitHub issue for an OpenROAD bug. File it upstream as a git am patch + failing bazel test.
+---
+
+# openroad-issue
+
+The instructions for this skill are maintained in the shared Claude slash command.
+Please read and follow the single source of truth:
+[../../../.claude/commands/openroad-issue.md](../../../.claude/commands/openroad-issue.md)

--- a/.claude/skills/untar-and-run-report/SKILL.md
+++ b/.claude/skills/untar-and-run-report/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: untar-and-run-report
+description: >-
+  Produce an untar and run reproducer archive for an OpenROAD bug, plus paste-ready text for a GitHub issue comment.
+---
+
+# untar-and-run-report
+
+The instructions for this skill are maintained in the shared Claude slash command.
+Please read and follow the single source of truth:
+[../../../.claude/commands/untar-and-run-report.md](../../../.claude/commands/untar-and-run-report.md)


### PR DESCRIPTION
Exposes the existing Claude debugging commands to Antigravity as skills by wrapping them in SKILL.md files that point to the single-source-of-truth markdown files. This ensures both agents have access to the same tools without duplicating logic.