### PR TITLE
Stage only the macro .lib variant the stage's arguments reference

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -237,7 +237,28 @@ def data_inputs_excluding(ctx, exclude_path):
         if f.path != exclude_path
     ])
 
-def source_inputs(ctx):
+def source_inputs(ctx, use_pre_layout = None):
+    """Inputs a stage action takes from its ``src`` stage.
+
+    Args:
+        ctx: Rule context.
+        use_pre_layout: selects which macro .lib variant is staged, with
+            the SAME meaning as orfs_additional_arguments(use_pre_layout):
+            True stages only the pre-layout (ideal-clock) libs, False only
+            the post-layout ones — matching what the stage's args.mk
+            actually references, so a macro re-characterization that
+            touches only the other variant no longer re-runs the stage.
+            None (default) stages both: for orfs_run/orfs_test/
+            orfs_arguments, whose user scripts may read either, and for
+            squashed multi-stage actions that span both timing domains.
+    Returns:
+        A depset of files.
+    """
+    lib_depsets = []
+    if use_pre_layout != False:
+        lib_depsets.append(ctx.attr.src[OrfsInfo].additional_libs_pre_layout)
+    if use_pre_layout != True:
+        lib_depsets.append(ctx.attr.src[OrfsInfo].additional_libs)
     return depset(
         ctx.files.src,
         transitive = [
@@ -256,8 +277,6 @@ def source_inputs(ctx):
             ctx.attr.src[OrfsDepInfo].files,
             ctx.attr.src[OrfsInfo].additional_gds,
             ctx.attr.src[OrfsInfo].additional_lefs,
-            ctx.attr.src[OrfsInfo].additional_libs,
-            ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
             ctx.attr.src[PdkInfo].files,
             ctx.attr.src[PdkInfo].libs,
             # Accumulate all JSON reports, so depend on previous stage.
@@ -265,7 +284,7 @@ def source_inputs(ctx):
             ctx.attr.src[LoggingInfo].reports,
             # non-idempotent by design transitive dependencies
             # ctx.attr.src[LoggingInfo].logs,
-        ],
+        ] + lib_depsets,
     )
 
 def rename_inputs(ctx):

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -2523,6 +2523,13 @@ def _make_impl(
             [_make_cmd(ctx)]
         )
 
