### PR TITLE
Bump ORFS/OpenROAD and stop resynthesizing on period-preserving SDC edits

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,19 +45,19 @@ bazel_dep(name = "orfs")
 # blocked (e.g. inside the maintainers organization).
 archive_override(
     module_name = "orfs",
-    integrity = "sha256-msMzEaX0tultTr1dYB7GCFIZwJbnN0P+6W35dKVKG6U=",
+    integrity = "sha256-hAos8HgYSs5NZlc3wWPKCT7dbZB23Poyqo4cqha6YwA=",
     patch_strip = 1,
     patches = [
         "//patches:0037-orfs-single-writer-1_synth-sdc.patch",
     ],
-    strip_prefix = "OpenROAD-flow-scripts-8c009b0b663703fc3fe2f474eab918b12fffbaf6",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/8c009b0b663703fc3fe2f474eab918b12fffbaf6.tar.gz"],
+    strip_prefix = "OpenROAD-flow-scripts-427bd762b7b7448f8bb6bc4e14207aa3963fca30",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/427bd762b7b7448f8bb6bc4e14207aa3963fca30.tar.gz"],
 )
 
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-qjGwZR/PLR/BZz1KsPzZVO38VC9a3Rk02QFPw7s3Dts=",
+    integrity = "sha256-Jv0jwVu6+XuTJycvfoVpcf5C2MWH29Hs+eOxjHASwFQ=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -71,8 +71,8 @@ archive_override(
         "find . -name BUILD -exec sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|g' {} +",
         "sed -i 's|defines = \\[|copts = [\"-include\", \"fmt/format.h\"],\\n    defines = [|' src/syn/src/elab/BUILD third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-f34c1bcd954a4ecfe33233466e03782cb2d5442d",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/f34c1bcd954a4ecfe33233466e03782cb2d5442d.tar.gz"],
+    strip_prefix = "OpenROAD-21512b0ab68cc3bc7e11a772e1ec32f6f90e0eec",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/21512b0ab68cc3bc7e11a772e1ec32f6f90e0eec.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.
@@ -181,7 +181,7 @@ pycross.configure_environments(python_versions = ["3.13"])
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "541ebf6df76eef96c4de6343316b1c9d63e296f6",
+    commit = "5587ebcaf61bab7abe8e69c4db6d068b35562245",
     # openroad-qt is on a deprecation track; we don't expect Qt to change much.
     # Build xcb-util-cursor from source so the Qt xcb platform plugin
     # doesn't depend on the host having libxcb-cursor0 installed.

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -215,6 +215,21 @@ def data_inputs(ctx):
                      [datum.data_runfiles.symlinks for datum in ctx.attr.data],
     )
 
