### PR TITLE
estimation_ladder: walk trial batches as one fork/join tree

### DIFF
--- a/EXTERNAL_API.md
+++ b/EXTERNAL_API.md
@@ -28,6 +28,12 @@ These are loaded by the public `.bzl` files above or by BUILD files that
 downstream consumers may transitively evaluate:
 
 - `rules_shell` — `sh_binary` in ppa.bzl, root BUILD
+- `rules_cc` — `cc_binary` in fork/BUILD.bazel (the fork/join Tcl extension,
+  a default attr of `orfs_run`/`orfs_run_executable`)
+- `tcl_lang` — `tclstub` dependency of fork/BUILD.bazel; pinned to the same
+  version the openroad module embeds so the loadable extension always
+  matches the interpreter
+- `platforms` — `target_compatible_with` in fork/BUILD.bazel
 - `rules_verilog` — verilog providers in verilog.bzl
 - `rules_verilator` — verilator toolchain, verilator_cc_library
 - `verilator` — required by rules_verilator
@@ -47,7 +53,6 @@ These are only used by dev-only extensions, toolchains, or BUILD files:
 - `rules_java` — transitive dep of rules_scala
 - `rules_scala` — scala_config/scala_deps extensions
 - `rules_chisel` — chisel/test.bzl, dev BUILD files
-- `rules_cc` — chisel/test.bzl, dev BUILD files
 
 ## PDK extensibility
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,9 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0", dev_dependency = True)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 
 bazel_dep(name = "rules_pkg", version = "1.2.0")
