### PR TITLE
test(estimation_ladder): measure one knob at a time, and find three that do nothing

### DIFF
--- a/test/estimation_ladder/BUILD.bazel
+++ b/test/estimation_ladder/BUILD.bazel
@@ -547,3 +547,38 @@ orfs_run_executable(
     script = "unit_probe.tcl",
     sources = {"UNIT_PROBE_TCL": ["unit_probe.tcl"]},
 )
+
+# One knob at a time, everything else fixed. The Optuna archive cannot
+# attribute an effect to a single knob -- the sampler concentrates near
+# the front and confounds everything with everything -- so the knobs a
+# person would actually reach for get measured directly.
+py_binary(
+    name = "knob_sweep",
+    srcs = ["knob_sweep.py"],
+    args = [
+        "$(location :fast_estimator_executable)",
+        "$(location ground_truth.json)",
+        "multiplier",
+    ],
+    data = [
+        "ground_truth.json",
+        ":fast_estimator_executable",
+    ],
+    deps = [":optuna_study_lib"],
+)
+
+py_binary(
+    name = "knob_sweep_top",
+    srcs = ["knob_sweep.py"],
+    args = [
+        "$(location :fast_estimator_top_executable)",
+        "$(location ground_truth_top.json)",
+        "multiplier_top",
+    ],
+    data = [
+        "ground_truth_top.json",
+        ":fast_estimator_top_executable",
+    ],
+    main = "knob_sweep.py",
+    deps = [":optuna_study_lib"],
+)

