### PR TITLE
mock-openroad: evaluate Tcl ternaries, honor exit, fail loudly

### DIFF
--- a/mock/openroad/src/bin/openroad.py
+++ b/mock/openroad/src/bin/openroad.py
@@ -164,11 +164,30 @@ def main(argv=None):
             continue
         try:
             interp.eval_file(script_path)
+        except SystemExit as e:
+            # TCL `exit`: real TCL semantics. A clean `exit` stops the
+            # scripts but still writes the -metrics file below; a nonzero
+            # exit fails the action.
+            code = e.code or 0
+            if code:
+                print(
+                    f"mock-openroad: {script_path} exited with code {code}",
+                    file=sys.stderr,
+                )
+                return code
+            break
         except Exception as e:
             print(f"mock-openroad: error in {script_path}: {e}", file=sys.stderr)
-            # Don't fail — ORFS scripts may reference things we don't
-            # implement yet. Create expected output files based on env vars.
-            _create_fallback_outputs(state)
+            # Tolerance for UNIMPLEMENTED commands lives in the
+            # interpreter (unknown commands return ""), so an exception
+            # here means the script genuinely broke. Fail the action —
+            # the silent alternative once shipped a fabricated 10x10
+            # abstract for every mock LEF. The old fabricate-and-succeed
+            # behavior remains available as an explicit escape hatch.
+            if os.environ.get("MOCK_OPENROAD_TOLERATE_TCL_ERRORS") == "1":
+                _create_fallback_outputs(state)
+            else:
+                return 1
 
     # Write metrics JSON if requested (real OpenROAD writes metrics here;
     # genMetrics.py later reads these files).

--- a/mock/openroad/src/bin/openroad_commands.py
+++ b/mock/openroad/src/bin/openroad_commands.py
@@ -662,9 +662,19 @@ def cmd_global_route(interp, args):
     return ""
 
 
+def cmd_grt_have_routes(interp, args):
+    """grt::have_routes — returns 1 (pretend global routing succeeded)."""
+    return "1"
+
+
 def cmd_detailed_route(interp, args):
     print("lint: detailed_route (skipped)", file=sys.stderr)
     return ""
+
+
+def cmd_design_is_routed(interp, args):
+    """design_is_routed — returns 1 (pretend detailed routing succeeded)."""
+    return "1"
 
 
 def cmd_estimate_parasitics(interp, args):
@@ -672,6 +682,10 @@ def cmd_estimate_parasitics(interp, args):
 
 
 # --- Repair / Optimization ---
+
+
+def cmd_repair_antennas(interp, args):
+    return "0"
 
 
 def cmd_repair_timing(interp, args):
@@ -880,7 +894,21 @@ def cmd_get_pins(interp, args):
 
 
 def cmd_get_clocks(interp, args):
+    if _state.clocks:
+        return " ".join(sorted(_state.clocks.keys()))
     return ""
+
+
+def cmd_all_clocks(interp, args):
+    return cmd_get_clocks(interp, args)
+
+
+def cmd_current_design(interp, args):
+    return _state.design_name
+
+
+def cmd_all_pins_placed(interp, args):
+    return "0"
 
 
 def cmd_all_registers(interp, args):
@@ -1279,11 +1307,11 @@ def cmd_filler_placement(interp, args):
 
 
 def cmd_check_placement(interp, args):
-    return ""
+    return "0"
 
 
 def cmd_check_antennas(interp, args):
-    return ""
+    return "0"
 
 
 def cmd_density_fill(interp, args):
@@ -1296,7 +1324,19 @@ def cmd_write_def(interp, args):
     return ""
 
 
-# --- utl namespace ---
+# --- utl / gpl / gui / sta helpers ---
+
+
+def cmd_gpl_get_global_placement_uniform_density(interp, args):
+    return "0.5"
+
+
+def cmd_ord_openroad_gui_compiled(interp, args):
+    return "0"
+
+
+def cmd_gui_enabled(interp, args):
+    return "0"
 
 
 def cmd_utl_set_metrics_stage(interp, args):
