### PR TITLE
Macro .gds feeds only the GDS-emitting steps

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -237,7 +237,7 @@ def data_inputs_excluding(ctx, exclude_path):
         if f.path != exclude_path
     ])
 
-def source_inputs(ctx, use_pre_layout = None):
+def source_inputs(ctx, use_pre_layout = None, gds = True):
     """Inputs a stage action takes from its ``src`` stage.
 
     Args:
@@ -251,6 +251,8 @@ def source_inputs(ctx, use_pre_layout = None):
             None (default) stages both: for orfs_run/orfs_test/
             orfs_arguments, whose user scripts may read either, and for
             squashed multi-stage actions that span both timing domains.
+        gds: whether the macro .gds files are staged. Only the
+            GDS-emitting make steps read them (do-gds, do-final).
     Returns:
         A depset of files.
     """
@@ -259,6 +261,15 @@ def source_inputs(ctx, use_pre_layout = None):
         lib_depsets.append(ctx.attr.src[OrfsInfo].additional_libs_pre_layout)
     if use_pre_layout != True:
         lib_depsets.append(ctx.attr.src[OrfsInfo].additional_libs)
+
+    # Macro .gds files are read only where GDS is emitted (ORFS consumes
+    # ADDITIONAL_GDS solely in the klayout wrap of the final/gds path).
+    # Staging them everywhere re-ran the whole PnR chain when a macro's
+    # .gds changed while its .lef/.lib did not (klayout tech-file edits,
+    # a macro final-stage rerun). Default True: orfs_run/orfs_test user
+    # scripts may read them.
+    if gds:
+        lib_depsets.append(ctx.attr.src[OrfsInfo].additional_gds)
     return depset(
         ctx.files.src,
         transitive = [
@@ -275,7 +286,6 @@ def source_inputs(ctx, use_pre_layout = None):
             # which are read-only in the sandbox and collide with the new
             # stage's same-named log writes (Permission denied).
             ctx.attr.src[OrfsDepInfo].files,
-            ctx.attr.src[OrfsInfo].additional_gds,
             ctx.attr.src[OrfsInfo].additional_lefs,
             ctx.attr.src[PdkInfo].files,
             ctx.attr.src[PdkInfo].libs,
@@ -295,9 +305,21 @@ def rename_inputs(ctx):
 def pdk_inputs(ctx):
     return depset(transitive = [ctx.attr.pdk[PdkInfo].files, ctx.attr.pdk[PdkInfo].libs])
 
-def deps_inputs(ctx):
+def deps_inputs(ctx, gds = True):
+    """Macro dep collateral for action inputs.
+
+    Args:
+        ctx: Rule context.
+        gds: whether macro .gds files are included. The synth/yosys
+            actions never read GDS (YOSYS_DEPENDENCIES and do-1_synth's
+            prereqs carry no GDS), so they pass False — a macro .gds
+            change with stable .lef/.lib then no longer re-synthesizes
+            the parent.
+    Returns:
+        A depset of files.
+    """
     return depset(
-        [dep[OrfsInfo].gds for dep in ctx.attr.deps if dep[OrfsInfo].gds] +
+        ([dep[OrfsInfo].gds for dep in ctx.attr.deps if dep[OrfsInfo].gds] if gds else []) +
         [dep[OrfsInfo].lef for dep in ctx.attr.deps if dep[OrfsInfo].lef] +
         [dep[OrfsInfo].lib for dep in ctx.attr.deps if dep[OrfsInfo].lib] +
         [

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1117,7 +1117,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 transitive = [
                     synth_data_inputs,
                     pdk_inputs(ctx),
-                    deps_inputs(ctx),
+                    deps_inputs(ctx, gds = False),
                 ],
             ),
             outputs = [checkpoint_output] + keep_logs,
@@ -1303,7 +1303,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
 
     # Full macro inputs — used by the top action, and as the fallback
     # for every partition when per-partition scoping is disabled.
-    all_macro_files = deps_inputs(ctx)
+    all_macro_files = deps_inputs(ctx, gds = False)
 
     # Per-macro lookup tables, keyed by Verilog module name
     # (TopInfo.module_top — what the RTLIL hierarchy contains). Used
@@ -1316,7 +1316,9 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
         info = dep[OrfsInfo]
         if not info.lef:
             continue
-        files = [info.gds, info.lef, info.lib]
+
+        # No .gds: partition synthesis never reads it (see deps_inputs).
+        files = [info.lef, info.lib]
         if info.lib_pre_layout:
             files.append(info.lib_pre_layout)
         name = dep[TopInfo].module_top
@@ -1592,7 +1594,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
             transitive = [
                 data_inputs(ctx),
                 pdk_inputs(ctx),
-                deps_inputs(ctx),
+                deps_inputs(ctx, gds = False),
             ],
         ),
         outputs = [synth_outputs["1_2_yosys.sdc"]],
@@ -1631,7 +1633,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
                 transitive = [
                     data_inputs(ctx),
                     pdk_inputs(ctx),
-                    deps_inputs(ctx),
+                    deps_inputs(ctx, gds = False),
                 ],
             ),
             outputs = [synth_outputs["1_synth.odb"], synth_outputs["1_synth.sdc"]] + synth_jsons,
@@ -1702,7 +1704,7 @@ def _yosys_impl(ctx):
     # then fails the ODB LEF-master lookup (ORD-2013). Blackboxing at read
     # keeps the bare name.
     canon_config = config
-    canon_deps = deps_inputs(ctx)
+    canon_deps = deps_inputs(ctx, gds = False)
     if ctx.attr.kept_macros_enabled and ctx.attr.canon_blackbox_macros:
         # The caller names exactly the macros to blackbox at canonicalize
         # (canon_blackbox_macros — e.g. the SHARED_LOGIC macros). They are
@@ -1768,8 +1770,9 @@ def _yosys_impl(ctx):
                 inputs = canon_jsons + [ctx.file._merge_arguments, filter_json] + ctx.files.extra_configs,
                 outputs = [canon_config],
             )