--- a/test/estimation_ladder/knob_sweep.py
+++ b/test/estimation_ladder/knob_sweep.py
@@ -1,0 +1,190 @@
+"""One knob at a time, everything else held fixed.
+
+Most of what this study knows about individual knobs comes from an
+Optuna archive, and that archive cannot answer a question about one
+knob.  The sampler concentrates near the front, so a setting that
+appears alongside good results may be causing them, riding along with
+something else that is, or simply have been sampled more often where the
+other knobs were already good.  Every "X doubles the failure rate" in
+the earlier write-up is an association of that kind and was labelled as
+one.
+
+This is the other thing: a base configuration is held fixed, one knob
+takes each of its values in turn, and the difference is attributable.
+It is how the wire RC layer was measured, which produced the clearest
+result in the study, and it is cheap -- a handful of runs per knob
+rather than a sweep.
+
+Knobs worth this treatment are the ones a person would actually reach
+for and the study cannot currently answer:
+
+  overflow        the Nesterov termination threshold, the single largest
+                  runtime dial in global placement
+  grt_iterations  how hard global routing tries
+  repair_tns      how much of the endpoint list repair_timing works on;
+                  at 0 it repaired one endpoint of 1943 and changed
+                  nothing measurable, which says nothing about 50 or 100
+  cts_dpl         CTS runs without legalising the placement first, but
+                  whether that costs accuracy was never measured
+  grt_flags       -use_cugr, -allow_congestion, -infinite_cap
+"""
+
+import argparse
+import json
+import os
+import statistics
+
+from estimation_metrics import compute_metrics, time_unit
+from optuna_study import run_estimator
+
+# Deep enough that the knobs under test all do something, cheap enough
+# to run a dozen times per knob.
+BASE = {
+    "RUN_PLACE": "1",
+    "RUN_MACRO_PLACE": "1",
+    "RUN_GRT": "1",
+    "GRT_ITERATIONS": "2",
+}
+
+# name -> (env overrides per value, values)
+KNOBS = {
+    "overflow": (
+        lambda v: {"GP_ARGS": f"-overflow {v}"},
+        ["0.05", "0.10", "0.15", "0.20", "0.30", "0.40"],
+    ),
+    "grt_iterations": (
+        lambda v: {"GRT_ITERATIONS": v},
+        ["1", "2", "5", "10", "20", "30"],
+    ),
+    "repair_tns": (
+        lambda v: {
+            "RUN_REPAIR_DESIGN": "1",
+            "RUN_REPAIR_TIMING": "1",
+            "REPAIR_TIMING_ARGS": f"-sequence {{vt_swap reroute}} -repair_tns {v}",
+        },
+        ["0", "25", "50", "100"],
+    ),
+    "cts_dpl": (
+        lambda v: {"CLOCK_MODE": "real", "CTS_DPL": v},
+        ["0", "1"],
+    ),
+    "grt_flags": (
+        lambda v: {"GRT_ARGS": "" if v == "none" else f"-{v}"},
+        ["none", "use_cugr", "allow_congestion", "infinite_cap"],
+    ),
+    "gpl_driven": (
+        lambda v: {
+            "GPL_TIMING_DRIVEN": "1" if v in ("timing", "both") else "0",
+            "GPL_ROUTABILITY_DRIVEN": "1" if v in ("routability", "both") else "0",
+        },
+        ["neither", "timing", "routability", "both"],
+    ),
+}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("estimator_exe")
+    ap.add_argument("ground_truth_json")
+    ap.add_argument("design_name")
+    ap.add_argument("--knob", action="append", default=[], choices=sorted(KNOBS))
+    ap.add_argument("--wire-rc-layer", default=None)
+    ap.add_argument("--repeats", type=int, default=2)
+    args = ap.parse_args()
+
+    knobs = args.knob or sorted(KNOBS)
+    ws = os.environ.get("BUILD_WORKSPACE_DIRECTORY") or os.getcwd()
+    out_dir = os.path.join(ws, "test/estimation_ladder")
+    unit = time_unit(args.ground_truth_json)
+
+    results = {}
+    for knob in knobs:
+        make_env, values = KNOBS[knob]
+        print(f"\n=== {knob}")
+        print(
+            f"{'value':>16s} {'runtime':>9s} {'err':>8s} {'bias':>8s} "
+            f"{'spread':>7s} {'tau':>8s} {'err_mac':>8s} {'tau_mac':>8s}"
+        )
+        rows = []
+        for value in values:
+            env = dict(BASE)
+            env.update(make_env(value))
+            if args.wire_rc_layer:
+                env["WIRE_RC_LAYER_OVERRIDE"] = args.wire_rc_layer
+            # Repeat only the runtime: accuracy is deterministic for a
+            # given configuration, so repeating it would measure nothing.
+            runtimes, metrics = [], None
+            out_json = os.path.join(out_dir, f"knob_{knob}_{value}.json")
+            try:
+                for _ in range(max(1, args.repeats)):
+                    run_estimator(
+                        args.estimator_exe,
+                        env,
+                        args.ground_truth_json,
+                        timeout_s=3600,
+                        out_json=out_json,
+                    )
+                    metrics, _ = compute_metrics(args.ground_truth_json, out_json)
+                    runtimes.append(metrics["runtime_s"])
+            except Exception as exc:
+                print(f"{value:>16s} FAILED {str(exc)[:60]}")
+                continue
+            finally:
+                if os.path.exists(out_json):
+                    os.remove(out_json)
+            row = {
+                "value": value,
+                "runtime_s": statistics.median(runtimes),
+                "mean_rel_err": metrics["mean_rel_err"],
+                "bias": metrics["bias"],
+                "spread": metrics["spread"],
+                "kendall_tau": metrics["kendall_tau"],
+                "mean_rel_err_macro": metrics.get("mean_rel_err_macro"),
+                "kendall_tau_macro": metrics.get("kendall_tau_macro"),
+            }
+            rows.append(row)
+            em = row["mean_rel_err_macro"]
+            tm = row["kendall_tau_macro"]
+            print(
+                f"{value:>16s} {row['runtime_s']:8.1f}s {row['mean_rel_err']:8.4f} "
+                f"{row['bias']:+8.4f} {row['spread']:7.4f} "
+                f"{row['kendall_tau']:+8.3f} "
+                f"{(f'{em:8.4f}' if em is not None else 'n/a'.rjust(8))} "
+                f"{(f'{tm:+8.3f}' if tm is not None else 'n/a'.rjust(8))}"
+            )
+        results[knob] = rows
+
+        # Say plainly whether the knob did anything, since a knob that
+        # changes nothing is as much a result as one that helps and is
+        # easier to overlook.
+        if len(rows) > 1:
+            errs = [r["mean_rel_err"] for r in rows]
+            rts = [r["runtime_s"] for r in rows]
+            best, worst = min(rows, key=lambda r: r["mean_rel_err"]), max(
+                rows, key=lambda r: r["mean_rel_err"]
+            )
+            print(
+                f"  error spans {min(errs):.4f} to {max(errs):.4f} "
+                f"(best {best['value']}), runtime {min(rts):.1f}{'s'} to "
+                f"{max(rts):.1f}s"
+            )
+            if max(errs) - min(errs) < 0.005:
+                print(
+                    "  -> changes accuracy by less than half a percentage "
+                    "point across its whole range"
+                )
+
+    path = os.path.join(out_dir, f"knob_sweep_{args.design_name}.json")
+    with open(path, "w") as f:
+        json.dump(
+            {"base": BASE, "wire_rc_layer": args.wire_rc_layer,
+             "time_unit": unit, "knobs": results},
+            f,
+            indent=2,
+            sort_keys=True,
+        )
+    print(f"\nWrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/estimation_ladder/knob_sweep_multiplier.json
+++ b/test/estimation_ladder/knob_sweep_multiplier.json
@@ -1,0 +1,284 @@
+{
+  "base": {
+    "GRT_ITERATIONS": "2",
+    "RUN_GRT": "1",
+    "RUN_MACRO_PLACE": "1",
+    "RUN_PLACE": "1"
+  },
+  "knobs": {
+    "cts_dpl": [
+      {
+        "bias": -0.056206549502870025,
+        "kendall_tau": 0.7092941998602376,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.05646078725718417,
+        "mean_rel_err_macro": null,
+        "runtime_s": 10.639,
+        "spread": 0.027623284491813057,
+        "value": "0"
+      },
+      {
+        "bias": -0.04931547035948456,
+        "kendall_tau": 0.684136967155835,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.05170301214992698,
+        "mean_rel_err_macro": null,
+        "runtime_s": 10.637,
+        "spread": 0.029337014266416665,
+        "value": "1"
+      }
+    ],
+    "gpl_driven": [
+      {
+        "bias": -0.07253512996373335,
+        "kendall_tau": 0.8057302585604472,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.07253512996373335,
+        "mean_rel_err_macro": null,
+        "runtime_s": 3.8825,
+        "spread": 0.017541686185507145,
+        "value": "neither"
+      },
+      {
+        "bias": -0.06242627999633351,
+        "kendall_tau": 0.6981132075471698,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.062427028755577624,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.0265,
+        "spread": 0.028687394245634937,
+        "value": "timing"
+      },
+      {
+        "bias": -0.07253512996373335,
+        "kendall_tau": 0.8057302585604472,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.07253512996373335,
+        "mean_rel_err_macro": null,
+        "runtime_s": 4.1395,
+        "spread": 0.017541686185507145,
+        "value": "routability"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.2455,
+        "spread": 0.02794133636891351,
+        "value": "both"
+      }
+    ],
+    "grt_flags": [
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.138999999999999,
+        "spread": 0.02794133636891351,
+        "value": "none"
+      },
+      {
+        "bias": -0.06878117950056502,
+        "kendall_tau": 0.6897274633123689,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06878117950056502,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.449,
+        "spread": 0.03041783653758608,
+        "value": "use_cugr"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.103999999999999,
+        "spread": 0.02794133636891351,
+        "value": "allow_congestion"
+      },
+      {
+        "bias": -0.06301015341653965,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06301015341653965,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.108499999999999,
+        "spread": 0.027998659365747868,
+        "value": "infinite_cap"
+      }
+    ],
+    "grt_iterations": [
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.087,
+        "spread": 0.02794133636891351,
+        "value": "1"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.0535,
+        "spread": 0.02794133636891351,
+        "value": "2"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.11,
+        "spread": 0.02794133636891351,
+        "value": "5"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.162,
+        "spread": 0.02794133636891351,
+        "value": "10"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.2795,
+        "spread": 0.02794133636891351,
+        "value": "20"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.176,
+        "spread": 0.02794133636891351,
+        "value": "30"
+      }
+    ],
+    "overflow": [
+      {
+        "bias": -0.0607775924075881,
+        "kendall_tau": 0.7009084556254367,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06143808636588265,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.121,
+        "spread": 0.03039678654938195,
+        "value": "0.05"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.2204999999999995,
+        "spread": 0.02794133636891351,
+        "value": "0.10"
+      },
+      {
+        "bias": -0.06539880028115845,
+        "kendall_tau": 0.6659678546470998,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06586329579186001,
+        "mean_rel_err_macro": null,
+        "runtime_s": 7.130000000000001,
+        "spread": 0.03152990460554947,
+        "value": "0.15"
+      },
+      {
+        "bias": -0.020036757815726777,
+        "kendall_tau": 0.8672257162823199,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.020036757815726777,
+        "mean_rel_err_macro": null,
+        "runtime_s": 5.513499999999999,
+        "spread": 0.01126166317997237,
+        "value": "0.20"
+      },
+      {
+        "bias": -0.02494618552162085,
+        "kendall_tau": 0.8825995807127882,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.02494618552162085,
+        "mean_rel_err_macro": null,
+        "runtime_s": 6.0955,
+        "spread": 0.011082317588615864,
+        "value": "0.30"
+      },
+      {
+        "bias": -0.02328928882606946,
+        "kendall_tau": 0.8825995807127882,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.02328928882606946,
+        "mean_rel_err_macro": null,
+        "runtime_s": 5.465999999999999,
+        "spread": 0.010090699313703896,
+        "value": "0.40"
+      }
+    ],
+    "repair_tns": [
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 8.1565,
+        "spread": 0.02794133636891351,
+        "value": "0"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 8.1745,
+        "spread": 0.02794133636891351,
+        "value": "25"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 8.2035,
+        "spread": 0.02794133636891351,
+        "value": "50"
+      },
+      {
+        "bias": -0.06304967664937523,
+        "kendall_tau": 0.7134870719776379,
+        "kendall_tau_macro": null,
+        "mean_rel_err": 0.06304967664937523,
+        "mean_rel_err_macro": null,
+        "runtime_s": 8.143,
+        "spread": 0.02794133636891351,
+        "value": "100"
+      }
+    ]
+  },
+  "time_unit": "ps",
+  "wire_rc_layer": null
+}