@@ -1321,6 +1361,46 @@ def cmd_utl_report(interp, args):
     return ""
 
 
+def cmd_utl_metric_int(interp, args):
+    return ""
+
+
+def cmd_utl_metric_float(interp, args):
+    return ""
+
+
+def cmd_utl_push_metrics_stage(interp, args):
+    return ""
+
+
+def cmd_utl_pop_metrics_stage(interp, args):
+    return ""
+
+
+def cmd_sta_limit(interp, args):
+    return "1e30"
+
+
+def cmd_sta_slack(interp, args):
+    return "0.0"
+
+
+def cmd_sta_count(interp, args):
+    return "0"
+
+
+def cmd_sta_format_time(interp, args):
+    return args[0] if args else "0.0"
+
+
+def cmd_sta_leaf_instance_count(interp, args):
+    return str(_state.cell_count)
+
+
+def cmd_sta_leaf_pin_count(interp, args):
+    return str(_state.cell_count * 4)
+
+
 def register_all(interp):
     """Register all lint OpenROAD commands on a TclInterpreter."""
     commands = {
@@ -1340,6 +1420,7 @@ def register_all(interp):
         "write_verilog": cmd_write_verilog,
         "write_spef": cmd_write_spef,
         # Design
+        "current_design": cmd_current_design,
         "link_design": cmd_link_design,
         "initialize_floorplan": cmd_initialize_floorplan,
         "make_tracks": cmd_make_tracks,
@@ -1347,6 +1428,7 @@ def register_all(interp):
         "add_global_connection": cmd_add_global_connection,
         "set_global_routing_layer_adjustment": cmd_set_global_routing_layer_adjustment,
         # Placement
+        "all_pins_placed": cmd_all_pins_placed,
         "global_placement": cmd_global_placement,
         "detailed_placement": cmd_detailed_placement,
         "improve_placement": cmd_improve_placement,
@@ -1357,8 +1439,10 @@ def register_all(interp):
         # Routing
         "global_route": cmd_global_route,
         "detailed_route": cmd_detailed_route,
+        "design_is_routed": cmd_design_is_routed,
         "estimate_parasitics": cmd_estimate_parasitics,
         # Repair
+        "repair_antennas": cmd_repair_antennas,
         "repair_timing": cmd_repair_timing,
         "repair_design": cmd_repair_design,
         "repair_tie_fanout": cmd_repair_tie_fanout,
@@ -1383,6 +1467,7 @@ def register_all(interp):
         "get_nets": cmd_get_nets,
         "get_pins": cmd_get_pins,
         "get_clocks": cmd_get_clocks,
+        "all_clocks": cmd_all_clocks,
         "all_registers": cmd_all_registers,
         "all_inputs": cmd_all_inputs,
         "all_outputs": cmd_all_outputs,
@@ -1436,5 +1521,45 @@ def register_all(interp):
     interp.register_command("utl::warn", cmd_utl_warn)
     interp.register_command("utl::error", cmd_utl_error)
     interp.register_command("utl::report", cmd_utl_report)
+    interp.register_command("utl::metric_int", cmd_utl_metric_int)
+    interp.register_command("utl::metric_float", cmd_utl_metric_float)
+    interp.register_command("utl::push_metrics_stage", cmd_utl_push_metrics_stage)
+    interp.register_command("utl::pop_metrics_stage", cmd_utl_pop_metrics_stage)
+
+    # Register grt:: namespace commands
+    interp.register_command("grt::have_routes", cmd_grt_have_routes)
+
+    # Register gpl:: namespace commands
+    interp.register_command(
+        "gpl::get_global_placement_uniform_density",
+        cmd_gpl_get_global_placement_uniform_density,
+    )
+
+    # Register ord:: and gui:: namespace commands
     interp.register_command("ord::get_db", cmd_get_db)
     interp.register_command("ord::get_db_block", cmd_get_db_block)
+    interp.register_command("ord::openroad_gui_compiled", cmd_ord_openroad_gui_compiled)
+    interp.register_command("gui::enabled", cmd_gui_enabled)
+
+    # Register sta:: namespace commands
+    interp.register_command("sta::max_slew_check_limit", cmd_sta_limit)
+    interp.register_command("sta::max_fanout_check_limit", cmd_sta_limit)
+    interp.register_command("sta::max_capacitance_check_limit", cmd_sta_limit)
+    interp.register_command("sta::max_slew_check_slack_limit", cmd_sta_limit)
+    interp.register_command("sta::max_fanout_check_slack_limit", cmd_sta_limit)
+    interp.register_command("sta::max_capacitance_check_slack_limit", cmd_sta_limit)
+    interp.register_command("sta::max_slew_check_slack", cmd_sta_slack)
+    interp.register_command("sta::max_fanout_check_slack", cmd_sta_slack)
+    interp.register_command("sta::max_capacitance_check_slack", cmd_sta_slack)
+    interp.register_command("sta::max_slew_violation_count", cmd_sta_count)
+    interp.register_command("sta::max_fanout_violation_count", cmd_sta_count)
+    interp.register_command("sta::max_capacitance_violation_count", cmd_sta_count)
+    interp.register_command("sta::endpoint_count", cmd_sta_count)
+    interp.register_command("sta::endpoint_violation_count", cmd_sta_count)
+    interp.register_command("sta::worst_slack_cmd", cmd_sta_slack)
+    interp.register_command("sta::time_sta_ui", cmd_sta_count)
+    interp.register_command("sta::format_time", cmd_sta_format_time)
+    interp.register_command(
+        "sta::network_leaf_instance_count", cmd_sta_leaf_instance_count
+    )
+    interp.register_command("sta::network_leaf_pin_count", cmd_sta_leaf_pin_count)

--- a/mock/openroad/src/bin/openroad_commands_test.py
+++ b/mock/openroad/src/bin/openroad_commands_test.py
@@ -851,5 +851,29 @@ class TestCoreAreaBbox:
         del os.environ["CORE_AREA"]
 
 
+class TestRoutingAndFlowPredicates:
+    def test_grt_have_routes(self, interp):
+        assert interp.eval("grt::have_routes") == "1"
+        assert interp.eval("expr {![grt::have_routes]}") == "0"
+
+    def test_design_is_routed(self, interp):
+        assert interp.eval("design_is_routed") == "1"
+        assert interp.eval("expr {![design_is_routed]}") == "0"
+
+    def test_check_antennas_and_placement_falsy(self, interp):
+        assert interp.eval("check_antennas") == "0"
+        assert interp.eval("check_placement") == "0"
+        assert interp.eval("repair_antennas") == "0"
+
+    def test_all_clocks_and_design(self, interp, state):
+        state.clocks = {"clk1": "clk1_port", "clk2": "clk2_port"}
+        state.design_name = "test_top"
+        assert interp.eval("all_clocks") == "clk1 clk2"
+        assert interp.eval("current_design") == "test_top"
+
+    def test_gpl_uniform_density(self, interp):
+        assert interp.eval("gpl::get_global_placement_uniform_density") == "0.5"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/mock/openroad/src/bin/tcl_interpreter.py
+++ b/mock/openroad/src/bin/tcl_interpreter.py
@@ -71,12 +71,16 @@ class TclInterpreter:
 
     def set_array(self, array_name, key, value):
         """Set an array element."""
+        if array_name in ("env", "::env"):
+            os.environ[key] = str(value)
         if array_name not in self.arrays:
             self.arrays[array_name] = {}
         self.arrays[array_name][key] = str(value)
 
     def get_array(self, array_name, key):
         """Get an array element."""
+        if array_name in ("env", "::env"):
+            return os.environ.get(key, "")
         if array_name in self.arrays and key in self.arrays[array_name]:
             return self.arrays[array_name][key]
         raise TclError(f'can\'t read "{array_name}({key})": no such element in array')
@@ -529,6 +533,8 @@ class TclInterpreter:
         self.commands["source"] = self._cmd_source
         self.commands["catch"] = self._cmd_catch
         self.commands["error"] = self._cmd_error
+        self.commands["exit"] = self._cmd_exit
+        self.commands["lassign"] = self._cmd_lassign
         self.commands["list"] = self._cmd_list
         self.commands["lappend"] = self._cmd_lappend
         self.commands["lindex"] = self._cmd_lindex
@@ -562,6 +568,7 @@ class TclInterpreter:
         self.commands["switch"] = self._cmd_switch
         self.commands["rename"] = self._cmd_rename
         self.commands["eval"] = self._cmd_eval
+        self.commands["exec"] = self._cmd_exec
         self.commands["namespace"] = self._cmd_namespace
         self.commands["package"] = self._cmd_package
         self.commands["variable"] = self._cmd_variable
@@ -765,6 +772,29 @@ class TclInterpreter:
         if len(args) < 1:
             raise TclError('wrong # args: should be "error message"')
         raise TclError(args[0])
+
+    def _cmd_lassign(self, interp, args):
+        if len(args) < 1:
+            raise TclError('wrong # args: should be "lassign list ?varName ...?"')
+        values = self._parse_list(args[0])
+        names = args[1:]
+        for i, name in enumerate(names):
+            self.variables[name] = values[i] if i < len(values) else ""
+        return " ".join(values[len(names) :])
+
+    def _cmd_exit(self, interp, args):
+        # Terminate like real TCL: a script's `exit 1` must fail the
+        # process, not be swallowed as an unknown command (that swallow
+        # once let execution run past a fatal ORFS error and fabricate
+        # outputs). SystemExit deliberately bypasses `except Exception`
+        # handlers between here and main().
+        code = 0
+        if args:
+            try:
+                code = int(args[0])
+            except ValueError:
+                raise TclError(f'expected integer but got "{args[0]}"')
+        raise SystemExit(code)
 
     # --- List commands ---
 
@@ -1124,17 +1154,15 @@ class TclInterpreter:
         elif subcmd == "delete":
             force = "-force" in sargs
             for f in sargs:
-                if f == "-force":
+                if f in ("-force", "--"):
                     continue
                 try:
                     if os.path.isdir(f):
                         import shutil
 
                         shutil.rmtree(f)
-                    elif os.path.exists(f):
+                    elif os.path.exists(f) or os.path.islink(f):
                         os.remove(f)
-                    elif not force:
-                        raise TclError(f'could not delete "{f}": no such file')
                 except OSError as e:
                     if not force:
                         raise TclError(str(e))
@@ -1231,7 +1259,19 @@ class TclInterpreter:
             return ""
         subcmd = args[0]
         if subcmd == "exists":
-            return "1" if args[1] in self.variables else "0"
+            varname = args[1] if len(args) > 1 else ""
+            if varname.startswith("::env(") or varname.startswith("env("):
+                key = varname[varname.index("(") + 1 : -1] if ")" in varname else ""
+                return "1" if key in os.environ else "0"
+            if "(" in varname and varname.endswith(")"):
+                arr = varname[: varname.index("(")].lstrip(":")
+                key = varname[varname.index("(") + 1 : -1]
+                return "1" if arr in self.arrays and key in self.arrays[arr] else "0"
+            return (
+                "1"
+                if varname in self.variables or varname.lstrip(":") in self.variables
+                else "0"
+            )
         elif subcmd == "procs":
             pattern = args[1] if len(args) > 1 else "*"
             return self._to_list(list(self.procs.keys()))
@@ -1407,6 +1447,24 @@ class TclInterpreter:
 
     def _cmd_eval(self, interp, args):
         return self._eval_script(" ".join(args))
+
+    def _cmd_exec(self, interp, args):
+        import subprocess
+
+        if not args:
+            return ""
+        cmd_args = [a for a in args if a != "--"]
+        if not cmd_args:
+            return ""
+        try:
+            res = subprocess.run(cmd_args, check=True, text=True, capture_output=True)
+            return res.stdout
+        except subprocess.CalledProcessError as e:
+            raise TclError(f"exec failed: {e}")
+        except FileNotFoundError as e:
+            raise TclError(
+                f'couldn\'t execute "{cmd_args[0]}": no such file or directory'
+            )
 
     def _cmd_namespace(self, interp, args):
         if not args:
@@ -1587,8 +1645,134 @@ class TclInterpreter:
     def _eval_expr(self, expr_str):
         """Evaluate a TCL expression. Returns result as appropriate Python type."""
         # First, substitute variables and commands
-        substituted = self._substitute(expr_str)
+        return self._eval_substituted_expr(self._substitute(expr_str))
 
+    @staticmethod
+    def _quote_bare_words(s):
+        """Quote unquoted string literals in TCL expressions so Python eval handles them."""
+        known_funcs = {
+            "int",
+            "float",
+            "round",
+            "abs",
+            "sqrt",
+            "pow",
+            "log",
+            "log10",
+            "ceil",
+            "floor",
+            "sin",
+            "cos",
+            "tan",
+            "max",
+            "min",
+            "double",
+            "wide",
+        }
+        keywords = {
+            "and",
+            "or",
+            "not",
+            "in",
+            "is",
+            "True",
+            "False",
+            "true",
+            "false",
+            "yes",
+            "no",
+            "on",
+            "off",
+        }
+
+        def is_number(token):
+            try:
+                float(token)
+                return True
+            except ValueError:
+                return False
+
+        pattern = re.compile(
+            r"\"(?:\\.|[^\"])*\"|\'[^\']*\'|[a-zA-Z0-9_./\-]+|==|!=|<=|>=|&&|\|\||//|\*\*|[^\s]"
+        )
+        pos = 0
+        res = []
+        for m in pattern.finditer(s):
+            res.append(s[pos : m.start()])
+            tok = m.group(0)
+            pos = m.end()
+            if (tok.startswith('"') and tok.endswith('"')) or (
+                tok.startswith("'") and tok.endswith("'")
+            ):
+                res.append(tok)
+            elif is_number(tok):
+                res.append(tok)
+            elif tok in keywords or tok in known_funcs:
+                res.append(tok)
+            elif re.match(r"^[a-zA-Z0-9_./\-]+$", tok) and tok not in (
+                "+",
+                "-",
+                "*",
+                "/",
+                "%",
+            ):
+                rest_of_s = s[pos:].lstrip()
+                if rest_of_s.startswith("("):
+                    res.append(tok)
+                else:
+                    res.append(f'"{tok}"')
+            else:
+                res.append(tok)
+        res.append(s[pos:])
+        return "".join(res)
+
+    @staticmethod
+    def _split_ternary(s):
+        """Split a top-level TCL ternary ``cond ? then : else``.
+
+        Returns (cond, then, else) or None when s has no top-level ``?``.
+        Skips over quoted strings and any parenthesis/bracket/brace
+        nesting; a nested ternary in the then-branch keeps its own ``:``.
+        """
+
+        def scan(start, stop_chars, pending_ternaries):
+            depth = 0
+            in_quote = False
+            i = start
+            while i < len(s):
+                c = s[i]
+                if in_quote:
+                    if c == "\\":
+                        i += 2
+                        continue
+                    if c == '"':
+                        in_quote = False
+                elif c == '"':
+                    in_quote = True
+                elif c in "([{":
+                    depth += 1
+                elif c in ")]}":
+                    depth -= 1
+                elif depth == 0 and c in stop_chars:
+                    if c == ":" and pending_ternaries[0] > 0:
+                        pending_ternaries[0] -= 1
+                    elif c == "?" and ":" in stop_chars:
+                        pending_ternaries[0] += 1
+                    else:
+                        return i
+                i += 1
+            return -1
+
+        q = scan(0, "?", [0])
+        if q < 0:
+            return None
+        colon = scan(q + 1, "?:", [0])
+        if colon < 0:
+            return None
+        return (s[:q], s[q + 1 : colon], s[colon + 1 :])
+
+    def _eval_substituted_expr(self, substituted):
+        """Evaluate an already-substituted TCL expression string."""
         # Handle TCL boolean literals
         s = substituted.strip()
         if s.lower() in ("true", "yes", "on"):
@@ -1596,9 +1780,38 @@ class TclInterpreter:
         if s.lower() in ("false", "no", "off"):
             return 0
 
-        # Replace TCL operators with Python equivalents
+        # TCL ternary: expr { cond ? a : b }. Python has no ?: and the
+        # branches may be bare words (e.g. "4_cts"), so evaluate the
+        # condition and recurse into only the chosen branch.
+        ternary = self._split_ternary(s)
+        if ternary is not None:
+            cond, then_branch, else_branch = ternary
+            chosen = (
+                then_branch
+                if self._truthy(self._eval_substituted_expr(cond))
+                else else_branch
+            ).strip()
+            if len(chosen) >= 2 and chosen[0] == chosen[-1] == '"':
+                return chosen[1:-1]
+            if len(chosen) >= 2 and chosen[0] == "{" and chosen[-1] == "}":
+                return chosen[1:-1]
+            return self._eval_substituted_expr(chosen)
+
+        # A command substitution that produced "" leaves a dangling
+        # comparison operand ('[find_macros] != ""' arrives as ' != ""');
+        # TCL would compare the empty string, so restore it.
+        if re.match(r"^\s*(?:==|!=|<=|>=|<|>|eq\b|ne\b)", s):
+            s = '""' + s
+        if re.search(r"(?:==|!=|<=|>=|<|>|\beq|\bne)\s*$", s):
+            s = s + '""'
+
+        # Quote bare string words before operator substitution so that
+        # unquoted strings (e.g. $PLATFORM expanding to asap7) compare correctly.
         s = re.sub(r"\beq\b", "==", s)
         s = re.sub(r"\bne\b", "!=", s)
+        s = self._quote_bare_words(s)
+
+        # Replace TCL operators with Python equivalents
         s = s.replace("&&", " and ")
         s = s.replace("||", " or ")
         s = s.replace("!", " not ")
@@ -1606,9 +1819,6 @@ class TclInterpreter:
         s = s.replace(" not =", "!=")
         # TCL integer division: use //
         s = re.sub(r"(?<!\/)\/(?!\/)", "//", s)
-
-        # Handle TCL ternary: expr { cond ? a : b }
-        # Python eval handles this natively
 
         # Handle double(x), int(x), etc.
         s = re.sub(r"\bdouble\s*\(", "float(", s)
@@ -1643,6 +1853,12 @@ class TclInterpreter:
                     "min": min,
                     "True": 1,
                     "False": 0,
+                    "true": 1,
+                    "false": 0,
+                    "yes": 1,
+                    "no": 0,
+                    "on": 1,
+                    "off": 0,
                 },
             )
             if isinstance(result, bool):
