### PR TITLE
The raw SDC is a synth-only concern: isolate it from downstream stages

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -563,6 +563,20 @@ def _orfs_pass(
     if abstract_stage or not last_stage:
         steps.append(ABSTRACT_IMPL)
 
+    # Post-synth stages consume the previous stage's written .odb/.sdc
+    # (for floorplan, the canonicalized 1_synth.odb/.sdc) — never the raw
+    # SDC_FILE. save_odb = False generates neither, so a flow that
+    # continues past synth would fail obscurely at floorplan; fail loudly
+    # here instead.
+    if not save_odb and len(steps) > 1:
+        fail(
+            "save_odb = False generates no 1_synth.odb/.sdc, but this " +
+            "flow has post-synth stages ({stages}) that consume them. " +
+            "Set last_stage = 'synth' or drop save_odb = False.".format(
+                stages = ", ".join([s.stage for s in steps[1:]]),
+            ),
+        )
+
     # Prune stages unused due to previous_stage
     if len(previous_stage) > 1:
         fail("Maximum previous stages is 1")

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -2040,6 +2040,10 @@ def _yosys_impl(ctx):
                 "--file",
                 ctx.file._makefile_yosys.path,
                 "print-LIB_FILES",
+                # A make-parse-only action: LIB_FILES never involves the
+                # SDC, so don't let raw-SDC edits re-run it (the input set
+                # below excludes the SDC accordingly).
+                "SDC_FILE=",
             ],
             command = """
             {make} $@ > {out}
@@ -2051,7 +2055,7 @@ def _yosys_impl(ctx):
             inputs = depset(
                 [canon_output, config] + ctx.files.extra_configs,
                 transitive = [
-                    data_inputs(ctx),
+                    synth_data_inputs,
                     pdk_inputs(ctx),
                     deps_inputs(ctx),
                 ],
@@ -2060,7 +2064,18 @@ def _yosys_impl(ctx):
             tools = depset(transitive = [flow_inputs(ctx)]),
         )
 
-    outputs = [canon_output, variables] + synth_outputs.values()
+    # 1_2_yosys.sdc is a verbatim copy of the raw SDC feeding do-1_synth —
+    # an intermediate, not a deliverable (nothing in the repo consumes it,
+    # and a deployed re-run regenerates it via ORFS's own file rule).
+    # Keeping it in DefaultInfo.files would land it in every downstream
+    # stage's action inputs (ctx.files.src → source_inputs) and re-run
+    # floorplan+ on every raw-SDC edit; the downstream contract is the
+    # canonicalized 1_synth.sdc.
+    outputs = [canon_output, variables] + [
+        f
+        for name, f in synth_outputs.items()
+        if name != "1_2_yosys.sdc"
+    ]
 
     # Write synth's data_arguments to a JSON so downstream stages
     # inherit synth-time variables (SDC_FILE, VERILOG_FILES, SYNTH_*)
@@ -2207,7 +2222,15 @@ def _yosys_impl(ctx):
             kept_macros_validation = depset(
                 [validated_kept_macros_json] if validated_kept_macros_json else [],
             ),
-            **{f.basename: depset([f]) for f in [config] + outputs}
+            # 1_2_yosys.sdc left DefaultInfo.files (see the outputs
+            # comment above) but stays inspectable on demand:
+            # bazelisk build --output_groups=1_2_yosys.sdc <synth target>.
+            **{
+                f.basename: depset([f])
+                for f in [config] + outputs + (
+                    [synth_outputs["1_2_yosys.sdc"]] if "1_2_yosys.sdc" in synth_outputs else []
+                )
+            }
         ),
         OrfsDepInfo(
             make = make,
@@ -2218,8 +2241,19 @@ def _yosys_impl(ctx):
             # OrfsDepInfo.files, and the synth config can reference
             # sources= paths (e.g. LAYER_PARASITICS_FILE) that load.tcl
             # sources at load_design time.
+            #
+            # EXCEPT the raw SDC: downstream's contract is the previous
+            # stage's written .odb/.sdc (for floorplan, the canonicalized
+            # 1_synth.sdc via OrfsInfo.sdc — write_sdc resolves every
+            # dependency the raw SDC_FILE may source), and nothing after
+            # synth reads SDC_FILE (open.tcl's fallback never fires once
+            # an N_*.sdc exists). Keeping it here would feed it into
+            # floorplan's inputs via source_inputs() and re-run floorplan
+            # on every raw-SDC edit, period-preserving or not.
             files = depset(
-                [config_short] + ctx.files.data + ctx.files.extra_configs,
+                [config_short] +
+                [f for f in ctx.files.data if f.path != sdc_path] +
+                ctx.files.extra_configs,
             ),
             runfiles = ctx.runfiles(transitive_files = deploy_files),
         ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -700,6 +700,17 @@ synth_action_inputs_test(
     target_under_test = ":kept_modules_synth",
 )
 
+# The raw SDC is a synth-only concern: downstream stages consume the
+# canonicalized 1_synth.sdc (write_sdc output) and must never see the
+# raw SDC_FILE — otherwise every raw-SDC edit re-runs floorplan+.
+synth_action_inputs_test(
+    name = "sdc_isolated_to_synth_test",
+    forbidden_input_basenames = ["constraints-combinational.sdc"],
+    output_basename = "2_floorplan.odb",
+    required_input_basenames = ["1_synth.sdc"],
+    target_under_test = ":src_propagation_floorplan",
+)
+
 REGFILE_ARGUMENTS = SRAM_ARGUMENTS | BLOCK_FLOORPLAN | {
     "CORE_AREA": "1.026 1.080 4.914 4.860",
     "DIE_AREA": "0 0 5.940 5.940",


### PR DESCRIPTION
Stacked on #829 (retarget to `main` once that merges).

Downstream stages' contract is the previous stage's written `.odb`/`.sdc` — for floorplan, the canonicalized `1_synth.sdc` that `synth_odb.tcl`'s `write_sdc` produces (sole writer, resolving anything the raw `SDC_FILE` sources). Nothing after synth reads the raw SDC (`open.tcl`'s `SDC_FILE` fallback never fires once an `N_*.sdc` exists), yet it leaked into floorplan's action inputs through two paths, re-running floorplan+ on every raw-SDC edit:

- synth's `OrfsDepInfo.files` carried `ctx.files.data` wholesale, and `source_inputs()` feeds that to the next stage. The SDC is subtracted; the other data entries (e.g. `LAYER_PARASITICS_FILE`, read by `load.tcl` at `load_design`) stay.
- `1_2_yosys.sdc` — a verbatim copy of the raw SDC consumed only by `do-1_synth` — sat in synth's `DefaultInfo.files`, reaching downstream via `ctx.files.src`. It leaves `DefaultInfo` but remains a declared output, inspectable on demand via `--output_groups=1_2_yosys.sdc`; a deployed re-run regenerates it through ORFS's own file rule.

Also: the `1_synth.vars` (`print-LIB_FILES`) action no longer carries the SDC it never parses, and `orfs_flow` now fails loudly when `save_odb = False` is combined with post-synth stages (without `1_synth.odb/.sdc` the downstream contract does not exist; the flow previously died obscurely inside floorplan).

## Verification

- New analysistest `sdc_isolated_to_synth_test`: the floorplan action must carry `1_synth.sdc` and must not carry the raw SDC.
- Verified live on `lb_32x128_floorplan`: a whitespace-only SDC edit executes exactly sdc-copy, clock-period extraction and `do-1_synth` (whose canonicalized outputs are byte-identical) — floorplan and synthesis stay cached. Changing the clock period still rebuilds everything.
- Remaining (deliberately out of scope): `orfs_run` consumes the src stage's timestamped logs as inputs ("so run scripts can read stage elapsed times"), so utility runs like `write_pin_placement` still re-run after a legitimate `do-1_synth` re-run; same story for the runtime-bearing `1_synth.json` metrics. That's a separate input-hygiene sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)