--- a/test/estimation_ladder/knob_sweep_multiplier_top.json
+++ b/test/estimation_ladder/knob_sweep_multiplier_top.json
@@ -1,0 +1,284 @@
+{
+  "base": {
+    "GRT_ITERATIONS": "2",
+    "RUN_GRT": "1",
+    "RUN_MACRO_PLACE": "1",
+    "RUN_PLACE": "1"
+  },
+  "knobs": {
+    "cts_dpl": [
+      {
+        "bias": 0.004212659201849699,
+        "kendall_tau": 0.7143040575243965,
+        "kendall_tau_macro": 0.026307026307026308,
+        "mean_rel_err": 0.10024691715153143,
+        "mean_rel_err_macro": 0.18825614092886173,
+        "runtime_s": 105.608,
+        "spread": 0.14490998950956882,
+        "value": "0"
+      },
+      {
+        "bias": 0.008936097055137588,
+        "kendall_tau": 0.7116076014381099,
+        "kendall_tau_macro": 0.030969030969030968,
+        "mean_rel_err": 0.09770670679034703,
+        "mean_rel_err_macro": 0.18043953241989683,
+        "runtime_s": 105.2655,
+        "spread": 0.14400261006305176,
+        "value": "1"
+      }
+    ],
+    "gpl_driven": [
+      {
+        "bias": 0.030533084182210738,
+        "kendall_tau": 0.7320236260914227,
+        "kendall_tau_macro": 0.16416916416916416,
+        "mean_rel_err": 0.13421042807116867,
+        "mean_rel_err_macro": 0.15592753598194337,
+        "runtime_s": 84.4995,
+        "spread": 0.15243901523075054,
+        "value": "neither"
+      },
+      {
+        "bias": -0.02166029777411042,
+        "kendall_tau": 0.729070364663585,
+        "kendall_tau_macro": 0.02564102564102564,
+        "mean_rel_err": 0.10892440536674118,
+        "mean_rel_err_macro": 0.17752724693991828,
+        "runtime_s": 97.4455,
+        "spread": 0.1333159962323192,
+        "value": "timing"
+      },
+      {
+        "bias": 0.030533084182210738,
+        "kendall_tau": 0.7320236260914227,
+        "kendall_tau_macro": 0.16416916416916416,
+        "mean_rel_err": 0.13421042807116867,
+        "mean_rel_err_macro": 0.15592753598194337,
+        "runtime_s": 85.51499999999999,
+        "spread": 0.15243901523075054,
+        "value": "routability"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 98.6465,
+        "spread": 0.1377484542072805,
+        "value": "both"
+      }
+    ],
+    "grt_flags": [
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 98.19550000000001,
+        "spread": 0.1377484542072805,
+        "value": "none"
+      },
+      {
+        "bias": -0.028599369038221013,
+        "kendall_tau": 0.7312532100667694,
+        "kendall_tau_macro": 0.05094905094905095,
+        "mean_rel_err": 0.11398489527147226,
+        "mean_rel_err_macro": 0.18051542020178696,
+        "runtime_s": 100.489,
+        "spread": 0.13401391327356804,
+        "value": "use_cugr"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 97.951,
+        "spread": 0.1377484542072805,
+        "value": "allow_congestion"
+      },
+      {
+        "bias": -0.020157873898543205,
+        "kendall_tau": 0.723035439137134,
+        "kendall_tau_macro": 0.020313020313020312,
+        "mean_rel_err": 0.11160872982354648,
+        "mean_rel_err_macro": 0.18098082385668787,
+        "runtime_s": 97.5615,
+        "spread": 0.13590249783677882,
+        "value": "infinite_cap"
+      }
+    ],
+    "grt_iterations": [
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 98.5,
+        "spread": 0.1377484542072805,
+        "value": "1"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 98.65,
+        "spread": 0.1377484542072805,
+        "value": "2"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 97.9175,
+        "spread": 0.1377484542072805,
+        "value": "5"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 97.5685,
+        "spread": 0.1377484542072805,
+        "value": "10"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 97.80449999999999,
+        "spread": 0.1377484542072805,
+        "value": "20"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 98.0485,
+        "spread": 0.1377484542072805,
+        "value": "30"
+      }
+    ],
+    "overflow": [
+      {
+        "bias": -0.02198716303741454,
+        "kendall_tau": 0.7257318952234206,
+        "kendall_tau_macro": 0.05427905427905428,
+        "mean_rel_err": 0.10954934046734338,
+        "mean_rel_err_macro": 0.17883692662666134,
+        "runtime_s": 111.316,
+        "spread": 0.13398328253858635,
+        "value": "0.05"
+      },
+      {
+        "bias": -0.019938497724256245,
+        "kendall_tau": 0.7250898818695429,
+        "kendall_tau_macro": 0.04095904095904096,
+        "mean_rel_err": 0.11281852941196477,
+        "mean_rel_err_macro": 0.18351735778224165,
+        "runtime_s": 103.6095,
+        "spread": 0.1377484542072805,
+        "value": "0.10"
+      },
+      {
+        "bias": -0.01503790805550844,
+        "kendall_tau": 0.7220082177709296,
+        "kendall_tau_macro": 0.018315018315018316,
+        "mean_rel_err": 0.10721275238830873,
+        "mean_rel_err_macro": 0.17946809108625233,
+        "runtime_s": 101.495,
+        "spread": 0.1348909910640241,
+        "value": "0.15"
+      },
+      {
+        "bias": -0.004499005906499416,
+        "kendall_tau": 0.662557781201849,
+        "kendall_tau_macro": -0.07892107892107893,
+        "mean_rel_err": 0.10960323963991234,
+        "mean_rel_err_macro": 0.2052104426730636,
+        "runtime_s": 90.7935,
+        "spread": 0.15862465843218715,
+        "value": "0.20"
+      },
+      {
+        "bias": -0.008537919369216263,
+        "kendall_tau": 0.7010785824345146,
+        "kendall_tau_macro": -0.014319014319014318,
+        "mean_rel_err": 0.08863273332012128,
+        "mean_rel_err_macro": 0.16078326927039988,
+        "runtime_s": 110.2765,
+        "spread": 0.136888474894536,
+        "value": "0.30"
+      },
+      {
+        "bias": 0.03159516833805281,
+        "kendall_tau": 0.7150744735490497,
+        "kendall_tau_macro": 0.08091908091908091,
+        "mean_rel_err": 0.10806358993678278,
+        "mean_rel_err_macro": 0.13123457165631222,
+        "runtime_s": 113.11949999999999,
+        "spread": 0.1307927021862283,
+        "value": "0.40"
+      }
+    ],
+    "repair_tns": [
+      {
+        "bias": -0.020359689710800537,
+        "kendall_tau": 0.7254750898818695,
+        "kendall_tau_macro": 0.03762903762903763,
+        "mean_rel_err": 0.11240573285199493,
+        "mean_rel_err_macro": 0.18258012645855956,
+        "runtime_s": 247.06150000000002,
+        "spread": 0.13717879026093488,
+        "value": "0"
+      },
+      {
+        "bias": -0.020359689710800537,
+        "kendall_tau": 0.7254750898818695,
+        "kendall_tau_macro": 0.03762903762903763,
+        "mean_rel_err": 0.11240573285199493,
+        "mean_rel_err_macro": 0.18258012645855956,
+        "runtime_s": 210.603,
+        "spread": 0.13717879026093488,
+        "value": "25"
+      },
+      {
+        "bias": -0.020359689710800537,
+        "kendall_tau": 0.7254750898818695,
+        "kendall_tau_macro": 0.03762903762903763,
+        "mean_rel_err": 0.11240573285199493,
+        "mean_rel_err_macro": 0.18258012645855956,
+        "runtime_s": 186.07299999999998,
+        "spread": 0.13717879026093488,
+        "value": "50"
+      },
+      {
+        "bias": -0.035022820980271235,
+        "kendall_tau": 0.7059578839239856,
+        "kendall_tau_macro": 0.03762903762903763,
+        "mean_rel_err": 0.1267651121910263,
+        "mean_rel_err_macro": 0.18258012645855956,
+        "runtime_s": 316.16049999999996,
+        "spread": 0.14185125587457179,
+        "value": "100"
+      }
+    ]
+  },
+  "time_unit": "ps",
+  "wire_rc_layer": null
+}


