### PR TITLE
Reject flow-level data=, scope files with stage_data

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -60,6 +60,12 @@ def _filter_stage_args(stage, **kwargs):
         return kwargs
 
     arguments = kwargs.pop("arguments", {})
+
+    # A `data` in kwargs here is PER-STAGE (an internal caller wiring one
+    # stage's own inputs, e.g. generate_metadata's stage-target deps) and
+    # passes through as the stage rule's data attr. The flow-level
+    # fan-out — one dict concatenated into every stage — is rejected in
+    # orfs_flow() itself; use stage_data= there instead.
     data = kwargs.pop("data", [])
     extra_arguments = kwargs.pop("extra_arguments", {})
     extra_configs = kwargs.pop("extra_configs", {})
@@ -350,6 +356,13 @@ def orfs_flow(
     # typo in a flow that instantiates no stage (last_stage past its own
     # start) still fails loudly.
     check_stage_variables(arguments, sources, user_arguments, user_sources)
+    if "data" in kwargs:
+        fail(
+            "orfs_flow(data = ...) fans the files out to every stage — " +
+            "any edit re-runs the whole flow. Use " +
+            'stage_data = {"<stage>": [...]} to scope them to the ' +
+            "stage(s) that read them.",
+        )
     if abstract_stage and last_stage:
         fail("abstract_stage and last_stage are mutually exclusive")
     if variant == "base":
@@ -391,7 +404,6 @@ def orfs_flow(
         name = _step_name(name, variant, "variables"),
         arguments = arguments | user_arguments,
         data = depset(
-            kwargs.get("data", []) +
             [v for vs in (sources | user_sources).values() for v in vs] +
             [v for vs in sources.values() for v in vs],
         ).to_list(),

--- a/test/downstream/BUILD.bazel
+++ b/test/downstream/BUILD.bazel
@@ -23,11 +23,11 @@ orfs_flow(
         "SYNTH_HDL_FRONTEND": "slang",
         "SLANG_PLUGIN_PATH": "$(location @sv-elab//src/yosys_plugin:slang.so)",
     },
-    data = ["@sv-elab//src/yosys_plugin:slang.so"],
     sources = {
         "SDC_FILE": [":constraints.sdc"],
     },
     last_stage = "synth",
+    stage_data = {"synth": ["@sv-elab//src/yosys_plugin:slang.so"]},
     verilog_files = ["rtl/counter.sv"],
 )
 


### PR DESCRIPTION
Dependency-leak sweep, next concern (after #833/#835): `orfs_flow`'s undocumented `**kwargs` `data=` was concatenated, unfiltered, into all eleven stage targets — one plugin or helper file re-ran the whole flow on any edit, bypassing the per-stage sources filter entirely.

- `orfs_flow(data = ...)` now fails at load time with the exact replacement spelled out: `stage_data = {"<stage>": [...]}`.
- Per-stage `data` is untouched: `_filter_stage_args` still passes an internal caller's `data` through as the single stage's own attr (that is how `generate_metadata` wires its stage-target deps) — only the flow-level fan-out is rejected.
- The one known user (test/downstream's synth-only slang plugin) moves to `stage_data = {"synth": [...]}`.

**Breaking change**, deliberately loud rather than silent: downstream consumers using flow-level `data=` get a one-line migration message at load time. Verified: full `bazelisk build --nobuild //...` clean, and a negative probe confirms the fail() fires with the migration message when `data=` is passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)