### PR TITLE
feat(flow)!: drop the --define/settings variable-override channel

### DIFF
--- a/EXTERNAL_API.md
+++ b/EXTERNAL_API.md
@@ -12,7 +12,7 @@ consumers.
 
 | File | Exports | External deps |
 |---|---|---|
-| `openroad.bzl` | `orfs_flow`, `orfs_synth`, `orfs_update`, `orfs_run`, `orfs_run_executable`, `orfs_test`, `orfs_macro`, `orfs_pdk`, `orfs_deps`, `orfs_floorplan`, `orfs_place`, `orfs_cts`, `orfs_grt`, `orfs_route`, `orfs_final`, `orfs_gds`, `orfs_abstract`, `orfs_generate_metadata`, `orfs_update_rules`, providers (`OrfsInfo`, `PdkInfo`, `TopInfo`, `OrfsDepInfo`, `LoggingInfo`) | `bazel_skylib` |
+| `openroad.bzl` | `orfs_flow`, `orfs_synth`, `orfs_update`, `orfs_run`, `orfs_run_executable`, `orfs_test`, `orfs_macro`, `orfs_pdk`, `orfs_deps`, `orfs_floorplan`, `orfs_place`, `orfs_cts`, `orfs_grt`, `orfs_route`, `orfs_final`, `orfs_gds`, `orfs_abstract`, `orfs_generate_metadata`, `orfs_update_rules`, providers (`OrfsInfo`, `PdkInfo`, `TopInfo`, `OrfsDepInfo`, `LoggingInfo`) | none |
 | `extension.bzl` | `orfs_repositories` module extension | built-in only |
 | `ppa.bzl` | `orfs_ppa` | `rules_shell` |
 | `verilog.bzl` | `verilog_directory`, `verilog_file`, `verilog_single_file_library` | `rules_verilog` |
@@ -27,7 +27,6 @@ consumers.
 These are loaded by the public `.bzl` files above or by BUILD files that
 downstream consumers may transitively evaluate:
 
-- `bazel_skylib` — `BuildSettingInfo` in private/attrs.bzl, private/environment.bzl
 - `rules_shell` — `sh_binary` in ppa.bzl, root BUILD
 - `rules_verilog` — verilog providers in verilog.bzl
 - `rules_verilator` — verilator toolchain, verilator_cc_library
@@ -43,6 +42,7 @@ downstream consumers may transitively evaluate:
 
 These are only used by dev-only extensions, toolchains, or BUILD files:
 
