### PR TITLE
orfs_run: the src stage's logs become an opt-in input (src_logs)

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -209,6 +209,13 @@ def data_inputs(ctx):
     # action graph. Stage rules set default_runfiles = flow_runfiles
     # (with qt) and data_runfiles = flow_inputs (without qt); for plain
     # file/filegroup targets the two are equal so behavior is unchanged.
+    #
+    # HAZARD: a STAGE TARGET in data= brings that stage's data_runfiles
+    # wholesale — including its timestamp-bearing logs — so the consuming
+    # action re-runs whenever the stage re-executes, byte-identical
+    # artifacts or not. generate_metadata does this deliberately
+    # (genMetrics.py reads logs and jsons); anything else should depend
+    # on the specific OutputGroupInfo sub-depset instead.
     return depset(
         ctx.files.data,
         transitive = [datum.data_runfiles.files for datum in ctx.attr.data] +

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -432,11 +432,17 @@ def _run_impl(ctx):
             transitive = [
                 data_inputs(ctx),
                 source_inputs(ctx),
-                # The src stage's accumulated logs, so run scripts can read
-                # e.g. stage elapsed times. Safe here, unlike in
-                # source_inputs: the run action writes only run.log, never
-                # a stage log name, so there is no sandbox collision.
-                ctx.attr.src[LoggingInfo].logs if LoggingInfo in ctx.attr.src else depset(),
+                # The src stage's accumulated logs, opt-in via src_logs=
+                # for run scripts that read e.g. stage elapsed times.
+                # Sandbox-safe here, unlike in source_inputs: the run
+                # action writes only run.log, never a stage log name.
+                # Opt-in because logs are never byte-stable (every one
+                # carries Elapsed/CPU/Peak-memory lines), so as a default
+                # input they re-ran every orfs_run whenever any upstream
+                # stage re-executed, byte-identical artifacts or not.
+                ctx.attr.src[LoggingInfo].logs if (
+                    ctx.attr.src_logs and LoggingInfo in ctx.attr.src
+                ) else depset(),
             ],
         ),
         outputs = outs,
@@ -530,6 +536,18 @@ _orfs_run_rule = rule(
                 "script": attr.label(
                     mandatory = True,
                     allow_single_file = ["tcl"],
+                ),
+                "src_logs": attr.bool(
+                    default = False,
+                    doc = "Stage the src stage's accumulated logs into the " +
+                          "run action's inputs, for scripts that read them " +
+                          "(e.g. stage elapsed times from $LOG_DIR/*.log). " +
+                          "Off by default: every log carries wall-clock/" +
+                          "CPU/memory lines, so a log input re-runs this " +
+                          "action whenever ANY upstream stage re-executes — " +
+                          "even when the artifacts it actually reads are " +
+                          "byte-identical — and guarantees remote-cache " +
+                          "misses across machines.",
                 ),
                 "stages": attr.string_list(
                     mandatory = False,

--- a/test/BUILD
+++ b/test/BUILD
@@ -711,6 +711,27 @@ synth_action_inputs_test(
     target_under_test = ":src_propagation_floorplan",
 )
 
+# Stage logs are timestamped (Elapsed/CPU/Peak-memory on every run), so
+# they enter an orfs_run's inputs only via src_logs = True — a default
+# log input re-ran every orfs_run whenever any upstream stage
+# re-executed, byte-identical artifacts or not.
+synth_action_inputs_test(
+    name = "orfs_run_no_src_logs_by_default_test",
+    forbidden_input_basenames = [
+        "1_synth.log",
+        "2_1_floorplan.log",
+    ],
+    output_basename = "lb_32x128_io-placement.tcl",
+    target_under_test = ":lb_32x128_write_pin_placement",
+)
+
+synth_action_inputs_test(
+    name = "orfs_run_src_logs_opt_in_test",
+    output_basename = "ground_truth.json",
+    required_input_basenames = ["5_1_grt.log"],
+    target_under_test = "//test/estimation_ladder:extract_ground_truth",
+)
+
 REGFILE_ARGUMENTS = SRAM_ARGUMENTS | BLOCK_FLOORPLAN | {
     "CORE_AREA": "1.026 1.080 4.914 4.860",
     "DIE_AREA": "0 0 5.940 5.940",

--- a/test/estimation_ladder/BUILD.bazel
+++ b/test/estimation_ladder/BUILD.bazel
@@ -62,6 +62,7 @@ orfs_run(
     sources = {
         "EXTRACT_TCL": ["extract.tcl"],
     },
+    src_logs = True,
 )
 
 # Standalone fast estimator executable target for Optuna hyperparameter exploration
@@ -187,6 +188,7 @@ orfs_run(
     sources = {
         "EXTRACT_TCL": ["extract.tcl"],
     },
+    src_logs = True,
 )
 
 orfs_run_executable(
@@ -507,6 +509,7 @@ AB_PERIODS = [
         cmd = "run",
         script = "extract.tcl",
         sources = {"EXTRACT_TCL": ["extract.tcl"]},
+        src_logs = True,
     )
     for period in AB_PERIODS
 ]


### PR DESCRIPTION
One concern from the dependency-leak sweep: **stage logs are never byte-stable** — ORFS `run_command.py` appends `Elapsed time / CPU time / Peak memory` to every log on every run — yet `orfs_run` unconditionally took the src stage's transitively accumulated logs as action inputs. Consequence: every `orfs_run` re-ran whenever ANY upstream stage re-executed, even with byte-identical artifacts, and every `orfs_run` was a guaranteed remote-cache miss across machines.

Exactly one in-repo script reads logs (`test/estimation_ladder/extract.tcl`, stage elapsed times), so the logs input becomes opt-in:

- `src_logs = attr.bool(default = False)` on `orfs_run`; the three `extract.tcl` call sites set it.
- A hazard note on `data_inputs()`: a stage target in `data=` drags that stage's timestamp-bearing logs in via `data_runfiles` — deliberate for `generate_metadata` (genMetrics.py reads logs), an accident anywhere else.

Locked by analysistests: a plain `orfs_run`'s action must not input stage logs; the estimation-ladder run must input `5_1_grt.log`.

**Verified live** (in combination with #830, on a local merge): a whitespace-only SDC edit on `lb_32x128` now executes exactly three cheap actions — sdc-copy, clock-period extraction, `do-1_synth` — with synthesis, floorplan, **and** the `write_pin_placement` orfs_run all cache-hitting. Before this change the orfs_run re-ran on every such edit via the fresh log bytes.

Downstream note: consumers whose run scripts read `$LOG_DIR/*.log` from the src stage need `src_logs = True` (fails loudly otherwise if the script errors on missing logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)