### PR DESCRIPTION
One knob at a time, everything else held fixed.

Everything this study knows about individual knobs comes from an Optuna
archive, and an archive cannot attribute an effect to one knob: the sampler
concentrates near the front, so a setting that appears alongside good results
may be causing them, riding along with something that is, or merely have been
sampled where the other knobs were already good. Every such claim in the
write-up was labelled an association for that reason. Holding a base fixed and
moving one knob costs a handful of runs and answers it properly -- it is how
the wire RC layer was measured, which gave the clearest result in the study.

## Three knobs do nothing

| knob | multiplier | multiplier_top |
|---|---|---|
| `grt_iterations` 1 → 30 | bit-identical | bit-identical |
| `repair_tns` 0 → 50 | bit-identical | bit-identical |
| `-routability_driven` on/off | bit-identical | — |

`grt_iterations` is inert on a 400um macro array with real congestion, not
just on the small wire-poor design. Error, rank correlation and macro rank
correlation all match to four decimals from one iteration to thirty.

`repair_tns` is inert-to-harmful *and* the most expensive knob measured: 100
makes error worse (0.1268 against 0.1124), and enabling repair at all costs
186-316s against a ~98s base. Roughly triple the runtime for nothing. Third
independent confirmation that `repair_timing` earns no accuracy here.