@@ -1656,12 +1872,23 @@ class TclInterpreter:
                 return int(result)
             return result
         except Exception:
-            # If eval fails, return as string
+            # If eval fails, return as string. That is how bare words pass
+            # through ("expr {abc}" -> "abc"), but a string that still
+            # carries operators is a real expression this interpreter
+            # failed to evaluate — say so instead of silently returning
+            # source text as a value (that is how the unevaluated ternary
+            # ended up spliced into a results filename once).
+            if any(op in s for op in ("?", "&&", "||", "<", ">", "==", "!=", "\n")):
+                print(
+                    f"mock-openroad: warning: expr not evaluated, "
+                    f"returning as string: {s!r}",
+                    file=sys.stderr,
+                )
             return s
 
-    def _expr_bool(self, expr_str):
-        """Evaluate an expression and return as boolean."""
-        result = self._eval_expr(expr_str)
+    @staticmethod
+    def _truthy(result):
+        """TCL truthiness of an already-evaluated expression result."""
         if isinstance(result, str):
             s = result.strip().lower()
             if s in ("0", "false", "no", "off", ""):
@@ -1676,3 +1903,7 @@ class TclInterpreter:
                 except ValueError:
                     return bool(s)
         return bool(result)
+
+    def _expr_bool(self, expr_str):
+        """Evaluate an expression and return as boolean."""
+        return self._truthy(self._eval_expr(expr_str))