+
+            # No .gds: canonicalize reads liberty to blackbox, never GDS.
             canon_deps = depset(
-                [info.gds for info in soft_infos if info.gds] +
                 [info.lef for info in soft_infos if info.lef] +
                 [info.lib for info in soft_infos if info.lib] +
                 [
@@ -1952,7 +1955,7 @@ def _yosys_impl(ctx):
                 transitive = [
                     data_inputs(ctx),
                     pdk_inputs(ctx),
-                    deps_inputs(ctx),
+                    deps_inputs(ctx, gds = False),
                 ],
             ),
             outputs = synth_outputs.values() + synth_logs + synth_jsons + synth_reports,
@@ -2016,7 +2019,7 @@ def _yosys_impl(ctx):
                 transitive = [
                     synth_data_inputs,
                     pdk_inputs(ctx),
-                    deps_inputs(ctx),
+                    deps_inputs(ctx, gds = False),
                 ],
             ),
             outputs = [synth_outputs["1_2_yosys.v"], synth_outputs["mem.json"]] +
@@ -2043,7 +2046,7 @@ def _yosys_impl(ctx):
                     transitive = [
                         data_inputs(ctx),
                         pdk_inputs(ctx),
-                        deps_inputs(ctx),
+                        deps_inputs(ctx, gds = False),
                     ],
                 ),
                 outputs = [synth_outputs["1_synth.odb"], synth_outputs["1_synth.sdc"]] +
@@ -2075,7 +2078,7 @@ def _yosys_impl(ctx):
                 transitive = [
                     synth_data_inputs,
                     pdk_inputs(ctx),
-                    deps_inputs(ctx),
+                    deps_inputs(ctx, gds = False),
                 ],
             ),
             outputs = [variables],