+- `bazel_skylib` — `unittest`/`build_test`/`write_file` in test BUILD files
 - `rules_jvm_external` — maven extension
 - `rules_java` — transitive dep of rules_scala
 - `rules_scala` — scala_config/scala_deps extensions

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,8 +5,7 @@ module(
     version = "0.0.1",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.9.0")
-
+bazel_dep(name = "bazel_skylib", version = "1.9.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 
 bazel_dep(name = "rules_pkg", version = "1.2.0")

--- a/README.md
+++ b/README.md
@@ -989,22 +989,12 @@ Potential improvements to the bazel-orfs CI pipeline:
 
 ## Design space exploration
 
-bazel-orfs supports design space exploration (DSE) by parameterizing
-`orfs_flow()` targets with Bazel build settings. This lets you sweep or
-optimize parameters like core utilization and placement density across
-multiple flow instances, with Bazel handling parallelism and caching.
+bazel-orfs supports design space exploration (DSE) by fanning out
+`orfs_flow()` variants in the BUILD file — see the `orfs_sweep` macro in
+`sweep.bzl` — with Bazel handling parallelism and caching.
 
 **Use-case:** Find parameter combinations (utilization, density, clock period,
 macro placement, etc.) that optimize area, timing, or power for a given design.
-
-**How it works:**
-
-1. Declare parameters as `string_flag` build settings
-2. Map them to ORFS variables via `orfs_flow(settings = {...})`
-3. Create N parallel flow instances using list comprehensions
-4. Invoke with overrides: `bazel build --//pkg:density0=0.7 --//pkg:util0=40 //pkg:design_0_place`
-
-The `orfs_sweep` macro in `sweep.bzl` wraps this pattern for common cases.
 
 Parameters only propagate to relevant stages — changing `PLACE_DENSITY` does not
 invalidate the synthesis cache.
@@ -1305,8 +1295,12 @@ Features removed from bazel-orfs. Check git history for the original implementat
   DSE with multi-fidelity (synth→place→grt) progressive refinement. Included a
   parameterized `mock-cpu.sv` test design. See `optuna/` in git history.
 - **dse/** — Bazel-native DSE example using `string_flag` build settings with
-  `orfs_flow(settings = {...})` to sweep utilization and density. The pattern
-  is now documented in the DSE section above. See `dse/` in git history.
+  `orfs_flow(settings = {...})` to sweep utilization and density. The
+  `settings` attribute and the `--define` variable-override channel were
+  later removed as well: overriding ORFS variables from the Bazel command
+  line invalidates every stage the variable touches, and the
+  `orfs_arguments`/`extra_arguments` JSON overlay plus `orfs_run_executable`
+  replaced it. See `dse/` in git history.
 
 ### Deprecated
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -99,7 +99,6 @@ comm -23 \
 |---------|-------|
 | `stage_data` | Parameter exists in `orfs_flow`, never exercised |
 | `renamed_inputs` | Exists in flow.bzl/sweep.bzl, never tested |
-| `settings` (BuildSettingInfo) | Parameter exists, not tested |
 | `dissolve` in sweep | Feature exists (sweep.bzl), never used |
 | `orfs_update` | Rule exported, no test |
 | `save_odb=False` | Synthesis attribute, never tested |

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -1,6 +1,5 @@
 """Attribute builders for OpenROAD-flow-scripts Bazel rules."""
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "@config//:global_config.bzl",
     "CONFIG_KLAYOUT",
@@ -46,10 +45,6 @@ def orfs_attrs():
             doc = "List of additional flow data.",
             allow_files = True,
             default = [],
-        ),
-        "settings": attr.string_keyed_label_dict(
-            doc = "Arguments with build settings.",
-            providers = [BuildSettingInfo],
         ),
         "extra_arguments": attr.label_list(
             doc = "List of .json argument files to merge into stage config.",

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -1,6 +1,5 @@
 """Environment, input, and configuration helper functions for OpenROAD-flow-scripts rules."""
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "//private:providers.bzl",
     "LoggingInfo",
@@ -9,7 +8,7 @@ load(
     "PdkInfo",
     "TopInfo",
 )
-load("//private:stages.bzl", "ALL_STAGE_TO_VARIABLES", "dropped_variables")
+load("//private:stages.bzl", "dropped_variables")
 load("//private:utils.bzl", "file_path", "flatten")
 
 def odb_arguments(ctx, short = False):
@@ -420,26 +419,6 @@ done
 export VERILOG_FILES="$_expanded"
 """
 
-def config_overrides(ctx, arguments):
-    has_stage = hasattr(ctx.attr, "_stage")
-    defines_for_stage = {
-        var: value
-        for var, value in ctx.var.items()
-        if has_stage and
-           var in
-           (
-               ALL_STAGE_TO_VARIABLES[ctx.attr._stage] +
-               # FIXME delete this hotfix on next ORFS update
-               # https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3746
-               {"synth": ["VERILOG_TOP_PARAMS"]}.get(ctx.attr._stage, [])
-           )
-    }
-    settings = {
-        var: value[BuildSettingInfo].value
-        for var, value in ctx.attr.settings.items()
-    }
-    return arguments | defines_for_stage | settings
-
 def _workspace_prefix(ctx):
     """Return the execroot-relative prefix for the workspace containing ctx.
 
@@ -462,14 +441,14 @@ def _prefix_include_dirs(dirs_value, prefix):
     ])
 
 def config_arguments(ctx, arguments):
-    """Adds overrides and workarounds to the provided arguments dictionary.
+    """Adds workarounds to the provided arguments dictionary.
 
     Args:
       ctx: The rule context.
       arguments: The dictionary of arguments to augment.
 
     Returns:
-      A dictionary of the arguments including overrides.
+      A dictionary of the arguments including workarounds.
     """
     workaround = {
         # https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3907
@@ -485,7 +464,7 @@ def config_arguments(ctx, arguments):
             prefix,
         )
 
-    return config_overrides(ctx, workaround)
+    return workaround
 
 def config_content(ctx, arguments, paths, pre_paths = []):
     """Generate Makefile-style config content for an ORFS stage.

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -61,7 +61,6 @@ def _filter_stage_args(stage, **kwargs):
 
     arguments = kwargs.pop("arguments", {})
     data = kwargs.pop("data", [])
-    settings = kwargs.pop("settings", {})
     extra_arguments = kwargs.pop("extra_arguments", {})
     extra_configs = kwargs.pop("extra_configs", {})
     sources = kwargs.pop("sources", {})
@@ -100,10 +99,6 @@ def _filter_stage_args(stage, **kwargs):
                data,
         extra_arguments = extra_arguments.get(stage, []),
         extra_configs = extra_configs.get(stage, []),
-        settings = get_stage_args(
-            [stage],
-            arguments = settings,
-        ),
         **kwargs
     )
 
@@ -177,7 +172,7 @@ def _orfs_stage(stage, impl, **kwargs):
 
     The whole point of the public stage macros: a standalone
     orfs_floorplan() gets exactly what a floorplan target inside an
-    orfs_flow() gets — arguments/sources/settings filtered to this stage,
+    orfs_flow() gets — arguments/sources filtered to this stage,
     extra_arguments/extra_configs narrowed by stage key, the ORFS variable
     spell-check, the escape-hatch guard, and the companion _deps targets.
 
@@ -269,7 +264,6 @@ def orfs_flow(
         mock_area = None,
         previous_stage = {},
         pdk = None,
-        settings = {},
         stage_data = {},
         test_kwargs = {},
         squash = False,
@@ -321,7 +315,6 @@ def orfs_flow(
       variant: name of the target variant, added right after the module name
       mock_area: floating point number, scale the die width/height by this amount, default no scaling
       previous_stage: a dictionary with the input for a stage, default is previous stage. Useful when running experiments that share preceeding stages, like share synthesis for floorplan variants.
-      settings: dictionary with variable to BuildSettingInfo mappings
       pdk: name of the PDK to use, default is asap7
       stage_data: dictionary keyed by ORFS stages with lists of stage-specific data files
       test_kwargs: dictionary of arguments to pass to orfs_test
@@ -386,7 +379,6 @@ def orfs_flow(
         previous_stage = previous_stage,
         pdk = pdk,
         stage_data = stage_data,
-        settings = settings,
         test_kwargs = test_kwargs,
         squash = squash,
         substeps = substeps,
@@ -436,7 +428,6 @@ def orfs_flow(
         pdk = pdk,
         stage_data = stage_data,
         mock_area = True,
-        settings = settings,
         html = html,
         **kwargs
     )
@@ -533,7 +524,6 @@ def _orfs_pass(
         abstract_variant,
         previous_stage,
         pdk,
-        settings,
         stage_data,
         kept_macros = None,
         canon_blackbox_macros = [],
@@ -606,7 +596,6 @@ def _orfs_pass(
                 variant = variant,
                 verilog_files = verilog_files,
                 pdk = pdk,
-                settings = settings,
                 extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
                 stage_data = stage_data,
@@ -649,7 +638,6 @@ def _orfs_pass(
             all_data = []
             all_extra_arguments = []
             all_extra_configs = []
-            all_settings = {}
             for s in squash_steps:
                 meta = STAGE_METADATA[s.stage]
                 all_make_targets.extend(meta.make_targets)
@@ -667,7 +655,6 @@ def _orfs_pass(
                     user_arguments = dict(user_arguments),
                     sources = dict(sources),
                     user_sources = dict(user_sources),
-                    settings = dict(settings),
                     extra_arguments = dict(extra_arguments),
                     extra_configs = dict(extra_configs),
                     stage_data = dict(stage_data),
@@ -682,7 +669,6 @@ def _orfs_pass(
                 for c in stage_filtered.get("extra_configs", []):
                     if c not in all_extra_configs:
                         all_extra_configs.append(c)
-                all_settings.update(stage_filtered.get("settings", {}))
 
             orfs_squashed(
                 name = squash_name,
@@ -700,7 +686,6 @@ def _orfs_pass(
                 data = all_data,
                 extra_arguments = all_extra_arguments,
                 extra_configs = all_extra_configs,
-                settings = all_settings,
                 **kwargs
             )
             step_names.append(squash_name)
@@ -730,7 +715,6 @@ def _orfs_pass(
                         user_arguments = user_arguments,
                         sources = sources,
                         user_sources = user_sources,
-                        settings = settings,
                         extra_arguments = extra_arguments,
                         extra_configs = extra_configs,
                         src = squash_name,
@@ -757,7 +741,6 @@ def _orfs_pass(
                 user_arguments = user_arguments,
                 sources = sources,
                 user_sources = user_sources,
-                settings = settings,
                 extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
                 src = src,
@@ -815,7 +798,6 @@ def _orfs_pass(
                 user_arguments = user_arguments,
                 sources = sources,
                 user_sources = user_sources,
-                settings = settings,
                 extra_arguments = extra_arguments,
                 extra_configs = extra_configs,
                 src = place_src,

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -17,7 +17,6 @@ load(
     "EXPAND_VERILOG_DIRS",
     "config_arguments",
     "config_environment",
-    "config_overrides",
     "data_arguments",
     "data_inputs",
     "declare_artifact",
@@ -408,16 +407,13 @@ def _run_impl(ctx):
                 "$@",
             ],
         ),
-        env = config_overrides(
-            ctx,
-            flow_environment(ctx) |
-            yosys_environment(ctx) |
-            config_environment(config) |
-            odb_arguments(ctx) |
-            sdc_arguments(ctx) |
-            data_arguments(ctx) |
-            run_arguments(ctx),
-        ),
+        env = flow_environment(ctx) |
+              yosys_environment(ctx) |
+              config_environment(config) |
+              odb_arguments(ctx) |
+              sdc_arguments(ctx) |
+              data_arguments(ctx) |
+              run_arguments(ctx),
         inputs = depset(
             [config, ctx.file.script] + extra_files,
             transitive = [
@@ -603,17 +599,14 @@ def _arguments_impl(ctx):
                 "$@",
             ],
         ),
-        env = config_overrides(
-            ctx,
-            flow_environment(ctx) |
-            yosys_environment(ctx) |
-            config_environment(src_info.config) |
-            odb_arguments(ctx) |
-            sdc_arguments(ctx) |
-            data_arguments(ctx) |
-            run_arguments(ctx) |
-            {"OUTPUT": computed_json.path},
-        ),
+        env = flow_environment(ctx) |
+              yosys_environment(ctx) |
+              config_environment(src_info.config) |
+              odb_arguments(ctx) |
+              sdc_arguments(ctx) |
+              data_arguments(ctx) |
+              run_arguments(ctx) |
+              {"OUTPUT": computed_json.path},
         inputs = depset(
             [src_info.config, ctx.file.script],
             transitive = [
@@ -1057,7 +1050,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 "SYNTH_KEEP_SCRIPT=" + ctx.file._synth_keep_script.path,
             ],
             command = " && ".join(keep_commands),
-            env = config_overrides(ctx, base_env),
+            env = base_env,
             inputs = depset(
                 [canon_output, config, parallel_makefile, ctx.file._synth_keep_script] +
                 ctx.files.extra_configs,
@@ -1191,7 +1184,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 "SYNTH_CANONICALIZE_MODULE_SCRIPT=" + ctx.file._synth_canonicalize_module_script.path,
             ],
             command = " && ".join(per_module_commands),
-            env = config_overrides(ctx, base_env | partition_env_extra | {
+            env = base_env | partition_env_extra | {
                 "SYNTH_CHECKPOINT": checkpoint_output.path,
                 "MODULE_BLACKBOXES": " ".join(blackboxes),
                 "MODULE_TARGET_NAME": module,
@@ -1205,7 +1198,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 # upstream PnR runs that re-characterise SHARED_LOGIC
                 # macro .libs.
                 "SYNTH_REPEATABLE_BUILD": "1",
-            }),
+            },
             inputs = depset(
                 [
                     checkpoint_output,
@@ -1465,11 +1458,11 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 "SYNTH_PARTITION_SCRIPT=" + ctx.file._synth_partition_script.path,
             ],
             command = " && ".join(part_commands),
-            env = config_overrides(ctx, base_env | partition_env_extra | partition_env_override | {
+            env = base_env | partition_env_extra | partition_env_override | {
                 "SYNTH_PARTITION_ID": str(i),
                 "SYNTH_NUM_PARTITIONS": str(num_partitions),
                 "SYNTH_TCL": ctx.file._synth_tcl.path,
-            }),
+            },
             inputs = partition_inputs,
             outputs = [part_output],
             tools = yosys_and_flow_tools,
@@ -1497,11 +1490,11 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
             "SYNTH_PARTITION_SCRIPT=" + ctx.file._synth_partition_script.path,
         ],
         command = " && ".join(top_commands),
-        env = config_overrides(ctx, base_env | partition_env_extra | {
+        env = base_env | partition_env_extra | {
             "SYNTH_PARTITION_ID": "top",
             "SYNTH_NUM_PARTITIONS": str(num_partitions),
             "SYNTH_TCL": ctx.file._synth_tcl.path,
-        }),
+        },
         inputs = top_partition_inputs,
         outputs = [top_output],
         tools = yosys_and_flow_tools,
@@ -1529,7 +1522,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
             "do-yosys-sdc-copy",
         ],
         command = "{make} $@".format(make = ctx.executable._make.path),
-        env = config_overrides(ctx, base_env),
+        env = base_env,
         inputs = depset(
             [config, parallel_makefile] + ctx.files.extra_configs,
             transitive = [
@@ -1563,7 +1556,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 "do-1_synth",
             ],
             command = " && ".join(odb_commands),
-            env = config_overrides(ctx, base_env),
+            env = base_env,
             inputs = depset(
                 [
                     synth_outputs["1_2_yosys.v"],
@@ -1754,12 +1747,9 @@ def _yosys_impl(ctx):
                 "do-yosys-canonicalize",
             ],
             command = EXPAND_VERILOG_DIRS + " && ".join(commands),
-            env = config_overrides(
-                ctx,
-                verilog_arguments(ctx.files.verilog_files) |
-                yosys_environment(ctx) |
-                config_environment(canon_config),
-            ),
+            env = verilog_arguments(ctx.files.verilog_files) |
+                  yosys_environment(ctx) |
+                  config_environment(canon_config),
             inputs = depset(
                 [canon_config] + ctx.files.verilog_files + ctx.files.extra_configs,
                 transitive = [
@@ -1843,12 +1833,9 @@ def _yosys_impl(ctx):
                 "do-1_synth",
             ],
             command = EXPAND_VERILOG_DIRS + " && ".join(commands),
-            env = config_overrides(
-                ctx,
-                verilog_arguments(ctx.files.verilog_files) |
-                flow_environment(ctx) |
-                config_environment(config),
-            ),
+            env = verilog_arguments(ctx.files.verilog_files) |
+                  flow_environment(ctx) |
+                  config_environment(config),
             inputs = depset(
                 [config] + ctx.files.verilog_files + ctx.files.extra_configs,
                 transitive = [
@@ -1886,13 +1873,10 @@ def _yosys_impl(ctx):
                 "do-yosys",
             ] + (["do-1_synth"] if save_odb else []),
             command = " && ".join(commands),
-            env = config_overrides(
-                ctx,
-                verilog_arguments([]) |
-                flow_environment(ctx) |
-                yosys_environment(ctx) |
-                config_environment(config),
-            ),
+            env = verilog_arguments([]) |
+                  flow_environment(ctx) |
+                  yosys_environment(ctx) |
+                  config_environment(config),
             inputs = depset(
                 [canon_output, config] + ctx.files.extra_configs,
                 transitive = [
@@ -1915,13 +1899,10 @@ def _yosys_impl(ctx):
             command = """
             {make} $@ > {out}
             """.format(make = ctx.executable._make.path, out = variables.path),
-            env = config_overrides(
-                ctx,
-                verilog_arguments([]) |
-                flow_environment(ctx) |
-                yosys_environment(ctx) |
-                config_environment(config),
-            ),
+            env = verilog_arguments([]) |
+                  flow_environment(ctx) |
+                  yosys_environment(ctx) |
+                  config_environment(config),
             inputs = depset(
                 [canon_output, config] + ctx.files.extra_configs,
                 transitive = [
@@ -2348,7 +2329,7 @@ def _make_impl(
         ctx.actions.run_shell(
             arguments = ["--file", ctx.file._makefile.path] + steps,
             command = " && ".join(commands),
-            env = config_overrides(ctx, flow_environment(ctx) | config_environment(config)),
+            env = flow_environment(ctx) | config_environment(config),
             inputs = depset(
                 [config] + ctx.files.extra_configs + all_jsons,
                 transitive = [


### PR DESCRIPTION
Removes the two Bazel-command-line channels for overriding ORFS variables:

- the `settings=` attribute (`BuildSettingInfo` build settings) threaded through `orfs_flow` and every stage rule, and
- the `ctx.var` (`--define`) per-stage override in `config_overrides()`, including the `VERILOG_TOP_PARAMS` hotfix that was FIXME'd for removal since ORFS PR 3746 landed.

Both are unused and were never tested or (in the `--define` case) documented. Overriding a variable from the Bazel command line invalidates every stage that reads it, which makes these channels a poor fit for design space exploration; the `orfs_arguments`/`extra_arguments` JSON overlay and `orfs_run_executable` have replaced them.

With `BuildSettingInfo` gone, `bazel_skylib` is only used by test BUILD files, so it is demoted to a `dev_dependency` per the EXTERNAL_API.md policy — one less MVS constraint imposed on downstream consumers.

Verified with `bazel query //...`, the mock sweep/stage-filter/parser/guard test targets, and `//:fix_lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