--- a/mock/openroad/src/bin/tcl_interpreter_test.py
+++ b/mock/openroad/src/bin/tcl_interpreter_test.py
@@ -225,6 +225,82 @@ class TestExpr:
         result = interp.eval("expr $x * 2")
         assert result == "20"
 
+    def test_ternary(self, interp):
+        assert interp.eval('expr { 1 ? "a" : "b" }') == "a"
+        assert interp.eval('expr { 0 ? "a" : "b" }') == "b"
+        assert interp.eval("expr { 2 > 1 ? 10 : 20 }") == "10"
+
+    def test_ternary_bare_word_branches(self, interp):
+        # The generate_abstract.tcl shape: branches are bare words
+        # ("4_cts"), spread over multiple lines, condition from a
+        # command substitution. Must yield the branch VALUE, never the
+        # unevaluated expression text.
+        interp.eval("set stage 4_cts")
+        result = interp.eval('expr {\n  1 ?\n  $stage :\n  "6_final"\n}')
+        assert result == "4_cts"
+
+    def test_ternary_nested(self, interp):
+        assert interp.eval('expr { 1 ? 0 ? "x" : "y" : "z" }') == "y"
+        assert interp.eval('expr { 0 ? "x" : 1 ? "y" : "z" }') == "y"
+
+    def test_ternary_condition_variable(self, interp):
+        interp.eval("set flag 0")
+        assert interp.eval('expr { $flag ? "on" : "off" }') == "off"
+
+    def test_empty_command_result_comparison(self, interp):
+        # [unknown_cmd] substitutes to "" and would leave a dangling
+        # operand; TCL compares the empty string.
+        assert interp.eval('expr { [unknown_command_xyz] != "" }') == "0"
+        assert interp.eval('expr { [unknown_command_xyz] == "" }') == "1"
+
+    def test_unquoted_bare_word_comparisons(self, interp):
+        interp.eval("set platform asap7")
+        assert interp.eval('expr { $platform == "" }') == "0"
+        assert interp.eval('expr { $platform != "" }') == "1"
+        assert interp.eval('expr { $platform == "asap7" }') == "1"
+        assert interp.eval("expr { $platform == asap7 }") == "1"
+        assert interp.eval('expr { !1 || $platform == "" }') == "0"
+
+    def test_stage_name_comparisons(self, interp):
+        interp.eval("set stage 4_cts")
+        assert interp.eval('expr { $stage == "4_cts" }') == "1"
+        assert interp.eval('expr { $stage != "6_final" }') == "1"
+        assert interp.eval("expr { $stage == 4_cts }") == "1"
+        interp.eval("set file 1_2_yosys.v")
+        assert interp.eval('expr { $file == "1_2_yosys.v" }') == "1"
+        assert interp.eval('expr { $file == "" }') == "0"
+
+
+class TestLassign:
+    def test_lassign_basic(self, interp):
+        interp.eval("lassign {10 20} x y")
+        assert interp.eval("set x") == "10"
+        assert interp.eval("set y") == "20"
+
+    def test_lassign_missing_values_empty(self, interp):
+        interp.eval("lassign {only} a b")
+        assert interp.eval("set a") == "only"
+        assert interp.eval("set b") == ""
+
+    def test_lassign_returns_leftovers(self, interp):
+        assert interp.eval("lassign {1 2 3 4} a b") == "3 4"
+
+
+class TestExit:
+    def test_exit_raises_system_exit(self, interp):
+        import pytest
+
+        with pytest.raises(SystemExit) as excinfo:
+            interp.eval("exit 3")
+        assert excinfo.value.code == 3
+
+    def test_exit_default_code_zero(self, interp):
+        import pytest
+
+        with pytest.raises(SystemExit) as excinfo:
+            interp.eval("exit")
+        assert (excinfo.value.code or 0) == 0
+
 
 # --- List operations ---
 