+def data_inputs_excluding(ctx, exclude_path):
+    """data_inputs() minus the file at ``exclude_path``.
+
+    Used by the synth rule to drop the raw SDC from the expensive yosys
+    actions once the clock period has been extracted into its own
+    artifact: the yosys side reads only SDC_FILE_CLOCK_PERIOD
+    (synth_preamble.tcl), so keeping the raw SDC as an input would
+    re-run synthesis on every SDC edit, period-preserving or not.
+    """
+    return depset([
+        f
+        for f in data_inputs(ctx).to_list()
+        if f.path != exclude_path
+    ])
+
 def source_inputs(ctx):
     return depset(
         ctx.files.src,

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -20,6 +20,7 @@ load(
     "config_environment",
     "data_arguments",
     "data_inputs",
+    "data_inputs_excluding",
     "declare_artifact",
     "declare_artifacts",
     "deps_inputs",
@@ -1023,13 +1024,19 @@ SYNTH_OUTPUTS = ["1_2_yosys.v", "1_2_yosys.sdc", "mem.json"]
 SYN_OUTPUTS = ["1_synth.odb", "1_synth.sdc", "1_synth.v"]
 SYNTH_REPORTS = ["synth_stat.txt", "synth_mocked_memories.txt"]
 
-def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments = {}):
+def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments = {}, clock_period = None, sdc_overrides = [], synth_data_inputs = None):
     """Parallel synthesis: keep → kept-json → N partitions → merge.
 
     Yosys is not deterministic when using host threads, so SYNTH_NUM_PARTITIONS
     defaulting to NUM_CPUS means synthesis results vary across machines with
     different core counts. Users who need reproducible builds should set a fixed
     SYNTH_NUM_PARTITIONS value.
+
+    clock_period / sdc_overrides / synth_data_inputs carry the caller's
+    clock-period extraction (see _yosys_impl): the preamble-sourcing yosys
+    actions (keep, partitions, top) read SDC_FILE_CLOCK_PERIOD instead of
+    the raw SDC, whose only legitimate consumers here are the sdc-copy and
+    do-1_synth actions.
 
     When SYNTH_KEEP_MODULES is provided, the keep-hierarchy discovery step
     (synth_keep.tcl + rtlil_kept_modules.py) is skipped entirely.  The module
@@ -1051,6 +1058,9 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
     )
     yosys_and_flow_tools = depset(transitive = [yosys_inputs(ctx), flow_inputs(ctx)])
     parallel_makefile = ctx.file._parallel_synth_makefile
+    if synth_data_inputs == None:
+        synth_data_inputs = data_inputs(ctx)
+    clock_period_inputs = [clock_period] if clock_period else []
 
     kept_json = declare_artifact(ctx, "results", "kept_modules.json")
     skip_keep = all_arguments.get("SYNTH_KEEP_MODULES", "")
@@ -1080,14 +1090,14 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 "yosys-dependencies",
                 "do-yosys-keep",
                 "SYNTH_KEEP_SCRIPT=" + ctx.file._synth_keep_script.path,
-            ],
+            ] + sdc_overrides,
             command = " && ".join(keep_commands),
             env = base_env,
             inputs = depset(
                 [canon_output, config, parallel_makefile, ctx.file._synth_keep_script] +
-                ctx.files.extra_configs,
+                clock_period_inputs + ctx.files.extra_configs,
                 transitive = [
-                    data_inputs(ctx),
+                    synth_data_inputs,
                     pdk_inputs(ctx),
                     deps_inputs(ctx),
                 ],
@@ -1214,7 +1224,11 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 parallel_makefile.path,
                 "do-yosys-canonicalize-module",
                 "SYNTH_CANONICALIZE_MODULE_SCRIPT=" + ctx.file._synth_canonicalize_module_script.path,
-            ],
+                # No yosys-dependencies goal and no synth_preamble.tcl here,
+                # so the clock period is never read — only the raw SDC needs
+                # to stay out (dangling-path hygiene; the input set below
+                # already excludes it).
+            ] + (["SDC_FILE="] if sdc_overrides else []),
             command = " && ".join(per_module_commands),
             env = base_env | partition_env_extra | {
                 "SYNTH_CHECKPOINT": checkpoint_output.path,
@@ -1239,7 +1253,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                     ctx.file._synth_canonicalize_module_script,
                 ] + extra_partition_inputs + ctx.files.extra_configs,
                 transitive = [
-                    data_inputs(ctx),
+                    synth_data_inputs,
                     pdk_inputs(ctx),
                 ],
             ),
@@ -1261,10 +1275,10 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
             parallel_makefile,
             ctx.file._synth_partition_script,
             ctx.file._synth_tcl,
-        ] + extra_partition_inputs +
+        ] + clock_period_inputs + extra_partition_inputs +
         ctx.files.extra_configs,
         transitive = [
-            data_inputs(ctx),
+            synth_data_inputs,
             pdk_inputs(ctx),
         ],
     )
@@ -1488,7 +1502,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 "yosys-dependencies",
                 "do-yosys-partition",
                 "SYNTH_PARTITION_SCRIPT=" + ctx.file._synth_partition_script.path,
-            ],
+            ] + sdc_overrides,
             command = " && ".join(part_commands),
             env = base_env | partition_env_extra | partition_env_override | {
                 "SYNTH_PARTITION_ID": str(i),
@@ -1520,7 +1534,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
             "yosys-dependencies",
             "do-yosys-partition",
             "SYNTH_PARTITION_SCRIPT=" + ctx.file._synth_partition_script.path,
-        ],
+        ] + sdc_overrides,
         command = " && ".join(top_commands),
         env = base_env | partition_env_extra | {
             "SYNTH_PARTITION_ID": "top",
@@ -1753,6 +1767,52 @@ def _yosys_impl(ctx):
     # come through arguments/stage_arguments, not extra_arguments .json files.
     use_syn = all_arguments.get("SYNTH_USE_SYN") == "1"
 
+    # Clock-period extraction. The yosys side never reads the raw SDC:
+    # synth_preamble.tcl consumes only SDC_FILE_CLOCK_PERIOD (the abc -D
+    # value), which ORFS's do-sdc-clock-period target derives from the SDC
+    # in a make blink. Run that derivation as its own cheap action so a
+    # period-preserving SDC edit re-runs only this step; the expensive
+    # yosys actions get SDC_FILE_CLOCK_PERIOD=<artifact> and SDC_FILE=
+    # (empty — variables.mk guards every SDC_FILE use with $(wildcard))
+    # on the make command line and the raw SDC dropped from their inputs.
+    # SDC_FILE_CLOCK_PERIOD is not in variables.yaml, so it must ride the
+    # command line, not the config. The SYNTH_USE_SYN engine bypasses
+    # yosys and reads SDC_FILE directly, so it keeps the raw SDC.
+    sdc_file_raw = all_arguments.get("SDC_FILE")
+    sdc_path = ctx.expand_location(sdc_file_raw, ctx.attr.data) if sdc_file_raw else None
+    clock_period = None
+    sdc_overrides = []
+    synth_data_inputs = data_inputs(ctx)
+    if sdc_path and not use_syn:
+        clock_period = declare_artifact(ctx, "results", "clock_period.txt")
+        ctx.actions.run_shell(
+            arguments = [
+                "--file",
+                ctx.file._makefile_yosys.path,
+                "do-sdc-clock-period",
+                "SDC_FILE_CLOCK_PERIOD=" + clock_period.path,
+            ],
+            command = _make_cmd(ctx),
+            env = verilog_arguments([]) |
+                  yosys_environment(ctx) |
+                  config_environment(config),
+            inputs = depset(
+                [config] + ctx.files.extra_configs,
+                transitive = [
+                    data_inputs(ctx),
+                    pdk_inputs(ctx),
+                ],
+            ),
+            outputs = [clock_period],
+            tools = yosys_inputs(ctx),
+            progress_message = "Extracting clock period from SDC for %s" % module_top(ctx),
+        )
+        sdc_overrides = [
+            "SDC_FILE_CLOCK_PERIOD=" + clock_period.path,
+            "SDC_FILE=",
+        ]
+        synth_data_inputs = data_inputs_excluding(ctx, sdc_path)
+
     canon_logs = declare_artifacts(ctx, "logs", ["1_1_yosys_canonicalize.log"])
 
     canon_output = declare_artifact(ctx, "results", CANON_OUTPUT)
@@ -1777,15 +1837,16 @@ def _yosys_impl(ctx):
                 ctx.file._makefile_yosys.path,
                 "yosys-dependencies",
                 "do-yosys-canonicalize",
-            ],
+            ] + sdc_overrides,
             command = EXPAND_VERILOG_DIRS + " && ".join(commands),
             env = verilog_arguments(ctx.files.verilog_files) |
                   yosys_environment(ctx) |
                   config_environment(canon_config),
             inputs = depset(
-                [canon_config] + ctx.files.verilog_files + ctx.files.extra_configs,
+                [canon_config] + ([clock_period] if clock_period else []) +
+                ctx.files.verilog_files + ctx.files.extra_configs,
                 transitive = [
-                    data_inputs(ctx),
+                    synth_data_inputs,
                     pdk_inputs(ctx),
                     canon_deps,
                 ],
@@ -1881,45 +1942,97 @@ def _yosys_impl(ctx):
             progress_message = "OpenROAD-SYN synthesis for %s" % module_top(ctx),
         )
     elif num_partitions > 0:
-        validated_kept_macros_json = _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments)
+        validated_kept_macros_json = _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments, clock_period, sdc_overrides, synth_data_inputs)
     else:
+        # Serial path, split into three actions mirroring the parallel
+        # path so the raw SDC feeds only the cheap sdc-copy step:
+        #   1. sdc-copy: raw SDC -> 1_2_yosys.sdc (empty placeholder for
+        #      SYNTH_NETLIST_FILES designs with no SDC).
+        #   2. do-yosys: the expensive synthesis; reads the canonicalized
+        #      RTLIL and clock_period.txt, never the raw SDC.
+        #   3. do-1_synth (save_odb only): 1_synth.odb/.sdc from
+        #      1_2_yosys.v/.sdc.
         # SYNTH_NETLIST_FILES will not create an .rtlil file, logs,
         # reports or mem.json, so touch empty placeholders for those.
         # Primary artifacts (1_2_yosys.v/.sdc, 1_synth.odb/.sdc) are
         # deliberately excluded: a missing one must fail the action,
         # not be papered over with a touched empty file.
-        sdc_file_raw = all_arguments.get("SDC_FILE")
-        sdc_path = ctx.expand_location(sdc_file_raw, ctx.attr.data) if sdc_file_raw else None
-        commands = ([
-            "cp {sdc} {out}".format(sdc = sdc_path, out = synth_outputs["1_2_yosys.sdc"].path),
-        ] if sdc_path else [
-            "touch {out}".format(out = synth_outputs["1_2_yosys.sdc"].path),
-        ]) + [_make_cmd(ctx)] + generation_commands(
-            synth_logs + synth_reports + [synth_outputs["mem.json"]],
-        ) + json_fallback
+        serial_env = (
+            verilog_arguments([]) |
+            flow_environment(ctx) |
+            yosys_environment(ctx) |
+            config_environment(config)
+        )
+        serial_tools = depset(transitive = [yosys_inputs(ctx), flow_inputs(ctx)])
+        if sdc_path:
+            ctx.actions.run_shell(
+                command = "cp {sdc} {out}".format(
+                    sdc = sdc_path,
+                    out = synth_outputs["1_2_yosys.sdc"].path,
+                ),
+                inputs = data_inputs(ctx),
+                outputs = [synth_outputs["1_2_yosys.sdc"]],
+                progress_message = "Generating SDC for %s" % module_top(ctx),
+            )
+        else:
+            ctx.actions.write(output = synth_outputs["1_2_yosys.sdc"], content = "")
+
+        yosys_logs = [f for f in synth_logs if f.basename != "1_synth.log"]
+        odb_logs = [f for f in synth_logs if f.basename == "1_synth.log"]
+        yosys_commands = [_make_cmd(ctx)] + generation_commands(
+            yosys_logs + synth_reports + [synth_outputs["mem.json"]],
+        )
         ctx.actions.run_shell(
             arguments = [
                 "--file",
                 ctx.file._makefile_yosys.path,
                 "yosys-dependencies",
                 "do-yosys",
-            ] + (["do-1_synth"] if save_odb else []),
-            command = " && ".join(commands),
-            env = verilog_arguments([]) |
-                  flow_environment(ctx) |
-                  yosys_environment(ctx) |
-                  config_environment(config),
+            ] + sdc_overrides,
+            command = " && ".join(yosys_commands),
+            env = serial_env,
             inputs = depset(
-                [canon_output, config] + ctx.files.extra_configs,
+                [canon_output, config] +
+                ([clock_period] if clock_period else []) +
+                ctx.files.extra_configs,
                 transitive = [
-                    data_inputs(ctx),
+                    synth_data_inputs,
                     pdk_inputs(ctx),
                     deps_inputs(ctx),
                 ],
             ),
-            outputs = synth_outputs.values() + synth_logs + synth_jsons + synth_reports,
-            tools = depset(transitive = [yosys_inputs(ctx), flow_inputs(ctx)]),
+            outputs = [synth_outputs["1_2_yosys.v"], synth_outputs["mem.json"]] +
+                      yosys_logs + synth_reports,
+            tools = serial_tools,
         )
+
+        if save_odb:
+            odb_commands = [_make_cmd(ctx)] + generation_commands(odb_logs) + json_fallback
+            ctx.actions.run_shell(
+                arguments = [
+                    "--file",
+                    ctx.file._makefile_yosys.path,
+                    "do-1_synth",
+                ],
+                command = " && ".join(odb_commands),
+                env = serial_env,
+                inputs = depset(
+                    [
+                        synth_outputs["1_2_yosys.v"],
+                        synth_outputs["1_2_yosys.sdc"],
+                        config,
+                    ] + ctx.files.extra_configs,
+                    transitive = [
+                        data_inputs(ctx),
+                        pdk_inputs(ctx),
+                        deps_inputs(ctx),
+                    ],
+                ),
+                outputs = [synth_outputs["1_synth.odb"], synth_outputs["1_synth.sdc"]] +
+                          odb_logs + synth_jsons,
+                tools = serial_tools,
+                progress_message = "Building synth ODB for %s" % module_top(ctx),
+            )
 
     if not ctx.attr.lint:
         ctx.actions.run_shell(

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,6 +9,7 @@ load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
 load(":provider_test_rule.bzl", "lib_pre_layout_test")
 load(":quick_pins_test_rule.bzl", "quick_pins_data_dep_test")
+load(":sdc_clock_period_test.bzl", "synth_action_inputs_test")
 load(":source_input_propagation_test.bzl", "source_input_propagation_test")
 load(":stages_filter_test.bzl", "stages_filter_test_suite")
 
@@ -622,6 +623,81 @@ orfs_synth(
 build_test(
     name = "kept_modules_synth_test",
     targets = [":kept_modules_synth"],
+)
+
+# Lock the SDC/clock-period split on the serial synth path (Mul_synth):
+# the expensive actions read only the extracted clock_period.txt; the raw
+# SDC feeds only the cheap extraction and sdc-copy actions, so a
+# period-preserving SDC edit never re-runs synthesis.
+synth_action_inputs_test(
+    name = "sdc_serial_clock_period_extraction_test",
+    output_basename = "clock_period.txt",
+    required_input_basenames = ["constraints-combinational.sdc"],
+    target_under_test = ":Mul_synth",
+)
+
+synth_action_inputs_test(
+    name = "sdc_serial_canonicalize_test",
+    forbidden_input_basenames = ["constraints-combinational.sdc"],
+    output_basename = "1_1_yosys_canonicalize.rtlil",
+    required_input_basenames = ["clock_period.txt"],
+    target_under_test = ":Mul_synth",
+)
+
+synth_action_inputs_test(
+    name = "sdc_serial_do_yosys_test",
+    forbidden_input_basenames = ["constraints-combinational.sdc"],
+    output_basename = "1_2_yosys.v",
+    required_input_basenames = [
+        "1_1_yosys_canonicalize.rtlil",
+        "clock_period.txt",
+    ],
+    target_under_test = ":Mul_synth",
+)
+
+synth_action_inputs_test(
+    name = "sdc_serial_sdc_copy_test",
+    output_basename = "1_2_yosys.sdc",
+    required_input_basenames = ["constraints-combinational.sdc"],
+    target_under_test = ":Mul_synth",
+)
+
+synth_action_inputs_test(
+    name = "sdc_serial_odb_test",
+    output_basename = "1_synth.odb",
+    required_input_basenames = [
+        "1_2_yosys.sdc",
+        "1_2_yosys.v",
+    ],
+    target_under_test = ":Mul_synth",
+)
+
+# Same split on the parallel/hierarchical path (kept_modules_synth).
+synth_action_inputs_test(
+    name = "sdc_parallel_partition_test",
+    forbidden_input_basenames = ["constraints-top.sdc"],
+    output_basename = "partition_top.v",
+    required_input_basenames = ["clock_period.txt"],
+    target_under_test = ":kept_modules_synth",
+)
+
+# Per-module canonicalize never sources synth_preamble.tcl, so it needs
+# neither the raw SDC nor the extracted period.
+synth_action_inputs_test(
+    name = "sdc_parallel_module_canonicalize_test",
+    forbidden_input_basenames = [
+        "clock_period.txt",
+        "constraints-top.sdc",
+    ],
+    output_basename = "partition_adder_canonical.rtlil",
+    target_under_test = ":kept_modules_synth",
+)
+
+synth_action_inputs_test(
+    name = "sdc_parallel_sdc_copy_test",
+    output_basename = "1_2_yosys.sdc",
+    required_input_basenames = ["constraints-top.sdc"],
+    target_under_test = ":kept_modules_synth",
 )
 
 REGFILE_ARGUMENTS = SRAM_ARGUMENTS | BLOCK_FLOORPLAN | {

--- a/test/sdc_clock_period_test.bzl
+++ b/test/sdc_clock_period_test.bzl
@@ -1,0 +1,76 @@
+"""analysistest: pin down which synth actions see the raw SDC.
+
+The expensive yosys actions (canonicalize, do-yosys, keep, partitions)
+read only the extracted clock period (SDC_FILE_CLOCK_PERIOD ->
+results/clock_period.txt, ORFS's do-sdc-clock-period target), never the
+raw SDC — so a period-preserving SDC edit re-runs only the cheap
+extraction and sdc-copy actions, not synthesis. These tests key on the
+action that produces a named output and assert which basenames must and
+must not appear among its inputs, locking that split in place.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _synth_action_inputs_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    actions = analysistest.target_actions(env)
+    matching = []
+    for action in actions:
+        for out in action.outputs.to_list():
+            if out.basename == ctx.attr.output_basename:
+                matching.append(action)
+                break
+
+    asserts.equals(
+        env,
+        1,
+        len(matching),
+        "Expected exactly one action of %s producing %s, found %d" % (
+            analysistest.target_under_test(env).label,
+            ctx.attr.output_basename,
+            len(matching),
+        ),
+    )
+
+    for action in matching:
+        input_basenames = {f.basename: True for f in action.inputs.to_list()}
+        for required in ctx.attr.required_input_basenames:
+            asserts.true(
+                env,
+                required in input_basenames,
+                "Expected %s in the inputs of the action producing %s" % (
+                    required,
+                    ctx.attr.output_basename,
+                ),
+            )
+        for forbidden in ctx.attr.forbidden_input_basenames:
+            asserts.false(
+                env,
+                forbidden in input_basenames,
+                "Expected %s NOT to be an input of the action producing %s" % (
+                    forbidden,
+                    ctx.attr.output_basename,
+                ),
+            )
+
+    return analysistest.end(env)
+
+synth_action_inputs_test = analysistest.make(
+    _synth_action_inputs_test_impl,
+    attrs = {
+        "output_basename": attr.string(
+            mandatory = True,
+            doc = "Selects the action under test: the (single) action " +
+                  "producing an output with this basename.",
+        ),
+        "required_input_basenames": attr.string_list(
+            doc = "Basenames that must appear among the selected " +
+                  "action's inputs.",
+        ),
+        "forbidden_input_basenames": attr.string_list(
+            doc = "Basenames that must NOT appear among the selected " +
+                  "action's inputs.",
+        ),
+    },
+)


### PR DESCRIPTION
## Bump

ORFS to master (`427bd762`, brings the explicit `do-sdc-clock-period` target from The-OpenROAD-Project/OpenROAD-flow-scripts#4461), OpenROAD to upstream HEAD (`21512b0a`, via `bump --head=openroad`), qt-bazel to latest. Submodule pins are unchanged.

## Clock-period extraction

The yosys side never reads the raw SDC — `synth_preamble.tcl` consumes only `SDC_FILE_CLOCK_PERIOD`, the abc `-D` value that `do-sdc-clock-period` derives from the SDC. This PR runs that derivation as its own cheap action producing `results/clock_period.txt`, and hands the expensive yosys actions (canonicalize, do-yosys, keep, partitions, top) make command-line overrides `SDC_FILE_CLOCK_PERIOD=<artifact>` and `SDC_FILE=` (empty; every `SDC_FILE` use in `variables.mk` is wildcard-guarded), with the raw SDC dropped from their inputs via a new `data_inputs_excluding()` helper.

The serial synth action splits into sdc-copy / do-yosys / do-1_synth, mirroring the parallel path, so the raw SDC feeds only the cheap sdc-copy step there too. Per-module canonicalize never sources `synth_preamble.tcl`, so it gets neither the raw SDC nor the period. `SDC_FILE_CLOCK_PERIOD` rides the make command line rather than the config: it is not in ORFS `variables.yaml`. The `SYNTH_USE_SYN` engine bypasses yosys and reads `SDC_FILE` directly; it is unchanged.

**Net effect:** a period-preserving SDC edit (whitespace, comments, non-period constraints) re-runs only the extraction, sdc-copy and ODB steps — synthesis stays cached. A clock-period change still re-runs everything.

## Verification

- New analysistests (`test/sdc_clock_period_test.bzl`) lock the input split on both the serial (`Mul_synth`) and parallel (`kept_modules_synth`) paths: the expensive actions must carry `clock_period.txt` and must not carry the raw `.sdc`; extraction and sdc-copy must carry the raw `.sdc`.
- Verified live on `kept_modules_synth`: a whitespace-only SDC edit re-runs 4 cheap actions (no canonicalize, no partition synth); changing `clk_period` re-runs canonicalize and every partition, with the yosys logs showing the period read from `clock_period.txt`.
- `Mul_synth`, `kept_modules_synth`, deploy/output-group synth tests, and `stages_filter_test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)