### PR TITLE
refactor(test): simplify verify_macro_collateral.tcl for early failure

### DIFF
--- a/test/verify_macro_collateral.tcl
+++ b/test/verify_macro_collateral.tcl
@@ -1,14 +1,4 @@
-if {![info exists ::env(PLATFORM)] || $::env(PLATFORM) == ""} {
-    puts "FAIL: PLATFORM is not set"
-    exit 1
-}
-if {![info exists ::env(DESIGN_NAME)] || $::env(DESIGN_NAME) == ""} {
-    puts "FAIL: DESIGN_NAME is not set"
-    exit 1
-}
-if {![info exists ::env(ADDITIONAL_LEFS)] || $::env(ADDITIONAL_LEFS) == ""} {
-    puts "FAIL: ADDITIONAL_LEFS is empty or not set"
-    exit 1
+if {$::env(PLATFORM) eq "" || $::env(DESIGN_NAME) eq "" || $::env(ADDITIONAL_LEFS) eq ""} {
+    error "PLATFORM, DESIGN_NAME, and ADDITIONAL_LEFS must not be empty"
 }
 puts "PASS: Macro collateral and design immutable variables are present: PLATFORM=$::env(PLATFORM), DESIGN_NAME=$::env(DESIGN_NAME), ADDITIONAL_LEFS=$::env(ADDITIONAL_LEFS)"
-exit 0


### PR DESCRIPTION
Simplify `test/verify_macro_collateral.tcl` by letting missing env var references fail early with standard Tcl variable lookup errors rather than defensive manual `info exists` checks.