@@ -592,6 +668,28 @@ class TestFRC:
         interp.eval("file exists /nonexistent/foo.txt")
         captured = capsys.readouterr()
         assert "FRC" not in captured.err
+
+
+class TestExec:
+    def test_exec_echo(self, interp):
+        res = interp.eval('exec echo "hello world"')
+        assert "hello world" in res
+
+    def test_exec_cp(self, interp, tmp_path):
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("content")
+        interp.eval(f"exec cp {src} {dst}")
+        assert dst.read_text() == "content"
+
+
+class TestEnvArray:
+    def test_env_read_and_exists(self, interp, monkeypatch):
+        monkeypatch.setenv("TEST_VAR_123", "abc")
+        assert interp.eval("info exists env(TEST_VAR_123)") == "1"
+        assert interp.eval("info exists ::env(TEST_VAR_123)") == "1"
+        assert interp.eval("set x $env(TEST_VAR_123)") == "abc"
+        assert interp.eval("set y $::env(TEST_VAR_123)") == "abc"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the `can't read "num1"` / `Could not determine design stage from .../1 ?  4_cts : "6_final".odb` error seen in mock `generate_abstract` actions. Not an ORFS regression — `generate_abstract.tcl`/`util.tcl` are byte-identical across the recent ORFS pins; the defect is in the mock's Tcl interpreter and predates the bump.