@@ -20,6 +23,12 @@ local_path_override(
 
 bazel_dep(name = "abc", version = "0.64-yosyshq.bcr.2")
 bazel_dep(name = "yosys", version = "0.64")
+
+# Tcl, for //fork: the fork/join extension is compiled against the same
+# @tcl_lang the openroad module embeds (MVS keeps the two in lockstep), so
+# the loadable .so always matches the interpreter that `load`s it. Non-dev:
+# downstream roots build //fork:liborfsfork.so through orfs_run targets.
+bazel_dep(name = "tcl_lang", version = "9.0.2.bcr.2")
 
 # The slang yosys frontend plugin (slang.so). yosys-slang was renamed to
 # sv-elab and published on BCR; it's not bundled in BCR yosys, so we load

--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,12 @@ produces a binary that invokes the underlying tool (e.g. OpenROAD) directly.
 
 See the `orfs_run_executable` rule docstring in `private/rules.bzl` for important execution constraints regarding logging, output directories, and parallel invocations.
 
+When trials share a common flow prefix (a decision *tree* rather than a flat
+list), a run script can walk the whole tree in one OpenROAD process with the
+`fork` snapshot idiom, paying each shared stage once and writing one result
+file per leaf into an output folder (`orfs_run(out_dir = ...)` /
+`$RUN_OUTPUT_DIR`). See `docs/fork.md`.
+
 ```python
 # In your bazel-run Python script or objective function:
 import os

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -1,0 +1,96 @@
+# `fork` — a fork/join snapshot idiom for run scripts
+
+## Why
+
+Configuration studies walk a *tree* of flow decisions (placement flavor ×
+routing iterations × repair effort × ...). Run as independent processes,
+every configuration re-pays the shared prefix — load, floorplan, placement —
+even when it differs from its sibling only in the last stage. POSIX `fork()`
+turns the running process into a copy-on-write snapshot: a child continues
+down one branch while the suspended parent holds the pre-branch state for
+free, so every tree *edge* is computed exactly once instead of once per leaf.
+
+Fork here is a **snapshot mechanism, not parallelism**: the default walk is
+depth-first with exactly one active child at a time, so the machine's CPUs
+and memory always belong to a single run. Suspended ancestors are frozen in
+`waitpid` and cost only the pages the active child has diverged. It is an
+in-memory `write_db`/`read_db` checkpoint that costs nothing to take and
+nothing to resume.
+
+## The idiom
+
+Any `orfs_run` / `orfs_run_executable` script may:
+
+```tcl
+source $::env(ORFS_FORK_TCL)
+
+fork gp_mode {plain timing_driven} {
+    run_global_placement $gp_mode
+    fork grt_iters {0 2 5} {
+        run_global_route $grt_iters
+        write_leaf_json $::env(RUN_OUTPUT_DIR)/${gp_mode}_${grt_iters}.json
+    }
+}
+```
+
+`fork ?-parallel? ?-timeout seconds? varName valueList body` forks one
+copy-on-write child per value; the child sets `varName` in the caller's
+scope, evals `body` there, and `_exit`s. The join is implicit: `fork`
+returns once every child is reaped, with a dict mapping each value to its
+exit status — `0` ok, `1` a Tcl error in the body, `N` an explicit
+`::orfs::posix_exit N`, `128+SIG` a crash (`142` = SIGALRM: the child ran
+past `-timeout` and self-destructed). A failed child never stops the
+walk: its status is recorded and the remaining siblings still run, so a
+crashed or runaway branch loses only its subtree. `-timeout` is enforced
+*inside* each child via `alarm(2)` — a parent-side kill would orphan the
+child's own running descendants, which then hold the machine and the
+stdout pipe open; deadlines do not survive fork, so nested forks pass
+their own `-timeout`. `-parallel` forks all children before joining —
+shared edges are still paid once, but siblings contend for the machine,
+so use it only when nothing downstream reads runtimes.
+
+Raw primitives (`::orfs::posix_fork`, `::orfs::posix_waitpid`,
+`::orfs::posix_exit`) live in `//fork:liborfsfork.so`, a Tcl-stubs
+extension `load`ed by `fork.tcl` from `$ORFS_FORK_LIB`. Both env vars are
+provided automatically by `orfs_run` and `orfs_run_executable`. The
+extension is compiled against the same `@tcl_lang` the openroad module
+embeds, so it can never drift from the interpreter that loads it.
+
+## Where results go
+
+Pair the walk with an output folder — each leaf writes one independent
+file, results are incremental, and a crashed subtree leaves the other
+leaves' files intact:
+
+- `orfs_run(out_dir = "...")` declares a directory output and exports its
+  path as `$RUN_OUTPUT_DIR`.
+- `orfs_run_executable` callers pass an absolute scratch path per
+  invocation (e.g. `RESULTS_OUT=/abs/scratch/...`), like `LOG_DIR`.
+
+## Fork hazards (read before writing a walk)
+
+- **Threads do not survive fork**: only the forking thread exists in the
+  child. OpenSTA/OpenROAD respawn their worker pools on demand (validated
+  by `//test:fork_smoke`, which runs timing queries in forked
+  grandchildren), but if a tool hangs in a child right after a fork,
+  re-issue its thread-count command (e.g. `set_thread_count`) at the top of
+  the body.
+- **No event-loop code in bodies**: `vwait` / `after`-driven callbacks
+  inherited from the parent will not fire correctly in a child.
+- **stdio**: the extension `fflush(NULL)`s before forking and children
+  leave via `_exit`, so output is not duplicated and the host's exit hooks
+  run only in the root process. With the sequential default, children's
+  log output interleaves in order; under `-parallel` it interleaves
+  arbitrarily.
+- **Linux only**: fork-without-exec is unsafe on macOS hosts;
+  `//fork:liborfsfork.so` is restricted to Linux.
+
+## Tests
+
+- `//fork:fork_test` — the idiom's semantics in hermetic tclsh
+  (sequencing, statuses, crash tolerance, nesting, `-parallel` barrier).
+- `//test:run_out_dir_test` — `out_dir` / `$RUN_OUTPUT_DIR` end to end
+  (fast, mock-openroad).
+- `//test:fork_smoke_test` (manual) — the walk inside real OpenROAD after
+  `load_design`, timing queries in forked children, one JSON per leaf in
+  `$RUN_OUTPUT_DIR`, a deliberate failing leaf.

--- a/docs/orfs_run.md
+++ b/docs/orfs_run.md
@@ -24,5 +24,40 @@ Because realistic physical design flows often involve feedback loops—such as a
    - Users define shared configuration dictionaries and sources in their `BUILD.bazel` or `.bzl` files, rather than relying on rule internals to guess dependencies.
    - This approach allows multi-stage ladders (such as generic estimators) to be cleanly expressed via list comprehensions over `orfs_run()` targets without risking cyclic dependencies.
 
+## Output directories
+
+`outs` names individual output files known in advance. When the *set* of
+output files is only known at runtime — a tree-walking study writing one
+JSON per leaf, a report generator emitting one file per violation class —
+declare a directory instead:
+
+```python
+orfs_run(
+    name = "study",
+    src = ":design_synth",
+    out_dir = "study_results",
+    script = ":study.tcl",
+)
+```
+
+The rule declares `study_results` as a tree artifact and exports its path
+to the script as `$RUN_OUTPUT_DIR`; the script decides what files land
+there. `outs` and `out_dir` compose (at least one is required). The name is
+deliberately not `RESULTS_DIR` — the ORFS Makefile owns that variable for
+staged flow outputs.
+
+For `orfs_run_executable` the same contract is by convention: the caller
+passes an absolute scratch path per invocation (like `LOG_DIR`), e.g.
+`RESULTS_OUT=/abs/scratch/trial42`, and concurrent invocations must not
+share it.
+
+## fork/join tree walks
+
+Run scripts can walk a decision tree in one OpenROAD process, paying every
+shared stage exactly once, with the `fork` idiom — see `docs/fork.md`.
+Every `orfs_run`/`orfs_run_executable` script gets `$ORFS_FORK_TCL` and
+`$ORFS_FORK_LIB` automatically; pair `fork` with `out_dir` so each leaf
+writes an independent result file.
+
 ## Example Usage
 See `test/estimation_ladder/BUILD.bazel` for a demonstration of composing multi-stage targets using explicit `sources`.

--- a/fork/BUILD.bazel
+++ b/fork/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# Loadable Tcl extension with the raw POSIX primitives behind fork.tcl.
+# Linked against @tcl_lang//:tclstub (USE_TCL_STUBS), so the .so resolves
+# the interpreter through the stub table of whatever host `load`s it —
+# tclsh and the statically linked openroad alike. @tcl_lang resolves to the
+# same version the openroad module embeds (MVS), so host and extension can
+# never drift apart.
+cc_binary(
+    name = "liborfsfork.so",
+    srcs = ["orfsfork.c"],
+    linkshared = True,
+    linkstatic = True,
+    local_defines = ["USE_TCL_STUBS"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = ["@tcl_lang//:tclstub"],
+)
+
+exports_files(["fork.tcl"])
+
+sh_test(
+    name = "fork_test",
+    srcs = ["fork_test.sh"],
+    data = [
+        "fork.tcl",
+        "fork_test.tcl",
+        ":liborfsfork.so",
+        "@tcl_lang//:tclsh",
+    ],
+    env = {
+        "FORK_TEST_TCL": "$(rootpath fork_test.tcl)",
+        "ORFS_FORK_LIB": "$(rootpath :liborfsfork.so)",
+        "ORFS_FORK_TCL": "$(rootpath fork.tcl)",
+        "TCLSH": "$(rootpath @tcl_lang//:tclsh)",
+    },
+)

--- a/fork/fork.tcl
+++ b/fork/fork.tcl
@@ -1,0 +1,128 @@
+# fork.tcl -- fork/join snapshot idiom.
+#
+#   fork ?-parallel? ?-timeout seconds? varName valueList body
+#
+# For each value in valueList: fork a copy-on-write child of the whole
+# process; the child sets varName in the caller's scope, evals body there,
+# and _exits. Sequential by default — exactly one child alive at a time, in
+# list order — because fork here is a snapshot mechanism, not parallelism:
+# an in-memory checkpoint that costs nothing to take and nothing to resume.
+# -parallel forks all children first, then joins.
+#
+# The join is implicit: fork returns only when every child has been reaped.
+# Returns a dict mapping each value to its child's exit status: 0 ok, 1 a
+# Tcl error in body, N an explicit `::orfs::posix_exit N`, 128+SIG a crash
+# (142 = SIGALRM: the child ran past -timeout seconds and self-destructed).
+# A failed child never stops the walk — its nonzero status is recorded and
+# the remaining values still run. Duplicate values are last-wins in the
+# returned dict. Bodies may call fork again (nested forks walk a tree).
+#
+# -timeout is enforced INSIDE each child (alarm(2)), never by the parent
+# killing it: an outside kill would orphan the child's own running
+# descendants, which then hold the machine and the parent's stdout pipe
+# open indefinitely. Deadlines do not survive fork, so a nested fork must
+# pass its own -timeout for its children to stay bounded.
+#
+# Threads do not survive fork, and the host's persistent worker pools
+# (OpenSTA's dispatch queue, sized by `-threads N` at startup) would
+# deadlock the first child that dispatches to them. When the host defines
+# set_thread_count/thread_count (OpenROAD does), fork quiesces the pool to
+# one thread in the parent BEFORE forking -- joining live workers, which
+# is fully defined -- so children run those code paths inline, and
+# restores the parent's count after the join. Children must never raise
+# the count themselves: that would join workers that died at fork.
+# Bodies must also not run event-loop code (`vwait`, `after`-driven
+# callbacks) inherited from the parent.
+#
+# Scripts opt in with:  source $::env(ORFS_FORK_TCL)
+
+namespace eval ::orfs {}
+
+if {[info commands ::orfs::posix_fork] eq ""} {
+    load $::env(ORFS_FORK_LIB) Orfsfork
+}
+
+# The quiesce/restore in fork would otherwise log ORD-0030 ("Using N
+# thread(s)") at every branch point.
+catch {suppress_message ORD 30}
+
+proc fork {args} {
+    set parallel 0
+    set timeout -1
+    while {[llength $args] > 3} {
+        switch -- [lindex $args 0] {
+            -parallel {
+                set parallel 1
+                set args [lrange $args 1 end]
+            }
+            -timeout {
+                set timeout [lindex $args 1]
+                set args [lrange $args 2 end]
+            }
+            default {
+                error "fork: unknown option \"[lindex $args 0]\""
+            }
+        }
+    }
+    if {[llength $args] != 3} {
+        error {usage: fork ?-parallel? ?-timeout seconds? varName valueList body}
+    }
+    lassign $args varName valueList body
+
+    # Quiesce the host's worker pools before forking (see header). At one
+    # thread, OpenSTA bypasses its dispatch queue entirely, so the dead
+    # queue workers a child inherits are never touched.
+    set restore_threads -1
+    if {[info commands ::thread_count] ne "" &&
+        [info commands ::set_thread_count] ne ""} {
+        catch {
+            set n [thread_count]
+            if {$n > 1} {
+                set_thread_count 1
+                set restore_threads $n
+            }
+        }
+    }
+
+    set statuses [dict create]
+    set pending {}
+    foreach value $valueList {
+        set pid [::orfs::posix_fork]
+        if {$pid == 0} {
+            # Child: run body in the caller's scope, then leave via _exit —
+            # returning would run the rest of the parent's script again.
+            if {$timeout > 0} {
+                ::orfs::posix_alarm $timeout
+            }
+            set rc [catch {
+                uplevel 1 [list set $varName $value]
+                uplevel 1 $body
+            } msg opts]
+            catch {
+                flush stdout
+                flush stderr
+            }
+            if {$rc == 0 || $rc == 2} {
+                ::orfs::posix_exit 0
+            }
+            catch {
+                puts stderr "fork child ($varName = $value) failed: $msg"
+                puts stderr [dict get $opts -errorinfo]
+                flush stderr
+            }
+            ::orfs::posix_exit 1
+        }
+        if {$parallel} {
+            lappend pending $pid $value
+        } else {
+            dict set statuses $value [::orfs::posix_waitpid $pid]
+        }
+    }
+    foreach {pid value} $pending {
+        dict set statuses $value [::orfs::posix_waitpid $pid]
+    }
+    if {$restore_threads > 0} {
+        catch {set_thread_count $restore_threads}
+    }
+    return $statuses
+}

--- a/fork/fork_test.sh
+++ b/fork/fork_test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exec "$TCLSH" "$FORK_TEST_TCL"

--- a/fork/fork_test.tcl
+++ b/fork/fork_test.tcl
@@ -1,0 +1,137 @@
+# Unit tests for the fork/join idiom in fork.tcl, run in plain tclsh —
+# the idiom is host-agnostic, so everything except OpenROAD-specific
+# hazards (thread pools) is testable here in milliseconds.
+
+source $::env(ORFS_FORK_TCL)
+
+set dir $::env(TEST_TMPDIR)
+set failures 0
+
+proc check {label expected actual} {
+    if {$expected eq $actual} {
+        puts "ok: $label"
+        return
+    }
+    puts stderr "FAIL: $label\n  expected: $expected\n  actual:   $actual"
+    incr ::failures
+}
+
+# 1. All children succeed: dict of zeros, side effects present.
+set st [fork x {a b c} {
+    set f [open $dir/ok.$x w]
+    puts $f $x
+    close $f
+}]
+check "all-ok statuses" {a 0 b 0 c 0} $st
+check "all-ok side effects" {ok.a ok.b ok.c} \
+    [lsort [glob -directory $dir -tails ok.*]]
+
+# 2. Sequential by default: each child sees exactly the files its
+# predecessors wrote, so the recorded counts must be 0, 1, 2.
+set st [fork x {p q r} {
+    set n [llength [glob -nocomplain -directory $dir seq.*]]
+    set f [open $dir/seq.$x w]
+    puts $f $n
+    close $f
+}]
+check "sequential statuses" {p 0 q 0 r 0} $st
+set counts {}
+foreach x {p q r} {
+    set f [open $dir/seq.$x r]
+    lappend counts [string trim [read $f]]
+    close $f
+}
+check "sequential ordering" {0 1 2} $counts
+
+# 3. A Tcl error in one body is status 1; the walk continues.
+set st [fork x {a bad c} {
+    if {$x eq "bad"} {
+        error boom
+    }
+    close [open $dir/walk.$x w]
+}]
+check "error status recorded" {a 0 bad 1 c 0} $st
+check "walk continued past failure" {walk.a walk.c} \
+    [lsort [glob -directory $dir -tails walk.*]]
+
+# 4. Explicit exit codes propagate.
+set st [fork x {u v} {
+    if {$x eq "v"} {
+        ::orfs::posix_exit 42
+    }
+}]
+check "explicit exit code" {u 0 v 42} $st
+
+# 5. A crashed child (signal) is 128+SIG; siblings unaffected.
+set st [fork x {fine crash} {
+    if {$x eq "crash"} {
+        exec kill -KILL [pid]
+    }
+}]
+check "signal status" {fine 0 crash 137} $st
+
+# 6. Nested forks: the inner dict is visible to the forking child, which
+# forwards failure by exiting nonzero iff any inner status is nonzero.
+set st [fork outer {L R} {
+    set inner [fork n {1 2} {
+        if {$outer eq "R" && $n == 2} {
+            error boom
+        }
+        close [open $dir/leaf.$outer.$n w]
+    }]
+    set bad 0
+    dict for {_ code} $inner {
+        if {$code != 0} {
+            set bad 1
+        }
+    }
+    ::orfs::posix_exit $bad
+}]
+check "nested statuses" {L 0 R 1} $st
+check "nested leaves" {leaf.L.1 leaf.L.2 leaf.R.1} \
+    [lsort [glob -directory $dir -tails leaf.*]]
+
+# 7. Isolation: a child's writes never reach the parent.
+set shared parent
+set st [fork x {only} {
+    set ::shared child
+}]
+check "child isolated from parent" parent $shared
+check "isolation status" {only 0} $st
+
+# 8. -timeout: an overrunning child self-destructs via its own alarm
+# (128+SIGALRM = 142); siblings before and after are unaffected.
+# (clock is unavailable in the hermetic tclsh, so the wall guard uses date.)
+set t0 [exec date +%s]
+set st [fork -timeout 1 x {quick stuck also_quick} {
+    if {$x eq "stuck"} {
+        after 30000
+    }
+}]
+set elapsed [expr {[exec date +%s] - $t0}]
+check "timeout status" {quick 0 stuck 142 also_quick 0} $st
+if {$elapsed > 10} {
+    puts stderr "FAIL: timeout did not cut the stuck child short (${elapsed}s)"
+    incr ::failures
+}
+
+# 9. -parallel is a real barrier: every child blocks until all three have
+# announced themselves, which can only complete if all were forked before
+# the join. A sequential walk would time out (status 1).
+set st [fork -parallel x {1 2 3} {
+    close [open $dir/par.$x w]
+    for {set i 0} {$i < 1000} {incr i} {
+        if {[llength [glob -nocomplain -directory $dir par.*]] == 3} {
+            ::orfs::posix_exit 0
+        }
+        after 10
+    }
+    ::orfs::posix_exit 1
+}]
+check "parallel barrier" {1 0 2 0 3 0} $st
+
+if {$failures > 0} {
+    puts stderr "$failures test(s) failed"
+    exit 1
+}
+puts "all fork tests passed"

--- a/fork/orfsfork.c
+++ b/fork/orfsfork.c
@@ -1,0 +1,140 @@
+/* orfsfork: raw POSIX primitives for the fork/join snapshot idiom in
+ * fork.tcl. Compiled with USE_TCL_STUBS so the one .so loads into any host
+ * embedding the same-major Tcl — including a statically linked OpenROAD,
+ * which exports no Tcl_* symbols (Tcl_InitStubs resolves the stub table
+ * through the interp pointer, not the dynamic linker).
+ */
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <tcl.h>
+
+static int
+PosixForkCmd(void *cd, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
+{
+  (void) cd;
+  if (objc != 1) {
+    Tcl_WrongNumArgs(interp, 1, objv, NULL);
+    return TCL_ERROR;
+  }
+  /* Buffered stdio would be duplicated into the child and flushed twice. */
+  fflush(NULL);
+  pid_t pid = fork();
+  if (pid < 0) {
+    Tcl_SetObjResult(interp,
+                     Tcl_ObjPrintf("fork failed: %s", strerror(errno)));
+    return TCL_ERROR;
+  }
+  Tcl_SetObjResult(interp, Tcl_NewWideIntObj((Tcl_WideInt) pid));
+  return TCL_OK;
+}
+
+/* posix_waitpid pid -> exit status: N for exit(N), 128+SIG for a signal
+ * (142 = SIGALRM = a posix_alarm deadline fired), 255 for anything else. */
+static int
+PosixWaitpidCmd(void *cd, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
+{
+  (void) cd;
+  if (objc != 2) {
+    Tcl_WrongNumArgs(interp, 1, objv, "pid");
+    return TCL_ERROR;
+  }
+  Tcl_WideInt pid;
+  if (Tcl_GetWideIntFromObj(interp, objv[1], &pid) != TCL_OK) {
+    return TCL_ERROR;
+  }
+  int raw = 0;
+  pid_t reaped;
+  do {
+    reaped = waitpid((pid_t) pid, &raw, 0);
+  } while (reaped < 0 && errno == EINTR);
+  if (reaped < 0) {
+    Tcl_SetObjResult(interp,
+                     Tcl_ObjPrintf("waitpid failed: %s", strerror(errno)));
+    return TCL_ERROR;
+  }
+  int status = 255;
+  if (WIFEXITED(raw)) {
+    status = WEXITSTATUS(raw);
+  } else if (WIFSIGNALED(raw)) {
+    status = 128 + WTERMSIG(raw);
+  }
+  Tcl_SetObjResult(interp, Tcl_NewIntObj(status));
+  return TCL_OK;
+}
+
+/* posix_alarm seconds: self-destruct deadline via alarm(2)/SIGALRM.
+ *
+ * Timeouts are enforced in the CHILD, not by the parent killing it: a
+ * kill from outside reaps only the direct child and orphans its running
+ * descendants, which then hold the machine and the stdout pipe open
+ * indefinitely. A deadline armed inside every forked process bounds the
+ * whole tree -- no orphan can outlive its own alarm. Deadlines do not
+ * survive fork, so each generation re-arms its own (fork.tcl -timeout). */
+static int
+PosixAlarmCmd(void *cd, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
+{
+  (void) cd;
+  if (objc != 2) {
+    Tcl_WrongNumArgs(interp, 1, objv, "seconds");
+    return TCL_ERROR;
+  }
+  double seconds;
+  if (Tcl_GetDoubleFromObj(interp, objv[1], &seconds) != TCL_OK) {
+    return TCL_ERROR;
+  }
+  if (seconds < 0) {
+    Tcl_SetObjResult(interp, Tcl_NewStringObj("seconds must be >= 0", -1));
+    return TCL_ERROR;
+  }
+  /* Default SIGALRM disposition (terminate) is the mechanism; make sure
+   * no inherited ignore/handler defuses it. */
+  signal(SIGALRM, SIG_DFL);
+  alarm((unsigned int) (seconds + 0.999));
+  return TCL_OK;
+}
+
+/* posix_exit ?code?: _exit, not exit — a forked child must never run the
+ * host's atexit hooks (logger teardown, metrics dumps) that belong to the
+ * process image it copied. */
+static int
+PosixExitCmd(void *cd, Tcl_Interp *interp, int objc, Tcl_Obj *const objv[])
+{
+  (void) cd;
+  int code = 0;
+  if (objc > 2) {
+    Tcl_WrongNumArgs(interp, 1, objv, "?code?");
+    return TCL_ERROR;
+  }
+  if (objc == 2 && Tcl_GetIntFromObj(interp, objv[1], &code) != TCL_OK) {
+    return TCL_ERROR;
+  }
+  fflush(NULL);
+  _exit(code);
+}
+
+int
+Orfsfork_Init(Tcl_Interp *interp)
+{
+  if (Tcl_InitStubs(interp, "9.0", 0) == NULL) {
+    return TCL_ERROR;
+  }
+  if (Tcl_Eval(interp, "namespace eval ::orfs {}") != TCL_OK) {
+    return TCL_ERROR;
+  }
+  Tcl_CreateObjCommand(interp, "::orfs::posix_fork", PosixForkCmd, NULL,
+                       NULL);
+  Tcl_CreateObjCommand(interp, "::orfs::posix_waitpid", PosixWaitpidCmd,
+                       NULL, NULL);
+  Tcl_CreateObjCommand(interp, "::orfs::posix_exit", PosixExitCmd, NULL,
+                       NULL);
+  Tcl_CreateObjCommand(interp, "::orfs::posix_alarm", PosixAlarmCmd, NULL,
+                       NULL);
+  return Tcl_PkgProvide(interp, "orfsfork", "1.0");
+}

--- a/mock/openroad/src/bin/tcl_interpreter.py
+++ b/mock/openroad/src/bin/tcl_interpreter.py
@@ -610,6 +610,9 @@ class TclInterpreter:
         elif len(remaining) == 1:
             msg = remaining[0]
         end = "" if nonewline else "\n"
+        if hasattr(self, "_channels") and channel in self._channels:
+            self._channels[channel].write(msg + end)
+            return ""
         out = sys.stderr if channel == "stderr" else sys.stdout
         out.write(msg + end)
         return ""

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -242,6 +242,23 @@ def synth_attrs():
         ),
     }
 
+def fork_attrs():
+    """The fork/join idiom files shipped to every run script.
+
+    Scripts opt in with `source $::env(ORFS_FORK_TCL)`; the two files cost
+    nothing when unused. See fork/fork.tcl.
+    """
+    return {
+        "_fork_lib": attr.label(
+            default = "//fork:liborfsfork.so",
+            allow_single_file = True,
+        ),
+        "_fork_tcl": attr.label(
+            default = "//fork:fork.tcl",
+            allow_single_file = True,
+        ),
+    }
+
 def openroad_only_attrs():
     return {
         "src": attr.label(

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -508,6 +508,28 @@ def data_arguments(ctx):
 def run_arguments(ctx):
     return {"RUN_SCRIPT": ctx.file.script.path}
 
+def fork_arguments(ctx, short = False):
+    """The fork/join idiom files (see fork/fork.tcl).
+
+    Any run script may `source $::env(ORFS_FORK_TCL)`, which loads the
+    raw-primitive extension from $ORFS_FORK_LIB.
+    """
+    return {
+        "ORFS_FORK_LIB": file_path(ctx.file._fork_lib, short),
+        "ORFS_FORK_TCL": file_path(ctx.file._fork_tcl, short),
+    }
+
+def out_dir_arguments(out_dir):
+    """Points run scripts at their declared output directory, if any.
+
+    Deliberately not named RESULTS_DIR: the ORFS Makefile owns that
+    variable (staged flow outputs live there), so overriding it would
+    break input loading.
+    """
+    if out_dir:
+        return {"RUN_OUTPUT_DIR": out_dir.path}
+    return {}
+
 def environment_string(env):
     return " ".join(['{}="{}"'.format(*pair) for pair in env.items()])
 

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -4,6 +4,7 @@ load(
     "//private:attrs.bzl",
     "flow_attrs",
     "flow_provides",
+    "fork_attrs",
     "openroad_attrs",
     "openroad_only_attrs",
     "orfs_attrs",
@@ -28,6 +29,7 @@ load(
     "flow_inputs",
     "flow_runfiles",
     "flow_substitutions",
+    "fork_arguments",
     "generation_commands",
     "hack_away_prefix",
     "input_commands",
@@ -36,6 +38,7 @@ load(
     "module_top",
     "odb_arguments",
     "orfs_additional_arguments",
+    "out_dir_arguments",
     "pdk_inputs",
     "rename_inputs",
     "renames",
@@ -380,6 +383,13 @@ def _run_impl(ctx):
     for k in dir(ctx.outputs):
         outs.extend(getattr(ctx.outputs, k))
 
+    out_dir = None
+    if ctx.attr.out_dir:
+        out_dir = ctx.actions.declare_directory(ctx.attr.out_dir)
+        outs.append(out_dir)
+    if not outs:
+        fail("orfs_run requires at least one of `outs` or `out_dir`")
+
     original_config = config
     all_jsons = ctx.files.extra_arguments
     inherited_jsons = ctx.attr.src[OrfsInfo].arguments.to_list() if OrfsInfo in ctx.attr.src else []
@@ -413,9 +423,11 @@ def _run_impl(ctx):
               odb_arguments(ctx) |
               sdc_arguments(ctx) |
               data_arguments(ctx) |
-              run_arguments(ctx),
+              run_arguments(ctx) |
+              fork_arguments(ctx) |
+              out_dir_arguments(out_dir),
         inputs = depset(
-            [config, ctx.file.script] + extra_files,
+            [config, ctx.file.script, ctx.file._fork_tcl, ctx.file._fork_lib] + extra_files,
             transitive = [
                 data_inputs(ctx),
                 source_inputs(ctx),
@@ -448,7 +460,9 @@ def _run_impl(ctx):
                                             arguments = odb_arguments(ctx) |
                                                         sdc_arguments(ctx) |
                                                         data_arguments(ctx) |
-                                                        run_arguments(ctx),
+                                                        run_arguments(ctx) |
+                                                        fork_arguments(ctx) |
+                                                        out_dir_arguments(out_dir),
                                             prefix = config.root.path,
                                         ) |
                                         {
@@ -470,10 +484,10 @@ def _run_impl(ctx):
             make = make,
             config = config,
             renames = [],
-            files = depset([config, ctx.file.script] + extra_files),
+            files = depset([config, ctx.file.script, ctx.file._fork_tcl, ctx.file._fork_lib] + extra_files),
             runfiles = ctx.runfiles(
                 transitive_files = depset(
-                    [config, make, ctx.file.script] + extra_files,
+                    [config, make, ctx.file.script, ctx.file._fork_tcl, ctx.file._fork_lib] + extra_files,
                     transitive = [
                         flow_inputs(ctx),
                         data_inputs(ctx),
@@ -488,6 +502,7 @@ _orfs_run_rule = rule(
     implementation = _run_impl,
     attrs = yosys_attrs() |
             openroad_attrs() |
+            fork_attrs() |
             {
                 "cmd": attr.string(
                     mandatory = False,
@@ -497,9 +512,19 @@ _orfs_run_rule = rule(
                     mandatory = False,
                     default = "",
                 ),
+                "out_dir": attr.string(
+                    mandatory = False,
+                    default = "",
+                    doc = "Name of a declared output directory (a tree " +
+                          "artifact). Its path reaches the run script as " +
+                          "$RUN_OUTPUT_DIR; the script decides what files " +
+                          "to put there. Use for scripts whose set of " +
+                          "output files is not known in advance (e.g. a " +
+                          "fork/join tree walk writing one JSON per leaf).",
+                ),
                 "outs": attr.output_list(
-                    mandatory = True,
-                    allow_empty = False,
+                    mandatory = False,
+                    allow_empty = True,
                 ),
                 "script": attr.label(
                     mandatory = True,
@@ -848,7 +873,7 @@ def _run_executable_impl(ctx):
         "FLOW_HOME": ctx.file._makefile.dirname,
         "STDBUF_CMD": "",
         "RUN_SCRIPT": ctx.file.script.path,
-    }
+    } | fork_arguments(ctx, short = True)
 
     moreargs = environment_string(
         hack_away_prefix(
@@ -901,7 +926,7 @@ exec "$PYTHON" "$SCRIPT" {moreargs} "$@"
             executable = wrapper,
             runfiles = ctx.runfiles(
                 transitive_files = depset(
-                    [config, wrapper, ctx.file._run_executable_script, ctx.file.script],
+                    [config, wrapper, ctx.file._run_executable_script, ctx.file.script, ctx.file._fork_tcl, ctx.file._fork_lib],
                     transitive = [
                         flow_inputs(ctx),
                         yosys_inputs(ctx),
@@ -917,6 +942,7 @@ _orfs_rule_run_executable = rule(
     implementation = _run_executable_impl,
     attrs = yosys_attrs() |
             openroad_attrs() |
+            fork_attrs() |
             {
                 "cmd": attr.string(
                     mandatory = False,
@@ -963,6 +989,12 @@ def orfs_run_executable(**kwargs):
        the script author's responsibility; script-specific output destinations
        must be passed via custom variables as **absolute paths** to write back
        to the workspace.
+    5. **Results folders**: a script that produces a folder of files (e.g. a
+       fork/join tree walk writing one JSON per leaf — see docs/fork.md)
+       takes the folder as such an absolute-path variable, supplied by the
+       caller per invocation exactly like `LOG_DIR`; concurrent invocations
+       must not share it. (The build-time sibling `orfs_run` declares the
+       folder itself via its `out_dir` attribute instead.)
 
     The compiled binary accepts `KEY=VALUE` positional arguments which become
     Make variable overrides, and an optional `--cmd` flag to override the default

--- a/test/BUILD
+++ b/test/BUILD
@@ -873,6 +873,42 @@ orfs_flow(
     verilog_files = LB_VERILOG_FILES,
 )
 
+# Exercise orfs_run's out_dir (tree-artifact output directory): the script
+# decides at runtime what files land in $RUN_OUTPUT_DIR. Fast in CI via
+# mock-openroad.
+orfs_run(
+    name = "run_out_dir_mock",
+    src = ":lb_32x128_mock_openroad_floorplan",
+    openroad = "//mock/openroad/src/bin:openroad",
+    out_dir = "run_out_dir_mock_out",
+    script = ":run_out_dir.tcl",
+)
+
+sh_test(
+    name = "run_out_dir_test",
+    srcs = ["run_out_dir_test.sh"],
+    args = ["$(rootpath :run_out_dir_mock)"],
+    data = [":run_out_dir_mock"],
+)
+
+# fork/join smoke on real OpenROAD (see fork/fork.tcl): a nested tree walk
+# after load_design writing one JSON per leaf into out_dir, with an OpenSTA
+# query in every forked child and a deliberate failing leaf.
+orfs_run(
+    name = "fork_smoke",
+    src = ":lb_32x128_floorplan",
+    openroad = "@openroad//:openroad",
+    out_dir = "fork_smoke_out",
+    script = ":fork_smoke.tcl",
+    tags = ["manual"],
+)
+
+build_test(
+    name = "fork_smoke_test",
+    tags = ["manual"],
+    targets = [":fork_smoke"],
+)
+
 # Manual target for testing the source-built OpenROAD GUI locally.
 # Run: bazelisk run //test:lb_32x128_openroad_gui_synth
 # This builds OpenROAD from source with GUI and opens the synthesis

--- a/test/estimation_ladder/BUILD.bazel
+++ b/test/estimation_ladder/BUILD.bazel
@@ -41,6 +41,8 @@ orfs_flow(
 
 # Common configuration shared across the estimator
 ESTIMATOR_SOURCES = {
+    "ESTIMATOR_BATCH_TCL": ["estimator_batch.tcl"],
+    "ESTIMATOR_LIB_TCL": ["estimator_lib.tcl"],
     "ESTIMATOR_TCL": ["estimator.tcl"],
     "IO_CONSTRAINTS": ["io_constraints.tcl"],
 }

--- a/test/estimation_ladder/BUILD.bazel
+++ b/test/estimation_ladder/BUILD.bazel
@@ -96,6 +96,11 @@ py_binary(
 )
 
 py_binary(
+    name = "wave_savings",
+    srcs = ["wave_savings.py"],
+)
+
+py_binary(
     name = "update-readme",
     srcs = ["update_readme.py"],
     args = [

--- a/test/estimation_ladder/estimator.tcl
+++ b/test/estimation_ladder/estimator.tcl
@@ -14,42 +14,17 @@ set sdc_tail [file rootname $odb_tail].sdc
 load_design $odb_tail $sdc_tail
 set load_s [expr {([clock clicks -milliseconds] - $script_start) / 1000.0}]
 
-# Every rung of the ladder is gated by an environment variable so the
-# Optuna study owns the search space and this script stays a thin,
-# faithful mirror of the ORFS stages it approximates.  Knob *values* are
-# passed as ready-made argument strings (GP_ARGS, GRT_ARGS, ...) rather
-# than one variable per option: the study composes them, and adding a
-# knob to the sweep does not mean touching this file.
-proc est_flag { name {default 0} } {
-    if { [info exists ::env($name)] && $::env($name) ne "" } {
-        return $::env($name)
-    }
-    return $default
-}
-
-proc est_args { name } {
-    if { [info exists ::env($name)] && $::env($name) ne "" } {
-        return $::env($name)
-    }
-    return ""
-}
-
-# Per-phase runtimes.  A single total cannot say which knob bought which
-# second, and the runtime surrogate in the study models the phases
-# separately (they depend on disjoint knob subsets) rather than treating
-# the total as one black box.
+# Knob overlay for batch mode; empty here, so est_flag/est_args fall back
+# to the environment exactly as before.
+set ::est_cfg [dict create]
 set ::phase_times [dict create]
 
-proc time_phase { name body } {
-    set t0 [clock clicks -milliseconds]
-    uplevel 1 $body
-    set t1 [clock clicks -milliseconds]
-    dict set ::phase_times $name [expr {($t1 - $t0) / 1000.0}]
-}
+source $::env(ESTIMATOR_LIB_TCL)
 
 set start_time [clock clicks -milliseconds]
 
-# 1. Floorplan
+# 1. Floorplan.  Common to every configuration -- in batch mode it is the
+# root of the tree and is paid exactly once.
 time_phase floorplan {
     initialize_floorplan -die_area $::env(DIE_AREA) \
         -core_area $::env(CORE_AREA) \
@@ -60,296 +35,33 @@ time_phase floorplan {
     }
 }
 
-# 2. Parasitics calibration.  estimate_parasitics -placement turns
-# wirelength into delay through the RC that set_wire_rc installs; which
-# layer stands in for "an average wire" is a free parameter, and
-# WIRE_RC_LAYER_OVERRIDE lets the study sweep it.
-if {[est_args WIRE_RC_LAYER_OVERRIDE] ne ""} {
-    set_wire_rc -signal -layer $::env(WIRE_RC_LAYER_OVERRIDE)
+# Batch mode: walk a whole tree of configurations in this one process,
+# forking at each divergence so a shared stage is paid exactly once.  One
+# leaf JSON per configuration lands in EST_RESULTS_DIR.
+if {[info exists ::env(EST_MANIFEST_DIR)] && $::env(EST_MANIFEST_DIR) ne ""} {
+    source $::env(ESTIMATOR_BATCH_TCL)
+    exit 0
 }
 
-# 3. Place Pins.  With -place_ios the pins are co-optimized with the
-# cells inside global placement, but gpl leaves them off-track, so
-# place_pins still has to run -- afterwards, to legalize what gpl chose,
-# instead of beforehand to fix locations gpl must then live with.
-set place_ios [est_flag PLACE_IOS 0]
-
-proc est_place_pins { } {
-    source $::env(IO_CONSTRAINTS)
-    place_pins -hor_layers $::env(IO_PLACER_H) -ver_layers $::env(IO_PLACER_V)
-}
-
-if {$place_ios != 1} {
-    time_phase place_pins { est_place_pins }
-}
-
-# 4. Macro Placement (mirrors ORFS macro_place_util.tcl).  Gated: with
-# macros present this is not free, and leaving it unconditional made the
-# "synthesis only" rung silently include a full RTLMP run.
-if {[est_flag RUN_MACRO_PLACE 1] == 1 && [find_macros] != ""} {
-    time_phase macro_place {
-        lassign $::env(MACRO_PLACE_HALO) halo_x halo_y
-        set mp_args [list -halo_width $halo_x -halo_height $halo_y \
-            -target_util [place_density_with_lb_addon]]
-        eval rtl_macro_placer $mp_args [est_args RTLMP_ARGS]
-    }
-}
-
-# 5. Global Placement
-if {[est_flag RUN_PLACE 0] == 1} {
-    time_phase global_place {
-        # Follow ORFS's padding rather than pinning it to 0: the ground
-        # truth was placed with it, and a different pad spreads the cells
-        # differently than the flow being estimated.  The variable is
-        # scoped to the place/floorplan stages and this script runs off
-        # the synth target, so fall back to ORFS's own default of 0
-        # instead of failing on an unset variable.
-        set cell_pad [est_flag CELL_PAD_IN_SITES_GLOBAL_PLACEMENT 0]
-        set gp_args "-density [place_density_with_lb_addon]"
-        append gp_args " -pad_left $cell_pad -pad_right $cell_pad"
-        append gp_args " -force_center_initial_place"
-
-        # -place_ios is a branch, not another dimension: gpl rejects it
-        # together with -timing_driven and -routability_driven.
-        if {$place_ios == 1} {
-            append gp_args " -place_ios"
-        } else {
-            if {[est_flag GPL_TIMING_DRIVEN 0] == 1} {
-                append gp_args " -timing_driven"
-            }
-            if {[est_flag GPL_ROUTABILITY_DRIVEN 0] == 1} {
-                append gp_args " -routability_driven"
-            }
-        }
-        if {[est_flag GPL_VIRTUAL_CTS 0] == 1} {
-            append gp_args " -virtual_cts"
-        }
-        append gp_args " [est_args GP_ARGS]"
-
-        eval global_placement $gp_args
-    }
-
-    if {$place_ios == 1} {
-        time_phase place_pins { est_place_pins }
-    }
-
-    estimate_parasitics -placement
-}
-
-# 6. Clock tree.  The ground truth is a post-CTS ODB read back with
-# propagated clocks, so an ideal clock here does not merely lose skew: on
-# a design with macros the clock insertion latency does not cancel and
-# lands directly in min_period = clk_period - slack.  CLOCK_MODE picks
-# how much of that gap to buy back:
-#   none        - ideal clock (the old behaviour, kept as a rung)
-#   propagated  - set_propagated_clock with no tree to propagate
-#   real        - clock_tree_synthesis, as ORFS runs it
-# The virtual clock tree is gpl's -virtual_cts (GPL_VIRTUAL_CTS above),
-# since it happens inside global placement rather than after it.
-set clock_mode [est_flag CLOCK_MODE none]
-
-if {$clock_mode eq "real"} {
-    time_phase cts {
-        # ORFS runs CTS on a legalized placement (3_place.odb).  Whether
-        # TritonCTS tolerates raw global-placement output is what
-        # CTS_DPL exists to measure.
-        if {[est_flag CTS_DPL 0] == 1} {
-            detailed_placement
-        }
-        repair_clock_inverters
-        set cts_args [list -sink_clustering_enable -repair_clock_nets]
-        eval clock_tree_synthesis $cts_args [est_args CTS_ARGS_EXTRA]
-        # Order follows ORFS cts.tcl: re-estimate straight after CTS,
-        # which has just inserted buffers and dummy loads, and only then
-        # propagate the clock.
-        estimate_parasitics -placement
-        set_propagated_clock [all_clocks]
-        estimate_parasitics -placement
-    }
-} elseif {$clock_mode eq "propagated"} {
-    set_propagated_clock [all_clocks]
-}
-
-
-# Per-path features, for the question calibration cannot touch.
-#
-# Any correction that reads only the estimate is a monotone function of
-# it and so cannot reorder the paths -- which is exactly what the
-# estimator gets wrong.  Reordering needs to know something about the
-# individual path, and the obvious candidate is how far it physically
-# reaches: the error is wire-related, and a path whose endpoints sit far
-# apart has more room for the router to add detour than a local one.
-# Gated because it costs an ODB lookup per path and only the feature
-# study wants it.
-proc est_pin_xy { name } {
-    set blk [ord::get_db_block]
-    # Split on the last separator and go via the instance: findITerm on
-    # the block does not resolve the names OpenSTA reports for escaped
-    # Verilog identifiers like sum_stage1[2][78]$_DFF_PP0_/QN.
-    # ODB stores escaped Verilog identifiers -- sum_stage1\[0\]\[42\] --
-    # while OpenSTA reports them unescaped, so a direct lookup of the
-    # name STA gives back finds nothing at all.
-    set idx [string last "/" $name]
-    if {$idx > 0} {
-        set inst_name [string range $name 0 [expr {$idx - 1}]]
-        set term_name [string range $name [expr {$idx + 1}] end]
-        set inst [$blk findInst $inst_name]
-        if {$inst eq "NULL"} {
-            set inst [$blk findInst \
-                [string map [list "\[" "\\\[" "\]" "\\\]"] $inst_name]]
-        }
-        if {$inst ne "NULL"} {
-            set it [$inst findITerm $term_name]
-            if {$it ne "NULL"} {
-                set is_macro [[$inst getMaster] isBlock]
-                set net [$it getNet]
-                set fan [expr {$net eq "NULL" ? 0 : [$net getITermCount]}]
-                lassign [$it getAvgXY] ok x y
-                if {$ok} { return [list $x $y $is_macro $fan] }
-                lassign [$inst getOrigin] x y
-                return [list $x $y $is_macro $fan]
-            }
-        }
-    }
-    set bt [$blk findBTerm $name]
-    if {$bt ne "NULL"} {
-        set bb [$bt getBBox]
-        return [list [expr {([$bb xMin] + [$bb xMax]) / 2}] \
-                     [expr {([$bb yMin] + [$bb yMax]) / 2}] 0 0]
-    }
-    return {}
-}
-
-proc est_features { start end } {
-    set a [est_pin_xy $start]
-    set b [est_pin_xy $end]
-    if {[llength $a] == 0 || [llength $b] == 0} {
-        return "\"dist_um\": -1, \"macro_ends\": 0, \"fanout\": 0"
-    }
-    lassign $a ax ay amacro afan
-    lassign $b bx by bmacro bfan
-    set dbu [[[ord::get_db] getTech] getDbUnitsPerMicron]
-    set dist [expr {(abs($ax - $bx) + abs($ay - $by)) / double($dbu)}]
-    return "\"dist_um\": $dist, \"macro_ends\": [expr {$amacro + $bmacro}], \"fanout\": [expr {$afan + $bfan}]"
-}
-
-# Re-estimate against whichever source is current.  repair_design and
-# repair_timing open an incremental-parasitics guard that errors out
-# (EST-0104) if anything upstream -- CTS inserting buffers and dummy
-# loads, most notably -- left parasitics invalid.
-proc est_refresh_parasitics { } {
-    if {[est_flag RUN_GRT 0] == 1 && [grt::have_routes]} {
-        estimate_parasitics -global_routing
-    } else {
-        estimate_parasitics -placement
-    }
-}
-
-# 7. Repair design.  The ground-truth ODB has been through repair_design
-# and repair_timing; without them the estimate carries a systematic
-# optimism no placement knob can remove.
-if {[est_flag RUN_REPAIR_DESIGN 0] == 1} {
-    time_phase repair_design {
-        est_refresh_parasitics
-        eval repair_design [est_args REPAIR_DESIGN_ARGS]
-        est_refresh_parasitics
-    }
-}
-
-# 8. Global Routing
-if {[est_flag RUN_GRT 0] == 1} {
-    time_phase global_route {
-        set grt_args "-congestion_iterations [est_flag GRT_ITERATIONS 1]"
-        append grt_args " [est_args GRT_ARGS]"
-        eval global_route $grt_args
-    }
-    estimate_parasitics -global_routing
-}
-
-# 9. Repair timing.  Hold repair is deliberately absent: the metric is
-# the minimum clock period, so -hold can only cost runtime.
-if {[est_flag RUN_REPAIR_TIMING 0] == 1} {
-    time_phase repair_timing {
-        est_refresh_parasitics
-        eval repair_timing -setup [est_args REPAIR_TIMING_ARGS]
-        est_refresh_parasitics
-    }
-}
+est_stage_wire_rc
+est_stage_pins_pre
+est_stage_macro_place
+est_stage_global_place
+est_stage_clock
+est_stage_repair_design
+est_stage_grt
+est_stage_repair_timing
 
 set end_time [clock clicks -milliseconds]
 set estimate_s [expr {($end_time - $start_time) / 1000.0}]
 dict set ::phase_times load $load_s
 
-# Measure Target Paths against Ground Truth.  Deliberately after
-# end_time: the study measures how long until a timing signal is
-# available, not how long it takes to interrogate it.
-set sampled_file [string trim $::env(GROUND_TRUTH_JSON) "'\""]
-set fp [open $sampled_file r]
-set path_data [read $fp]
-close $fp
-
-set target_paths []
-foreach line [split $path_data "\n"] {
-    if {[regexp {"start": "([^"]+)", "end": "([^"]+)"} $line match start end]} {
-        lappend target_paths [list $start $end]
-    }
-}
-
-set sta_start [clock clicks -milliseconds]
-set measured []
-foreach pt $target_paths {
-    set start [lindex $pt 0]
-    set end [lindex $pt 1]
-    set paths [find_timing_paths -sort_by_slack -group_path_count 1 -from $start -to $end]
-
-    if {[llength $paths] == 0} {
-        error "No timing path found from $start to $end"
-    }
-    set slack [get_property [lindex $paths 0] slack]
-    set clk_period [get_property [lindex [get_clocks] 0] period]
-    lappend measured [list $start $end [expr {$clk_period - $slack}]]
-}
-# OpenSTA builds the timing graph and computes delays on the first
-# query, so this is not bookkeeping around the result -- it is where a
-# large part of the work happens, and on a rung that runs no flow stages
-# it is very nearly all of it.
-set sta_s [expr {([clock clicks -milliseconds] - $sta_start) / 1000.0}]
-dict set ::phase_times sta $sta_s
+est_measure_paths
+set sta_s [dict get $::phase_times sta]
 
 set total_s [expr {$load_s + $estimate_s + $sta_s}]
 puts "ESTIMATOR_RUNTIME: $total_s s (load $load_s, estimate $estimate_s, sta $sta_s)"
 
-set out_fp [open $::env(OUTPUT_JSON) w]
-puts $out_fp "{"
-puts $out_fp "\"runtime_s\": $total_s,"
-puts $out_fp "\"load_s\": $load_s,"
-puts $out_fp "\"estimate_s\": $estimate_s,"
-puts $out_fp "\"sta_s\": $sta_s,"
-puts $out_fp "\"phases\": \{"
-set phase_first 1
-foreach {phase_name phase_s} $::phase_times {
-    if {$phase_first == 0} { puts $out_fp "," }
-    set phase_first 0
-    puts -nonewline $out_fp "  \"$phase_name\": $phase_s"
-}
-puts $out_fp ""
-puts $out_fp "\},"
-puts $out_fp "\"paths\": \["
-
-set is_first 1
-foreach m $measured {
-    lassign $m start end min_period
-    if {$is_first == 0} { puts $out_fp "," }
-    set is_first 0
-    set extra ""
-    if {[est_flag DUMP_FEATURES 0] == 1} {
-        set extra ", [est_features $start $end]"
-    }
-    puts -nonewline $out_fp "  {\"start\": \"$start\", \"end\": \"$end\", \"min_period\": $min_period$extra}"
-}
-puts $out_fp ""
-puts $out_fp "\]"
-puts $out_fp "}"
-close $out_fp
+est_write_json $::env(OUTPUT_JSON) $load_s $estimate_s $sta_s
 
 exit 0

--- a/test/estimation_ladder/estimator_batch.tcl
+++ b/test/estimation_ladder/estimator_batch.tcl
@@ -102,13 +102,30 @@ proc est_stage_key { cfg knobs } {
     return $key
 }
 
-proc est_apply_stage { stage knobs cfg } {
+# Edge log: one JSON line per executed tree edge, appended as it
+# completes (children inherit ::est_path across fork, so the path is the
+# edge's identity in the trie). This is the instrumentation behind the
+# resident-root / snapshot-cache decision: wave_savings.py sums, across a
+# study's waves, the time spent re-computing edges an earlier wave had
+# already paid for -- the upper bound on what keeping snapshots alive
+# between waves would save.
+proc est_log_edge { stage seconds } {
+    set path [string map {\\ \\\\ \" \\\"} [join $::est_path " > "]]
+    set fp [open [file join $::env(EST_RESULTS_DIR) edges.jsonl] a]
+    puts $fp "{\"path\": \"$path\", \"stage\": \"$stage\", \"seconds\": $seconds}"
+    close $fp
+}
+
+proc est_apply_stage { stage knobs key cfg } {
     foreach k $knobs {
         if {[dict exists $cfg $k]} {
             dict set ::est_cfg $k [dict get $cfg $k]
         }
     }
+    lappend ::est_path $key
+    set t0 [clock clicks -milliseconds]
     est_stage_$stage
+    est_log_edge $stage [expr {([clock clicks -milliseconds] - $t0) / 1000.0}]
 }
 
 # At the bottom of the tree the remaining configurations are identical in
@@ -118,6 +135,7 @@ proc est_run_leaves { configs } {
     dict set ::phase_times load $::load_s
     est_measure_paths
     set sta_s [dict get $::phase_times sta]
+    est_log_edge sta $sta_s
     set estimate_s 0.0
     dict for {name secs} $::phase_times {
         if {$name ni {load sta}} {
@@ -153,15 +171,16 @@ proc est_walk { configs depth } {
     if {[dict size $groups] == 1} {
         # Sole subtree: this process is already dedicated to it, so an
         # inline stage costs nothing a fork would buy.
-        set sub [lindex [dict values $groups] 0]
-        est_apply_stage $stage $knobs [lindex [dict values $sub] 0]
+        set key [lindex [dict keys $groups] 0]
+        set sub [dict get $groups $key]
+        est_apply_stage $stage $knobs $key [lindex [dict values $sub] 0]
         est_walk $sub [expr {$depth + 1}]
         return
     }
 
     set statuses [fork {*}$::est_fork_opts key [dict keys $groups] {
         set sub [dict get $groups $key]
-        est_apply_stage $stage $knobs [lindex [dict values $sub] 0]
+        est_apply_stage $stage $knobs $key [lindex [dict values $sub] 0]
         est_walk $sub [expr {$depth + 1}]
     }]
     dict for {key code} $statuses {
@@ -177,5 +196,8 @@ if {[dict size $est_configs] == 0} {
     error "no .cfg files in EST_MANIFEST_DIR=$::env(EST_MANIFEST_DIR)"
 }
 puts "estimator batch: walking [dict size $est_configs] configurations"
+set ::est_path {}
+est_log_edge load $::load_s
+est_log_edge floorplan [dict get $::phase_times floorplan]
 est_walk $est_configs 0
 puts "estimator batch: walk complete"

--- a/test/estimation_ladder/estimator_batch.tcl
+++ b/test/estimation_ladder/estimator_batch.tcl
@@ -1,0 +1,181 @@
+# Batch mode: one estimator process walks a decision tree of
+# configurations instead of paying the shared prefix once per trial.
+#
+# The manifest is a directory of <id>.cfg files, one KEY=VALUE line per
+# knob (the same knob names the single-config mode reads from the
+# environment).  The knob space is a tree because the stage order is
+# fixed: configurations are grouped stage by stage on the knobs that
+# stage consumes, and where a stage has more than one distinct setting
+# the walk forks -- a copy-on-write snapshot per group, sequential
+# depth-first, so every tree edge (stage execution) runs exactly once
+# and a crashed configuration loses only its own subtree (its leaf JSON
+# is simply missing; siblings still land).  See docs/fork.md.
+#
+# Each leaf writes EST_RESULTS_DIR/<id>.json in the same schema as the
+# single-config OUTPUT_JSON, with two caveats inherent to sharing:
+# estimate_s is the sum of the timed phases on the leaf's own root path
+# (fork inherits ::phase_times, so that attribution is exact) rather
+# than a wall-clock difference, and load_s/floorplan were measured once
+# in the root for everyone.
+
+source $::env(ORFS_FORK_TCL)
+
+# Sequential is the default: one active run owns the whole machine, which
+# is what honest runtime numbers need.  EST_PARALLEL=1 forks the divergent
+# subtrees concurrently instead -- shared edges are still paid once, but
+# siblings contend for the machine, so it is for callers that never look
+# at the runtime axis (the CI machinery test) and for accuracy-only
+# sweeps.
+set ::est_fork_opts {}
+if {[info exists ::env(EST_PARALLEL)] && $::env(EST_PARALLEL) eq "1"} {
+    lappend ::est_fork_opts -parallel
+}
+
+# The per-subtree budget stands in for the per-trial timeout of the
+# one-process-per-trial mode: a runaway subtree self-destructs (status
+# 142, its leaf JSONs missing) instead of stalling the walk or, in
+# parallel mode, outliving the whole batch's deadline.
+if {[info exists ::env(EST_SUBTREE_TIMEOUT)] && $::env(EST_SUBTREE_TIMEOUT) ne ""} {
+    lappend ::est_fork_opts -timeout $::env(EST_SUBTREE_TIMEOUT)
+}
+
+# Which stage consumes which knobs, in flow order.  A knob shared by two
+# stages is keyed at the earliest stage that reads it (PLACE_IOS branches
+# pin placement, and global placement then re-reads the inherited value).
+set ::est_stage_names {
+    wire_rc
+    pins_pre
+    macro_place
+    global_place
+    clock
+    repair_design
+    grt
+    repair_timing
+}
+set ::est_stage_knobs [dict create \
+    wire_rc {WIRE_RC_LAYER_OVERRIDE} \
+    pins_pre {PLACE_IOS} \
+    macro_place {RUN_MACRO_PLACE RTLMP_ARGS} \
+    global_place {RUN_PLACE GPL_TIMING_DRIVEN GPL_ROUTABILITY_DRIVEN \
+                  GPL_VIRTUAL_CTS GP_ARGS CELL_PAD_IN_SITES_GLOBAL_PLACEMENT} \
+    clock {CLOCK_MODE CTS_DPL CTS_ARGS_EXTRA} \
+    repair_design {RUN_REPAIR_DESIGN REPAIR_DESIGN_ARGS} \
+    grt {RUN_GRT GRT_ITERATIONS GRT_ARGS} \
+    repair_timing {RUN_REPAIR_TIMING REPAIR_TIMING_ARGS} \
+]
+
+proc est_read_manifest { dir } {
+    set configs [dict create]
+    foreach f [lsort [glob -nocomplain -directory $dir *.cfg]] {
+        set id [file rootname [file tail $f]]
+        set cfg [dict create]
+        set fp [open $f r]
+        foreach line [split [read $fp] "\n"] {
+            set line [string trim $line]
+            if {$line eq "" || [string index $line 0] eq "#"} {
+                continue
+            }
+            set idx [string first "=" $line]
+            if {$idx < 1} {
+                error "manifest $f: not KEY=VALUE: $line"
+            }
+            dict set cfg [string range $line 0 [expr {$idx - 1}]] \
+                [string range $line [expr {$idx + 1}] end]
+        }
+        close $fp
+        dict set configs $id $cfg
+    }
+    return $configs
+}
+
+# The grouping key distinguishes "knob unset" (est_flag default applies)
+# from any explicit value, including the empty string.
+proc est_stage_key { cfg knobs } {
+    set key {}
+    foreach k $knobs {
+        if {[dict exists $cfg $k]} {
+            lappend key "$k=[dict get $cfg $k]"
+        } else {
+            lappend key "$k?"
+        }
+    }
+    return $key
+}
+
+proc est_apply_stage { stage knobs cfg } {
+    foreach k $knobs {
+        if {[dict exists $cfg $k]} {
+            dict set ::est_cfg $k [dict get $cfg $k]
+        }
+    }
+    est_stage_$stage
+}
+
+# At the bottom of the tree the remaining configurations are identical in
+# every stage knob, so one STA pass serves them all; only the leaf-level
+# DUMP_FEATURES output option may still differ per id.
+proc est_run_leaves { configs } {
+    dict set ::phase_times load $::load_s
+    est_measure_paths
+    set sta_s [dict get $::phase_times sta]
+    set estimate_s 0.0
+    dict for {name secs} $::phase_times {
+        if {$name ni {load sta}} {
+            set estimate_s [expr {$estimate_s + $secs}]
+        }
+    }
+    dict for {id cfg} $configs {
+        if {[dict exists $cfg DUMP_FEATURES]} {
+            dict set ::est_cfg DUMP_FEATURES [dict get $cfg DUMP_FEATURES]
+        } else {
+            dict unset ::est_cfg DUMP_FEATURES
+        }
+        est_write_json [file join $::env(EST_RESULTS_DIR) $id.json] \
+            $::load_s $estimate_s $sta_s
+        puts "estimator batch: leaf $id done\
+            (estimate ${estimate_s}s, sta ${sta_s}s)"
+    }
+}
+
+proc est_walk { configs depth } {
+    if {$depth == [llength $::est_stage_names]} {
+        est_run_leaves $configs
+        return
+    }
+    set stage [lindex $::est_stage_names $depth]
+    set knobs [dict get $::est_stage_knobs $stage]
+
+    set groups [dict create]
+    dict for {id cfg} $configs {
+        dict set groups [est_stage_key $cfg $knobs] $id $cfg
+    }
+
+    if {[dict size $groups] == 1} {
+        # Sole subtree: this process is already dedicated to it, so an
+        # inline stage costs nothing a fork would buy.
+        set sub [lindex [dict values $groups] 0]
+        est_apply_stage $stage $knobs [lindex [dict values $sub] 0]
+        est_walk $sub [expr {$depth + 1}]
+        return
+    }
+
+    set statuses [fork {*}$::est_fork_opts key [dict keys $groups] {
+        set sub [dict get $groups $key]
+        est_apply_stage $stage $knobs [lindex [dict values $sub] 0]
+        est_walk $sub [expr {$depth + 1}]
+    }]
+    dict for {key code} $statuses {
+        if {$code != 0} {
+            puts stderr "estimator batch: subtree ($stage: $key)\
+                failed with status $code; its leaves are missing"
+        }
+    }
+}
+
+set est_configs [est_read_manifest $::env(EST_MANIFEST_DIR)]
+if {[dict size $est_configs] == 0} {
+    error "no .cfg files in EST_MANIFEST_DIR=$::env(EST_MANIFEST_DIR)"
+}
+puts "estimator batch: walking [dict size $est_configs] configurations"
+est_walk $est_configs 0
+puts "estimator batch: walk complete"

--- a/test/estimation_ladder/estimator_lib.tcl
+++ b/test/estimation_ladder/estimator_lib.tcl
@@ -1,0 +1,343 @@
+# Shared estimator machinery: knob lookup, per-phase timing, the flow
+# stages, path measurement and the leaf JSON writer.  estimator.tcl runs
+# these once for a single configuration; estimator_batch.tcl walks a whole
+# tree of configurations, forking at each divergence so a shared stage is
+# paid exactly once.
+
+# Every rung of the ladder is gated by a knob so the study owns the search
+# space and this script stays a thin, faithful mirror of the ORFS stages it
+# approximates.  Knob *values* are passed as ready-made argument strings
+# (GP_ARGS, GRT_ARGS, ...) rather than one variable per option: the study
+# composes them, and adding a knob to the sweep does not mean touching this
+# file.  Knobs come from the ::est_cfg overlay (batch mode: the walk fills
+# it in stage by stage) and fall back to the environment (single mode: the
+# driver passes them as make variables).
+proc est_flag { name {default 0} } {
+    if { [dict exists $::est_cfg $name] && [dict get $::est_cfg $name] ne "" } {
+        return [dict get $::est_cfg $name]
+    }
+    if { [info exists ::env($name)] && $::env($name) ne "" } {
+        return $::env($name)
+    }
+    return $default
+}
+
+proc est_args { name } {
+    return [est_flag $name ""]
+}
+
+# Per-phase runtimes.  A single total cannot say which knob bought which
+# second, and the runtime surrogate in the study models the phases
+# separately (they depend on disjoint knob subsets) rather than treating
+# the total as one black box.  In batch mode the dict is inherited across
+# fork, so a leaf's ::phase_times holds exactly the phases on its own path
+# from the root -- per-leaf attribution for free.
+proc time_phase { name body } {
+    set t0 [clock clicks -milliseconds]
+    uplevel 1 $body
+    set t1 [clock clicks -milliseconds]
+    dict set ::phase_times $name [expr {($t1 - $t0) / 1000.0}]
+}
+
+# 2. Parasitics calibration.  estimate_parasitics -placement turns
+# wirelength into delay through the RC that set_wire_rc installs; which
+# layer stands in for "an average wire" is a free parameter, and
+# WIRE_RC_LAYER_OVERRIDE lets the study sweep it.
+proc est_stage_wire_rc { } {
+    if {[est_args WIRE_RC_LAYER_OVERRIDE] ne ""} {
+        set_wire_rc -signal -layer [est_args WIRE_RC_LAYER_OVERRIDE]
+    }
+}
+
+# 3. Place Pins.  With -place_ios the pins are co-optimized with the
+# cells inside global placement, but gpl leaves them off-track, so
+# place_pins still has to run -- afterwards, to legalize what gpl chose,
+# instead of beforehand to fix locations gpl must then live with.
+proc est_place_pins { } {
+    source $::env(IO_CONSTRAINTS)
+    place_pins -hor_layers $::env(IO_PLACER_H) -ver_layers $::env(IO_PLACER_V)
+}
+
+proc est_stage_pins_pre { } {
+    if {[est_flag PLACE_IOS 0] != 1} {
+        time_phase place_pins { est_place_pins }
+    }
+}
+
+# 4. Macro Placement (mirrors ORFS macro_place_util.tcl).  Gated: with
+# macros present this is not free, and leaving it unconditional made the
+# "synthesis only" rung silently include a full RTLMP run.
+proc est_stage_macro_place { } {
+    if {[est_flag RUN_MACRO_PLACE 1] == 1 && [find_macros] != ""} {
+        time_phase macro_place {
+            lassign $::env(MACRO_PLACE_HALO) halo_x halo_y
+            set mp_args [list -halo_width $halo_x -halo_height $halo_y \
+                -target_util [place_density_with_lb_addon]]
+            eval rtl_macro_placer $mp_args [est_args RTLMP_ARGS]
+        }
+    }
+}
+
+# 5. Global Placement
+proc est_stage_global_place { } {
+    set place_ios [est_flag PLACE_IOS 0]
+    if {[est_flag RUN_PLACE 0] == 1} {
+        time_phase global_place {
+            # Follow ORFS's padding rather than pinning it to 0: the ground
+            # truth was placed with it, and a different pad spreads the cells
+            # differently than the flow being estimated.  The variable is
+            # scoped to the place/floorplan stages and this script runs off
+            # the synth target, so fall back to ORFS's own default of 0
+            # instead of failing on an unset variable.
+            set cell_pad [est_flag CELL_PAD_IN_SITES_GLOBAL_PLACEMENT 0]
+            set gp_args "-density [place_density_with_lb_addon]"
+            append gp_args " -pad_left $cell_pad -pad_right $cell_pad"
+            append gp_args " -force_center_initial_place"
+
+            # -place_ios is a branch, not another dimension: gpl rejects it
+            # together with -timing_driven and -routability_driven.
+            if {$place_ios == 1} {
+                append gp_args " -place_ios"
+            } else {
+                if {[est_flag GPL_TIMING_DRIVEN 0] == 1} {
+                    append gp_args " -timing_driven"
+                }
+                if {[est_flag GPL_ROUTABILITY_DRIVEN 0] == 1} {
+                    append gp_args " -routability_driven"
+                }
+            }
+            if {[est_flag GPL_VIRTUAL_CTS 0] == 1} {
+                append gp_args " -virtual_cts"
+            }
+            append gp_args " [est_args GP_ARGS]"
+
+            eval global_placement $gp_args
+        }
+
+        if {$place_ios == 1} {
+            time_phase place_pins { est_place_pins }
+        }
+
+        estimate_parasitics -placement
+    }
+}
+
+# 6. Clock tree.  The ground truth is a post-CTS ODB read back with
+# propagated clocks, so an ideal clock here does not merely lose skew: on
+# a design with macros the clock insertion latency does not cancel and
+# lands directly in min_period = clk_period - slack.  CLOCK_MODE picks
+# how much of that gap to buy back:
+#   none        - ideal clock (the old behaviour, kept as a rung)
+#   propagated  - set_propagated_clock with no tree to propagate
+#   real        - clock_tree_synthesis, as ORFS runs it
+# The virtual clock tree is gpl's -virtual_cts (GPL_VIRTUAL_CTS above),
+# since it happens inside global placement rather than after it.
+proc est_stage_clock { } {
+    set clock_mode [est_flag CLOCK_MODE none]
+    if {$clock_mode eq "real"} {
+        time_phase cts {
+            # ORFS runs CTS on a legalized placement (3_place.odb).  Whether
+            # TritonCTS tolerates raw global-placement output is what
+            # CTS_DPL exists to measure.
+            if {[est_flag CTS_DPL 0] == 1} {
+                detailed_placement
+            }
+            repair_clock_inverters
+            set cts_args [list -sink_clustering_enable -repair_clock_nets]
+            eval clock_tree_synthesis $cts_args [est_args CTS_ARGS_EXTRA]
+            # Order follows ORFS cts.tcl: re-estimate straight after CTS,
+            # which has just inserted buffers and dummy loads, and only then
+            # propagate the clock.
+            estimate_parasitics -placement
+            set_propagated_clock [all_clocks]
+            estimate_parasitics -placement
+        }
+    } elseif {$clock_mode eq "propagated"} {
+        set_propagated_clock [all_clocks]
+    }
+}
+
+# Re-estimate against whichever source is current.  repair_design and
+# repair_timing open an incremental-parasitics guard that errors out
+# (EST-0104) if anything upstream -- CTS inserting buffers and dummy
+# loads, most notably -- left parasitics invalid.
+proc est_refresh_parasitics { } {
+    if {[est_flag RUN_GRT 0] == 1 && [grt::have_routes]} {
+        estimate_parasitics -global_routing
+    } else {
+        estimate_parasitics -placement
+    }
+}
+
+# 7. Repair design.  The ground-truth ODB has been through repair_design
+# and repair_timing; without them the estimate carries a systematic
+# optimism no placement knob can remove.
+proc est_stage_repair_design { } {
+    if {[est_flag RUN_REPAIR_DESIGN 0] == 1} {
+        time_phase repair_design {
+            est_refresh_parasitics
+            eval repair_design [est_args REPAIR_DESIGN_ARGS]
+            est_refresh_parasitics
+        }
+    }
+}
+
+# 8. Global Routing
+proc est_stage_grt { } {
+    if {[est_flag RUN_GRT 0] == 1} {
+        time_phase global_route {
+            set grt_args "-congestion_iterations [est_flag GRT_ITERATIONS 1]"
+            append grt_args " [est_args GRT_ARGS]"
+            eval global_route $grt_args
+        }
+        estimate_parasitics -global_routing
+    }
+}
+
+# 9. Repair timing.  Hold repair is deliberately absent: the metric is
+# the minimum clock period, so -hold can only cost runtime.
+proc est_stage_repair_timing { } {
+    if {[est_flag RUN_REPAIR_TIMING 0] == 1} {
+        time_phase repair_timing {
+            est_refresh_parasitics
+            eval repair_timing -setup [est_args REPAIR_TIMING_ARGS]
+            est_refresh_parasitics
+        }
+    }
+}
+
+# Per-path features, for the question calibration cannot touch.
+#
+# Any correction that reads only the estimate is a monotone function of
+# it and so cannot reorder the paths -- which is exactly what the
+# estimator gets wrong.  Reordering needs to know something about the
+# individual path, and the obvious candidate is how far it physically
+# reaches: the error is wire-related, and a path whose endpoints sit far
+# apart has more room for the router to add detour than a local one.
+# Gated because it costs an ODB lookup per path and only the feature
+# study wants it.
+proc est_pin_xy { name } {
+    set blk [ord::get_db_block]
+    # Split on the last separator and go via the instance: findITerm on
+    # the block does not resolve the names OpenSTA reports for escaped
+    # Verilog identifiers like sum_stage1[2][78]$_DFF_PP0_/QN.
+    # ODB stores escaped Verilog identifiers -- sum_stage1\[0\]\[42\] --
+    # while OpenSTA reports them unescaped, so a direct lookup of the
+    # name STA gives back finds nothing at all.
+    set idx [string last "/" $name]
+    if {$idx > 0} {
+        set inst_name [string range $name 0 [expr {$idx - 1}]]
+        set term_name [string range $name [expr {$idx + 1}] end]
+        set inst [$blk findInst $inst_name]
+        if {$inst eq "NULL"} {
+            set inst [$blk findInst \
+                [string map [list "\[" "\\\[" "\]" "\\\]"] $inst_name]]
+        }
+        if {$inst ne "NULL"} {
+            set it [$inst findITerm $term_name]
+            if {$it ne "NULL"} {
+                set is_macro [[$inst getMaster] isBlock]
+                set net [$it getNet]
+                set fan [expr {$net eq "NULL" ? 0 : [$net getITermCount]}]
+                lassign [$it getAvgXY] ok x y
+                if {$ok} { return [list $x $y $is_macro $fan] }
+                lassign [$inst getOrigin] x y
+                return [list $x $y $is_macro $fan]
+            }
+        }
+    }
+    set bt [$blk findBTerm $name]
+    if {$bt ne "NULL"} {
+        set bb [$bt getBBox]
+        return [list [expr {([$bb xMin] + [$bb xMax]) / 2}] \
+                     [expr {([$bb yMin] + [$bb yMax]) / 2}] 0 0]
+    }
+    return {}
+}
+
+proc est_features { start end } {
+    set a [est_pin_xy $start]
+    set b [est_pin_xy $end]
+    if {[llength $a] == 0 || [llength $b] == 0} {
+        return "\"dist_um\": -1, \"macro_ends\": 0, \"fanout\": 0"
+    }
+    lassign $a ax ay amacro afan
+    lassign $b bx by bmacro bfan
+    set dbu [[[ord::get_db] getTech] getDbUnitsPerMicron]
+    set dist [expr {(abs($ax - $bx) + abs($ay - $by)) / double($dbu)}]
+    return "\"dist_um\": $dist, \"macro_ends\": [expr {$amacro + $bmacro}], \"fanout\": [expr {$afan + $bfan}]"
+}
+
+# Measure Target Paths against Ground Truth.  Deliberately outside the
+# estimate clock: the study measures how long until a timing signal is
+# available, not how long it takes to interrogate it.
+proc est_measure_paths { } {
+    set sampled_file [string trim $::env(GROUND_TRUTH_JSON) "'\""]
+    set fp [open $sampled_file r]
+    set path_data [read $fp]
+    close $fp
+
+    set target_paths []
+    foreach line [split $path_data "\n"] {
+        if {[regexp {"start": "([^"]+)", "end": "([^"]+)"} $line match start end]} {
+            lappend target_paths [list $start $end]
+        }
+    }
+
+    set sta_start [clock clicks -milliseconds]
+    set ::measured []
+    foreach pt $target_paths {
+        set start [lindex $pt 0]
+        set end [lindex $pt 1]
+        set paths [find_timing_paths -sort_by_slack -group_path_count 1 -from $start -to $end]
+
+        if {[llength $paths] == 0} {
+            error "No timing path found from $start to $end"
+        }
+        set slack [get_property [lindex $paths 0] slack]
+        set clk_period [get_property [lindex [get_clocks] 0] period]
+        lappend ::measured [list $start $end [expr {$clk_period - $slack}]]
+    }
+    # OpenSTA builds the timing graph and computes delays on the first
+    # query, so this is not bookkeeping around the result -- it is where a
+    # large part of the work happens, and on a rung that runs no flow stages
+    # it is very nearly all of it.
+    set sta_s [expr {([clock clicks -milliseconds] - $sta_start) / 1000.0}]
+    dict set ::phase_times sta $sta_s
+}
+
+proc est_write_json { out_json load_s estimate_s sta_s } {
+    set total_s [expr {$load_s + $estimate_s + $sta_s}]
+    set out_fp [open $out_json w]
+    puts $out_fp "{"
+    puts $out_fp "\"runtime_s\": $total_s,"
+    puts $out_fp "\"load_s\": $load_s,"
+    puts $out_fp "\"estimate_s\": $estimate_s,"
+    puts $out_fp "\"sta_s\": $sta_s,"
+    puts $out_fp "\"phases\": \{"
+    set phase_first 1
+    foreach {phase_name phase_s} $::phase_times {
+        if {$phase_first == 0} { puts $out_fp "," }
+        set phase_first 0
+        puts -nonewline $out_fp "  \"$phase_name\": $phase_s"
+    }
+    puts $out_fp ""
+    puts $out_fp "\},"
+    puts $out_fp "\"paths\": \["
+
+    set is_first 1
+    foreach m $::measured {
+        lassign $m start end min_period
+        if {$is_first == 0} { puts $out_fp "," }
+        set is_first 0
+        set extra ""
+        if {[est_flag DUMP_FEATURES 0] == 1} {
+            set extra ", [est_features $start $end]"
+        }
+        puts -nonewline $out_fp "  {\"start\": \"$start\", \"end\": \"$end\", \"min_period\": $min_period$extra}"
+    }
+    puts $out_fp ""
+    puts $out_fp "\]"
+    puts $out_fp "}"
+    close $out_fp
+}

--- a/test/estimation_ladder/measure_runtime.py
+++ b/test/estimation_ladder/measure_runtime.py
@@ -6,6 +6,15 @@ time so nothing competes for the machine, with whatever thread count
 ORFS hands the tool -- the question is how fast the estimator goes on
 the whole machine, not how it behaves pinned to one core.
 
+This rung deliberately does NOT use the fork/join batch mode rung A runs
+on: its whole contract is wall-clock purity of a standalone run, and a
+tree walk replaces the repeated measurements of the shared prefix with a
+single one, quietly changing what repeat convergence means.  If this
+rung ever needs the speedup, the honest variant is batching the REPEATS
+of one configuration (the same config N times in one manifest), which
+measures the load phase once -- the per-phase surrogate already treats
+load as its own phase.
+
 Measuring every archived configuration would cost hours, and measuring
 an arbitrary ten of them tends to produce ten points bunched at one end
 of the range.  Which configurations would spread the front out is not

--- a/test/estimation_ladder/optuna_study.py
+++ b/test/estimation_ladder/optuna_study.py
@@ -16,6 +16,7 @@ of the archive this rung writes.
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 
@@ -200,6 +201,98 @@ def run_estimator(estimator_exe, env, ground_truth_json, timeout_s=None, out_jso
     return metrics
 
 
+def run_estimator_batch(
+    estimator_exe,
+    envs_by_id,
+    ground_truth_json,
+    timeout_s=None,
+    parallel=False,
+    subtree_timeout_s=None,
+):
+    """Run many configurations in ONE estimator process.
+
+    The estimator walks the configurations as a decision tree, forking at
+    each divergence (see estimator_batch.tcl), so a stage shared by two
+    trials -- most importantly the design load and floorplan every trial
+    shares -- is paid once instead of once per trial.
+
+    The walk is sequential by default (one active run owns the machine,
+    the honest setting for anything that reads runtimes); parallel=True
+    forks divergent subtrees concurrently, which restores the old
+    jobs-style concurrency for accuracy-only callers.
+
+    Returns {id: metrics or None}: an id whose subtree crashed has no leaf
+    JSON and maps to None, while its siblings still report.
+    """
+    work = tempfile.mkdtemp(prefix="est_batch_")
+    manifest_dir = os.path.join(work, "manifest")
+    results_dir = os.path.join(work, "results")
+    os.makedirs(manifest_dir)
+    os.makedirs(results_dir)
+    ground_truth = os.path.abspath(ground_truth_json)
+    try:
+        for cid, env in envs_by_id.items():
+            with open(os.path.join(manifest_dir, f"{cid}.cfg"), "w") as f:
+                for key, value in env.items():
+                    f.write(f"{key}={value}\n")
+
+        cmd = [
+            estimator_exe,
+            f"EST_MANIFEST_DIR={manifest_dir}",
+            f"EST_RESULTS_DIR={results_dir}",
+            f"GROUND_TRUTH_JSON={ground_truth}",
+            f"LOG_DIR={work}",
+        ]
+        if parallel:
+            cmd.append("EST_PARALLEL=1")
+            # Every forked child inherits the tool's thread count; a wave
+            # of concurrent subtrees each sized for the whole machine is
+            # oversubscription, not speed. Divide the machine instead.
+            threads = max(1, (os.cpu_count() or 8) // max(1, len(envs_by_id)))
+            cmd.append(f"NUM_CORES={threads}")
+        if subtree_timeout_s is not None:
+            # The batch-level timeout below is a backstop; this is the
+            # per-trial budget, enforced inside the walk (a runaway
+            # subtree is killed, its siblings still report).
+            cmd.append(f"EST_SUBTREE_TIMEOUT={subtree_timeout_s}")
+        try:
+            res = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            raise TimeoutError(f"estimator batch exceeded {timeout_s}s")
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"estimator batch exited {res.returncode}\n"
+                f"stdout: {res.stdout[-4000:]}\nstderr: {res.stderr[-4000:]}"
+            )
+
+        results = {}
+        for cid in envs_by_id:
+            leaf = os.path.join(results_dir, f"{cid}.json")
+            if os.path.exists(leaf):
+                metrics, _ = compute_metrics(ground_truth, leaf)
+                results[cid] = metrics
+            else:
+                results[cid] = None
+        return results
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def objective_values(metrics, subset):
+    """The study's two objectives, or ValueError if the subset is empty.
+
+    Maximizing rank correlation and minimizing the *magnitude* of the
+    bias: a large bias that is consistent is a calibration constant, so
+    it should not be penalized by its sign.
+    """
+    suffix = "" if subset == "all" else f"_{subset}"
+    tau = metrics.get(f"kendall_tau{suffix}")
+    bias = metrics.get(f"bias{suffix}")
+    if tau is None or bias is None or tau != tau:
+        raise ValueError(f"no {subset} metrics for this trial")
+    return tau, abs(bias)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("estimator_exe")
@@ -225,6 +318,30 @@ def main():
         default=1800.0,
         help="seconds before a single estimator run is abandoned",
     )
+    ap.add_argument(
+        "--batch-size",
+        type=int,
+        default=0,
+        help=(
+            "run trials in fork/join batches of this size: one estimator "
+            "process walks each batch as a decision tree, paying shared "
+            "stages (load, floorplan, common placements) once instead of "
+            "once per trial. 0 keeps the one-process-per-trial behavior. "
+            "--jobs applies only to that legacy mode; the batch walk is "
+            "sequential by default, one active run at a time. The batch "
+            "timeout is --trial-timeout times the batch size."
+        ),
+    )
+    ap.add_argument(
+        "--batch-parallel",
+        action="store_true",
+        help=(
+            "fork divergent subtrees of a batch concurrently instead of "
+            "sequentially. Runtime numbers become contention-contaminated, "
+            "so this is for accuracy-only sweeps (this rung's purpose) and "
+            "the machinery test; leave it off when runtimes matter."
+        ),
+    )
     args = ap.parse_args()
 
     for path in (args.estimator_exe, args.ground_truth_json):
@@ -232,6 +349,13 @@ def main():
             raise SystemExit(f"not found: {path}")
 
     archive = []
+
+    def record(trial, env, metrics):
+        trial.set_user_attr("env", env)
+        for key, value in metrics.items():
+            if key != "phases":
+                trial.set_user_attr(key, value)
+        archive.append({"number": trial.number, "env": env, "metrics": metrics})
 
     def objective(trial):
         env = build_env(trial)
@@ -241,31 +365,47 @@ def main():
             args.ground_truth_json,
             timeout_s=args.trial_timeout,
         )
-        trial.set_user_attr("env", env)
-        for key, value in metrics.items():
-            if key != "phases":
-                trial.set_user_attr(key, value)
-        archive.append({"number": trial.number, "env": env, "metrics": metrics})
-        # Maximizing rank correlation and minimizing the *magnitude* of
-        # the bias: a large bias that is consistent is a calibration
-        # constant, so it should not be penalized by its sign.
-        suffix = "" if args.subset == "all" else f"_{args.subset}"
-        tau = metrics.get(f"kendall_tau{suffix}")
-        bias = metrics.get(f"bias{suffix}")
-        if tau is None or bias is None or tau != tau:
-            raise ValueError(f"no {args.subset} metrics for this trial")
-        return tau, abs(bias)
+        record(trial, env, metrics)
+        return objective_values(metrics, args.subset)
 
     study = optuna.create_study(
         directions=["maximize", "minimize"],
         sampler=optuna.samplers.NSGAIISampler(seed=1),
     )
-    study.optimize(
-        objective,
-        n_trials=args.trials,
-        n_jobs=args.jobs,
-        catch=(RuntimeError, ValueError, TimeoutError),
-    )
+    if args.batch_size > 0:
+        done = 0
+        while done < args.trials:
+            wave = min(args.batch_size, args.trials - done)
+            trials = [study.ask() for _ in range(wave)]
+            envs = {str(t.number): build_env(t) for t in trials}
+            batch = run_estimator_batch(
+                args.estimator_exe,
+                envs,
+                args.ground_truth_json,
+                timeout_s=args.trial_timeout * wave,
+                parallel=args.batch_parallel,
+                subtree_timeout_s=args.trial_timeout,
+            )
+            for t in trials:
+                metrics = batch.get(str(t.number))
+                try:
+                    if metrics is None:
+                        raise RuntimeError("subtree crashed; no leaf JSON")
+                    values = objective_values(metrics, args.subset)
+                except (RuntimeError, ValueError) as e:
+                    print(f"trial {t.number} failed: {e}")
+                    study.tell(t, state=optuna.trial.TrialState.FAIL)
+                    continue
+                record(t, envs[str(t.number)], metrics)
+                study.tell(t, values)
+            done += wave
+    else:
+        study.optimize(
+            objective,
+            n_trials=args.trials,
+            n_jobs=args.jobs,
+            catch=(RuntimeError, ValueError, TimeoutError),
+        )
 
     ws = os.environ.get("BUILD_WORKSPACE_DIRECTORY") or os.environ.get("PWD", ".")
     out_dir = os.path.join(ws, "test/estimation_ladder")

--- a/test/estimation_ladder/optuna_study.py
+++ b/test/estimation_ladder/optuna_study.py
@@ -208,6 +208,7 @@ def run_estimator_batch(
     timeout_s=None,
     parallel=False,
     subtree_timeout_s=None,
+    keep_results_dir=None,
 ):
     """Run many configurations in ONE estimator process.
 
@@ -273,6 +274,10 @@ def run_estimator_batch(
                 results[cid] = metrics
             else:
                 results[cid] = None
+        if keep_results_dir:
+            # Preserve the wave's leaf JSONs and edges.jsonl (the per-edge
+            # instrumentation wave_savings.py aggregates).
+            shutil.copytree(results_dir, keep_results_dir)
         return results
     finally:
         shutil.rmtree(work, ignore_errors=True)
@@ -333,6 +338,17 @@ def main():
         ),
     )
     ap.add_argument(
+        "--keep-waves",
+        default="",
+        metavar="DIR",
+        help=(
+            "preserve each batch wave's results folder (leaf JSONs plus "
+            "edges.jsonl) under DIR/wave_NNN, for wave_savings.py to "
+            "estimate what a resident-root or snapshot-cache mode would "
+            "have saved across the study"
+        ),
+    )
+    ap.add_argument(
         "--batch-parallel",
         action="store_true",
         help=(
@@ -374,10 +390,14 @@ def main():
     )
     if args.batch_size > 0:
         done = 0
+        wave_number = 0
         while done < args.trials:
             wave = min(args.batch_size, args.trials - done)
             trials = [study.ask() for _ in range(wave)]
             envs = {str(t.number): build_env(t) for t in trials}
+            keep = None
+            if args.keep_waves:
+                keep = os.path.join(args.keep_waves, f"wave_{wave_number:03d}")
             batch = run_estimator_batch(
                 args.estimator_exe,
                 envs,
@@ -385,7 +405,9 @@ def main():
                 timeout_s=args.trial_timeout * wave,
                 parallel=args.batch_parallel,
                 subtree_timeout_s=args.trial_timeout,
+                keep_results_dir=keep,
             )
+            wave_number += 1
             for t in trials:
                 metrics = batch.get(str(t.number))
                 try:

--- a/test/estimation_ladder/optuna_study_test.py
+++ b/test/estimation_ladder/optuna_study_test.py
@@ -7,8 +7,12 @@ design, whose near-critical paths are dominated by wires that do not
 exist until placement, must be estimated *worse* by a synthesis-only
 rung than the small wire-poor design is.
 
-It runs the trials concurrently on purpose. Only the runtime axis is
-sensitive to that, and this test does not look at runtime.
+It runs all trials as ONE fork/join batch per design: a single estimator
+process walks the trials as a decision tree, so the design load and every
+shared stage are paid once instead of once per trial -- a machinery check
+for the batch mode itself.  The walk forks divergent subtrees in parallel
+(--batch-parallel) on purpose: only the runtime axis is sensitive to
+contention, and this test does not look at runtime.
 """
 
 import json
@@ -19,7 +23,11 @@ import sys
 import tempfile
 
 TRIALS = "8"
-JOBS = "8"
+BATCH_SIZE = TRIALS
+# Machinery check, not a study: a trial too slow for this budget is told
+# FAIL and the archive assertions run on the survivors, keeping the whole
+# test comfortably inside bazel's test timeout.
+TRIAL_TIMEOUT = "600"
 
 
 def run_study(study_exe, estimator_exe, ground_truth, design_name, env):
@@ -32,8 +40,11 @@ def run_study(study_exe, estimator_exe, ground_truth, design_name, env):
             design_name,
             "--trials",
             TRIALS,
-            "--jobs",
-            JOBS,
+            "--batch-size",
+            BATCH_SIZE,
+            "--batch-parallel",
+            "--trial-timeout",
+            TRIAL_TIMEOUT,
         ],
         env=env,
         capture_output=True,

--- a/test/estimation_ladder/wave_savings.py
+++ b/test/estimation_ladder/wave_savings.py
@@ -1,0 +1,98 @@
+"""Decide whether a resident estimator is worth building, from data.
+
+The fork/join batch walk logs every executed tree edge (its trie path,
+stage, and seconds) into edges.jsonl. Run a study with --keep-waves DIR
+and point this tool at DIR: it reports, per wave and in total,
+
+  * realized saving  -- what the walk already saved against naive
+    one-process-per-trial (sum of the leaves' path costs minus the sum
+    of executed edges);
+  * resident-root    -- what keeping one loaded process alive between
+    waves would additionally have saved (load + floorplan of every wave
+    after the first);
+  * snapshot-cache   -- the upper bound on keeping every suspended
+    branch-point snapshot alive across waves: the time spent
+    re-computing an edge (same trie path, same stage) an earlier wave
+    had already paid for.
+
+Build the resident mode when resident-root/snapshot-cache numbers are
+large against total study time; until then the complexity is not paid
+for.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+
+def read_edges(wave_dir):
+    path = os.path.join(wave_dir, "edges.jsonl")
+    edges = []
+    if not os.path.exists(path):
+        return edges
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                edges.append(json.loads(line))
+    return edges
+
+
+def leaf_runtimes(wave_dir):
+    total = 0.0
+    for leaf in glob.glob(os.path.join(wave_dir, "*.json")):
+        if os.path.basename(leaf) == "edges.jsonl":
+            continue
+        with open(leaf) as f:
+            data = json.load(f)
+        if "runtime_s" in data:
+            total += data["runtime_s"]
+    return total
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("study_dir", help="directory holding wave_*/ results")
+    args = ap.parse_args()
+
+    waves = sorted(glob.glob(os.path.join(args.study_dir, "wave_*")))
+    if not waves:
+        sys.exit(f"no wave_* directories under {args.study_dir}")
+
+    seen = set()
+    total_edges = total_naive = resident_root = snapshot_cache = 0.0
+    print(f"{'wave':<12}{'edges_s':>10}{'naive_s':>10}{'repeated_s':>12}")
+    for i, wave_dir in enumerate(waves):
+        edges = read_edges(wave_dir)
+        edges_s = sum(e["seconds"] for e in edges)
+        naive_s = leaf_runtimes(wave_dir)
+        repeated = 0.0
+        for e in edges:
+            key = (e["path"], e["stage"])
+            if e["stage"] in ("load", "floorplan"):
+                if i > 0:
+                    resident_root += e["seconds"]
+            if key in seen:
+                repeated += e["seconds"]
+            else:
+                seen.add(key)
+        total_edges += edges_s
+        total_naive += naive_s
+        snapshot_cache += repeated
+        print(
+            f"{os.path.basename(wave_dir):<12}{edges_s:>10.1f}"
+            f"{naive_s:>10.1f}{repeated:>12.1f}"
+        )
+
+    print()
+    print(f"executed (fork/join):        {total_edges:>10.1f} s")
+    print(f"naive one-per-trial cost:    {total_naive:>10.1f} s")
+    print(f"realized saving:             {total_naive - total_edges:>10.1f} s")
+    print(f"resident-root would save:    {resident_root:>10.1f} s")
+    print(f"snapshot-cache upper bound:  {snapshot_cache:>10.1f} s")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/fork_smoke.tcl
+++ b/test/fork_smoke.tcl
@@ -1,0 +1,43 @@
+# fork/join smoke on real OpenROAD: a nested tree walk after load_design,
+# an OpenSTA query in every leaf (exercising the thread-pool-after-fork
+# hazard), one JSON per leaf in $RUN_OUTPUT_DIR, and a deliberate failing
+# leaf that must not stop the walk.
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 2_floorplan.odb 2_floorplan.sdc
+
+source $::env(ORFS_FORK_TCL)
+
+set dir $::env(RUN_OUTPUT_DIR)
+
+set statuses [fork branch {a b} {
+    set inner [fork leaf {1 2} {
+        if {$branch eq "b" && $leaf == 2} {
+            error "deliberate failure"
+        }
+        # Timing queries build the graph with OpenSTA's thread pool; a
+        # forked child has only one thread, so this proves the pool comes
+        # back (or degrades safely) after fork.
+        report_tns
+        set f [open $dir/$branch$leaf.json w]
+        puts $f "{\"branch\": \"$branch\", \"leaf\": $leaf}"
+        close $f
+    }]
+    set bad 0
+    dict for {_ code} $inner {
+        if {$code != 0} {
+            set bad 1
+        }
+    }
+    ::orfs::posix_exit $bad
+}]
+
+if {$statuses ne {a 0 b 1}} {
+    puts stderr "unexpected statuses: $statuses"
+    exit 1
+}
+set got [lsort [glob -directory $dir -tails *.json]]
+if {$got ne {a1.json a2.json b1.json}} {
+    puts stderr "unexpected leaves: $got"
+    exit 1
+}
+puts "fork smoke ok"

--- a/test/run_out_dir.tcl
+++ b/test/run_out_dir.tcl
@@ -1,0 +1,12 @@
+# Exercises orfs_run's out_dir: the script decides at runtime what files
+# to put in $RUN_OUTPUT_DIR. Kept to the mock-openroad Tcl subset so the
+# capability is tested fast in CI.
+set dir $::env(RUN_OUTPUT_DIR)
+
+set f [open $dir/alpha.txt w]
+puts $f "alpha"
+close $f
+
+set f [open $dir/beta.txt w]
+puts $f "beta"
+close $f

--- a/test/run_out_dir_test.sh
+++ b/test/run_out_dir_test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+dir="$1"
+for name in alpha beta; do
+    if ! grep -q "$name" "$dir/$name.txt"; then
+        echo "FAIL: $dir/$name.txt missing or wrong content" >&2
+        exit 1
+    fi
+done
+echo "out_dir contents ok"


### PR DESCRIPTION
Stacked on #826 (the fork/join idiom); only the top two commits are new here. Retarget to `main` after #826 merges.

## Why

Every estimator trial was a fresh OpenROAD process re-running the shared prefix. The knob space is a tree — the stage order is fixed — so one process can walk a whole batch of configurations, forking a copy-on-write snapshot where they diverge and paying every shared stage exactly once.

## What

- `estimator.tcl` splits into a thin entry, `estimator_lib.tcl` (stage procs, knob lookup with a batch overlay, path measurement, leaf writer) and `estimator_batch.tcl` (the walk): a manifest directory of `<id>.cfg` KEY=VALUE files is grouped stage by stage into a trie; each leaf writes `EST_RESULTS_DIR/<id>.json`; a crashed or overrunning subtree (`EST_SUBTREE_TIMEOUT`) loses only its own leaves. Per-leaf phase attribution is exact for free: fork inherits `::phase_times`, so a leaf's dict holds the phases on its own root path. The single-config mode is unchanged.
- `optuna_study.py` gains `--batch-size` (ask/tell waves, one estimator invocation per wave) and `--batch-parallel` (fork divergent subtrees concurrently, dividing `NUM_CORES` across the wave) for accuracy-only callers. Sequential remains the default so runtime numbers stay honest — which is also why `measure_runtime.py` deliberately stays one-process-per-trial (documented).
- **Instrumentation instead of speculation** for a future resident/snapshot-cache mode: the walk logs every executed edge (trie path, stage, seconds) to `edges.jsonl`; `--keep-waves DIR` preserves each wave; `wave_savings.py` reports what the walk already saved, what a resident root would add (repeated load+floorplan), and the snapshot-cache upper bound (edges an earlier wave already paid for). Build the resident mode only if those numbers come back large.

## Measured

`optuna_study_test` runs its 8 trials as one parallel batch per design — 2 OpenROAD processes instead of 16. Same machine, same 600s per-trial budget:

| mode | wall |
|---|---|
| legacy one-process-per-trial, `--jobs 8` | 661 s |
| fork/join batch | **178 s (3.7×)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)