@@ -2530,6 +2533,11 @@ def _make_impl(
         lib_selection = use_pre_layout
         if getattr(ctx.attr, "stages", None) and len(ctx.attr.stages) > 1:
             lib_selection = None
+
+        # Macro .gds is read only by the GDS-emitting make steps (the
+        # klayout wrap under do-gds / do-final); a squashed action ending
+        # at final carries stage == "6_final" and keeps it.
+        include_gds = stage in ("6_final", "6_gds")
         ctx.actions.run_shell(
             arguments = ["--file", ctx.file._makefile.path] + steps,
             command = " && ".join(commands),
@@ -2538,7 +2546,11 @@ def _make_impl(
                 [config] + ctx.files.extra_configs + all_jsons,
                 transitive = [
                     data_inputs(ctx),
-                    source_inputs(ctx, use_pre_layout = lib_selection),
+                    source_inputs(
+                        ctx,
+                        use_pre_layout = lib_selection,
+                        gds = include_gds,
+                    ),
                     rename_inputs(ctx),
                 ],
             ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -1298,6 +1298,68 @@ build_test(
     targets = [":lb_32x128_top_mock_hierarchy_merge_generate_abstract"],
 )
 
+# Fixture for the macro-GDS input-scoping tests: a macro carrying a
+# .gds, consumed by a full flow. Never built (manual) — the
+# analysistests below only inspect its action graph.
+write_file(
+    name = "gds_scope_dummy_gds",
+    out = "gds_scope_dummy.gds",
+    content = ["dummy"],
+)
+
+orfs_macro(
+    name = "gds_scope_macro",
+    gds = ":gds_scope_dummy_gds",
+    lef = ":lb_32x128_mock_abstract_generate_abstract",
+    lib = ":lb_32x128_mock_abstract_generate_abstract",
+    module_top = "lb_32x128",
+)
+
+# buildifier: disable=duplicated-name
+orfs_flow(
+    name = "lb_32x128_top",
+    arguments = SRAM_ARGUMENTS | {
+        "CORE_AREA": "2 2 23 23",
+        "CORE_MARGIN": "2",
+        "DIE_AREA": "0 0 25 25",
+        "GDS_ALLOW_EMPTY": "lb_32x128",
+        "MACRO_PLACE_HALO": "5 5",
+        "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
+        "PLACE_DENSITY": "0.65",
+        "PWR_NETS_VOLTAGES": "",
+    },
+    macros = ["gds_scope_macro"],
+    sources = LB_SOURCES,
+    tags = ["manual"],
+    variant = "gds_scope",
+    verilog_files = ["rtl/lb_32x128_top.v"],
+)
+
+# A macro's .gds is read only by the GDS-emitting steps: synthesis and
+# the PnR stages before final must not carry it (a macro .gds change
+# with stable .lef/.lib used to re-run the parent's whole chain), while
+# the final stage's klayout wrap keeps it.
+synth_action_inputs_test(
+    name = "macro_gds_synth_excluded_test",
+    forbidden_input_basenames = ["gds_scope_dummy.gds"],
+    output_basename = "1_2_yosys.v",
+    target_under_test = ":lb_32x128_top_gds_scope_synth",
+)
+
+synth_action_inputs_test(
+    name = "macro_gds_floorplan_excluded_test",
+    forbidden_input_basenames = ["gds_scope_dummy.gds"],
+    output_basename = "2_floorplan.odb",
+    target_under_test = ":lb_32x128_top_gds_scope_floorplan",
+)
+
+synth_action_inputs_test(
+    name = "macro_gds_final_included_test",
+    output_basename = "6_final.odb",
+    required_input_basenames = ["gds_scope_dummy.gds"],
+    target_under_test = ":lb_32x128_top_gds_scope_final",
+)
+
 # Mock sweep test: tests orfs_sweep with macros + openroad override.
 # Uses mock-openroad for all stages. The sweep's "base" variant uses
 # lb_32x128_mock_abstract as a macro (hierarchical design).


### PR DESCRIPTION
Dependency-leak sweep, next concern. Stacked on #835 (retarget to `main` once that merges).

ORFS consumes `ADDITIONAL_GDS` solely in the klayout wrap of the final/gds path — never in `YOSYS_DEPENDENCIES`, never in `do-1_synth`'s prereqs, never in floorplan..route. Yet macro `.gds` files were staged into every stage action twice over: `source_inputs()` carried `OrfsInfo.additional_gds` into all PnR stages, and `deps_inputs()` handed every macro's `.gds` to all synth/yosys actions (keep, partitions, odb, canonicalize, even `print-LIB_FILES`). A macro `.gds` change with stable `.lef`/`.lib` — a klayout tech-file edit, a macro final-stage rerun — re-ran the parent's synthesis and whole PnR chain.

- `source_inputs()` gains `gds=`: staged only for stage `6_final`/`6_gds`, the steps whose make recipes read `ADDITIONAL_GDS`; a squashed action ending at final carries stage `6_final` and keeps it.
- `deps_inputs()` gains `gds=`; the synth actions pass `False`, and the per-partition macro file sets and canonicalize blackbox set drop `.gds` likewise.
- Provider propagation (`OrfsInfo.additional_gds`) and the deploy sets are untouched — the gds rule still reaches the files, reproducer tarballs stay complete.

Locked by analysistests on a manual dummy-gds macro fixture (analyzed, never built): synth's `1_2_yosys.v` and floorplan's `2_floorplan.odb` actions must not input the macro `.gds`; the final stage's `6_final.odb` action must. Full `--nobuild //...` clean; mock hierarchy/merge/sweep flows and the 23-test input suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)