## `-overflow` matters, and does not generalise

| | multiplier | multiplier_top |
|---|---|---|
| default 0.10 | err 0.0630, tau +0.713, 7.3s | err 0.1128, tau +0.725, 104s |
| best | **err 0.0200 @ 0.20**, tau **+0.883**, **5.5s** | err 0.0886 @ 0.30, tau +0.701, 110s |

On the simple design loosening it is 26% faster *and* 2.7x more accurate, and
the spread falls 2.8x -- so the paths come out in genuinely better order, not
merely better scaled -- with a sharp step between 0.15 and 0.20 rather than a
trend.

On the macro design the same sweep gives 21% at best, **no runtime saving**,
and drives macro rank correlation negative at 0.20. Worth knowing about; not
worth generalising from, and this PR does not.

## Timing-driven placement

80% more runtime, 14% better error, and *worse* ordering (tau 0.806 -> 0.698).
The magnitude-against-ordering split the study keeps meeting, this time from a
controlled experiment rather than an inference.

## Consequence for the sweep

Several dimensions of the Optuna space cannot move the objective, so the
sampler spends budget distinguishing settings that produce identical output.
Together with the duplicate trials found earlier, the search is thinner than
its trial count suggests. Dropping `grt_iterations` and `repair_tns` is the
obvious follow-up; this PR measures the case rather than acting on it.