+        # Stage only the macro .lib variant this stage's args.mk references
+        # (mirrors the orfs_additional_arguments(use_pre_layout) selection
+        # above). Squashed multi-stage actions span both timing domains,
+        # so they keep both variants.
+        lib_selection = use_pre_layout
+        if getattr(ctx.attr, "stages", None) and len(ctx.attr.stages) > 1:
+            lib_selection = None
         ctx.actions.run_shell(
             arguments = ["--file", ctx.file._makefile.path] + steps,
             command = " && ".join(commands),
@@ -2531,7 +2538,7 @@ def _make_impl(
                 [config] + ctx.files.extra_configs + all_jsons,
                 transitive = [
                     data_inputs(ctx),
-                    source_inputs(ctx),
+                    source_inputs(ctx, use_pre_layout = lib_selection),
                     rename_inputs(ctx),
                 ],
             ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -732,6 +732,29 @@ synth_action_inputs_test(
     target_under_test = "//test/estimation_ladder:extract_ground_truth",
 )
 
+# A stage's inputs carry only the macro .lib variant its args.mk
+# references (orfs_additional_arguments use_pre_layout): floorplan/place
+# take the pre-layout (ideal-clock) libs, later stages the post-layout
+# ones. Both .lib variants share a basename and differ only in the
+# variant directory, hence the path matching. Without the split, a
+# macro re-characterization that touches one variant re-ran stages that
+# only reference the other.
+synth_action_inputs_test(
+    name = "lib_pre_layout_inputs_floorplan_test",
+    forbidden_input_path_contains = ["base/lb_32x128_typ.lib"],
+    output_basename = "2_floorplan.odb",
+    required_input_path_contains = ["pre_layout/lb_32x128_typ.lib"],
+    target_under_test = ":lb_32x128_top_mock_hierarchy_floorplan",
+)
+
+synth_action_inputs_test(
+    name = "lib_post_layout_inputs_abstract_test",
+    forbidden_input_path_contains = ["pre_layout/lb_32x128_typ.lib"],
+    output_basename = "lb_32x128_top.lef",
+    required_input_path_contains = ["base/lb_32x128_typ.lib"],
+    target_under_test = ":lb_32x128_top_mock_hierarchy_generate_abstract",
+)
+
 REGFILE_ARGUMENTS = SRAM_ARGUMENTS | BLOCK_FLOORPLAN | {
     "CORE_AREA": "1.026 1.080 4.914 4.860",
     "DIE_AREA": "0 0 5.940 5.940",

--- a/test/sdc_clock_period_test.bzl
+++ b/test/sdc_clock_period_test.bzl
@@ -34,7 +34,8 @@ def _synth_action_inputs_test_impl(ctx):
     )
 
     for action in matching:
-        input_basenames = {f.basename: True for f in action.inputs.to_list()}
+        inputs = action.inputs.to_list()
+        input_basenames = {f.basename: True for f in inputs}
         for required in ctx.attr.required_input_basenames:
             asserts.true(
                 env,
@@ -49,6 +50,28 @@ def _synth_action_inputs_test_impl(ctx):
                 env,
                 forbidden in input_basenames,
                 "Expected %s NOT to be an input of the action producing %s" % (
+                    forbidden,
+                    ctx.attr.output_basename,
+                ),
+            )
+
+        # Path-substring matching, for inputs whose basenames collide —
+        # e.g. a macro's pre- and post-layout .lib are both
+        # <design>_typ.lib, distinguished only by the variant directory.
+        for required in ctx.attr.required_input_path_contains:
+            asserts.true(
+                env,
+                any([required in f.path for f in inputs]),
+                "Expected an input path containing %s in the action producing %s" % (
+                    required,
+                    ctx.attr.output_basename,
+                ),
+            )
+        for forbidden in ctx.attr.forbidden_input_path_contains:
+            asserts.false(
+                env,
+                any([forbidden in f.path for f in inputs]),
+                "Expected NO input path containing %s in the action producing %s" % (
                     forbidden,
                     ctx.attr.output_basename,
                 ),
@@ -71,6 +94,14 @@ synth_action_inputs_test = analysistest.make(
         "forbidden_input_basenames": attr.string_list(
             doc = "Basenames that must NOT appear among the selected " +
                   "action's inputs.",
+        ),
+        "required_input_path_contains": attr.string_list(
+            doc = "Substrings each of which must appear in at least one " +
+                  "input's path of the selected action.",
+        ),
+        "forbidden_input_path_contains": attr.string_list(
+            doc = "Substrings none of which may appear in any input's " +
+                  "path of the selected action.",
         ),
     },
 )


### PR DESCRIPTION
Next single-concern PR from the dependency-leak sweep (after #833).

`source_inputs()` staged **both** macro `.lib` variants (post-layout and pre-layout/ideal-clock) into every stage action, while the stage's `args.mk` references exactly one — `orfs_additional_arguments` selects by `_PRE_LAYOUT_STAGES` (floorplan/place take the pre-layout libs, cts onward the post-layout ones). Inputs and arguments disagreed: a macro re-characterization that rewrote only the post-layout `.lib` re-ran the parent's floorplan and place, which never open it — the classic "one macro re-hardens, the whole SoC re-runs" avalanche — and symmetrically for pre-layout-only changes.

- `source_inputs()` gains `use_pre_layout` with the same meaning as `orfs_additional_arguments`; the stage make action passes its stage-derived value.
- Squashed multi-stage actions span both timing domains and keep both variants, as do `orfs_run`/`orfs_test`/`orfs_arguments` (user scripts may read either). No behavior change there.
- The analysistest rule gains path-substring matching (`required/forbidden_input_path_contains`): both `.lib` variants share a basename and differ only in the variant directory.

Locked on the `mock_hierarchy` flow: floorplan must carry the pre-layout lib and not the post-layout one; `generate_abstract` the reverse. Verified: the full mock hierarchy/merge/sweep flows and the whole input-analysistest suite (25 tests) pass; `bazelisk build --nobuild //...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)