**The silent chain:** the mock's `_eval_expr` claimed Python `eval` handles the Tcl ternary natively (it doesn't), and its blanket `except` returned the *unevaluated source text* as the value. `generate_abstract.tcl`'s stem ternary became the literal string `1 ?\n 4_cts :\n "6_final"`; `util.tcl`'s `extract_stage` regexp failed; its `exit 1` was swallowed as an unknown command; execution fell through to the unset `num1`; and `openroad.py` caught the error, fabricated a hardcoded 10x10 stub LEF/lib, and returned 0. Every mock abstract to date was silently that stub.

**Fixes** (one per link):
- `expr` implements the Tcl ternary: quote/nesting-aware top-level `?`/`:` split, nested ternaries counted, only the chosen branch evaluated — bare-word branches like `4_cts` survive as values.
- An empty command-substitution result no longer drops its comparison operand: `[find_macros] != ""` now compares the empty string as Tcl does (this was silently steering `macro_place.tcl` into its macro branch on macro-less designs, where the also-missing `lassign` left `halo_x` unset).
- `exit` and `lassign` are real commands: `exit` raises SystemExit (nonzero fails the process; a clean exit stops the scripts but still writes the `-metrics` file), `lassign` assigns its variables.
- `openroad.py`: a Tcl error now **fails the action** instead of fabricating fallback outputs with exit 0. Tolerance for unimplemented commands is unchanged — unknown commands still return "" — an exception now means the script genuinely broke. The old fabricate-and-succeed behavior remains available behind `MOCK_OPENROAD_TOLERATE_TCL_ERRORS=1`.

**Verification:** new unit tests for ternary (incl. nested / bare-word / multiline), `lassign`, `exit`, and empty-operand comparisons; all 57 `//test` mock targets build under the strict policy; the `mock_full_abstract` `lb_32x128.lef` is now the real `write_abstract_lef` output (computed size, proper header) rather than the 10x10 stub; a deliberate `error` exits 1 and a clean `exit` still writes metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)