### PR TITLE
Upstream metrics jsons feed only genMetrics

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -237,7 +237,7 @@ def data_inputs_excluding(ctx, exclude_path):
         if f.path != exclude_path
     ])
 
-def source_inputs(ctx, use_pre_layout = None, gds = True):
+def source_inputs(ctx, use_pre_layout = None, gds = True, logging = True):
     """Inputs a stage action takes from its ``src`` stage.
 
     Args:
@@ -253,6 +253,14 @@ def source_inputs(ctx, use_pre_layout = None, gds = True):
             squashed multi-stage actions that span both timing domains.
         gds: whether the macro .gds files are staged. Only the
             GDS-emitting make steps read them (do-gds, do-final).
+        logging: whether the src chain's accumulated metrics .json and
+            report files are staged. Only genMetrics.py reads them
+            (generate_metadata / update_rules); nothing in the PnR make
+            steps opens an upstream stage's .json or .rpt. They are
+            SUPPOSED to be byte-stable, but OpenROAD is not trusted on
+            that — consumers declare the dependency instead of being fed
+            it for convenience. Default True for orfs_run/orfs_test/
+            orfs_arguments, whose user scripts may read them.
     Returns:
         A depset of files.
     """
@@ -270,6 +278,10 @@ def source_inputs(ctx, use_pre_layout = None, gds = True):
     # scripts may read them.
     if gds:
         lib_depsets.append(ctx.attr.src[OrfsInfo].additional_gds)
+    if logging:
+        # Accumulate all JSON metrics and reports from the src chain.
+        lib_depsets.append(ctx.attr.src[LoggingInfo].jsons)
+        lib_depsets.append(ctx.attr.src[LoggingInfo].reports)
     return depset(
         ctx.files.src,
         transitive = [
@@ -289,11 +301,9 @@ def source_inputs(ctx, use_pre_layout = None, gds = True):
             ctx.attr.src[OrfsInfo].additional_lefs,
             ctx.attr.src[PdkInfo].files,
             ctx.attr.src[PdkInfo].libs,
-            # Accumulate all JSON reports, so depend on previous stage.
-            ctx.attr.src[LoggingInfo].jsons,
-            ctx.attr.src[LoggingInfo].reports,
-            # non-idempotent by design transitive dependencies
-            # ctx.attr.src[LoggingInfo].logs,
+            # LoggingInfo.jsons/.reports are gated by `logging` above;
+            # LoggingInfo.logs never: non-idempotent by design (wall-clock
+            # lines on every run) and a sandbox-collision hazard.
         ] + lib_depsets,
     )
 

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -2538,6 +2538,14 @@ def _make_impl(
         # klayout wrap under do-gds / do-final); a squashed action ending
         # at final carries stage == "6_final" and keeps it.
         include_gds = stage in ("6_final", "6_gds")
+
+        # The src chain's metrics .json / report files are read only by
+        # genMetrics.py — the metadata stages declare them; the PnR make
+        # steps never open an upstream stage's .json or .rpt, and while
+        # the jsons are supposed to be byte-stable, OpenROAD is not
+        # trusted on that: consumers state the dependency, nobody gets
+        # fed it for convenience.
+        include_logging = stage in ("generate_metadata", "update_rules")
         ctx.actions.run_shell(
             arguments = ["--file", ctx.file._makefile.path] + steps,
             command = " && ".join(commands),
@@ -2550,6 +2558,7 @@ def _make_impl(
                         ctx,
                         use_pre_layout = lib_selection,
                         gds = include_gds,
+                        logging = include_logging,
                     ),
                     rename_inputs(ctx),
                 ],

--- a/test/BUILD
+++ b/test/BUILD
@@ -1360,6 +1360,37 @@ synth_action_inputs_test(
     target_under_test = ":lb_32x128_top_gds_scope_final",
 )
 
+# Upstream metrics .json / report files feed only genMetrics.py: the
+# PnR stage actions never open them, so they are declared by the
+# metadata stages and dropped everywhere else (the jsons are supposed
+# to be byte-stable, but OpenROAD is not trusted on that — consumers
+# state the dependency, nobody is fed it for convenience).
+synth_action_inputs_test(
+    name = "metrics_jsons_not_in_cts_test",
+    # 2_1_floorplan.json rides only LoggingInfo and is gone. The
+    # previous stage's own reports (2_floorplan_final.rpt) still arrive
+    # through its DefaultInfo.files (ctx.files.src) — that over-feed is
+    # the OrfsDepInfo/ctx.files.src narrowing, a separate concern.
+    forbidden_input_basenames = [
+        "1_synth.json",
+        "2_1_floorplan.json",
+    ],
+    output_basename = "4_cts.odb",
+    target_under_test = ":lb_32x128_cts",
+)
+
+# Pins the intended consumer so an input-hygiene refactor can't
+# silently starve genMetrics.py (it reads stage logs AND jsons).
+synth_action_inputs_test(
+    name = "metrics_jsons_reach_metadata_test",
+    output_basename = "metadata.json",
+    required_input_basenames = [
+        "1_synth.log",
+        "2_1_floorplan.json",
+    ],
+    target_under_test = ":lb_32x128_top_gds_scope_generate_metadata",
+)
+
 # Mock sweep test: tests orfs_sweep with macros + openroad override.
 # Uses mock-openroad for all stages. The sweep's "base" variant uses
 # lb_32x128_mock_abstract as a macro (hierarchical design).


### PR DESCRIPTION
Dependency-leak sweep, next concern. Stacked on #837 (retarget as the stack merges).

`source_inputs()` accumulated the src chain's metrics `.json` and report files into **every** downstream stage action, but only genMetrics.py reads them (generate_metadata / update_rules); no PnR make step opens an upstream stage's `.json` or `.rpt`. The jsons are *supposed* to be byte-stable — `openroad -metrics` serializes only `utl::metric` pairs, no runtimes — but OpenROAD is not trusted on that: whoever reads them declares the dependency, nobody is fed it for convenience.

- `source_inputs()` gains `logging=`; the stage make action sets it only for `generate_metadata`/`update_rules`.
- `orfs_run`/`orfs_test`/`orfs_arguments` keep the default `True` — user scripts may read metrics — and generate_metadata's primary feed (stage targets in `data=`, via `data_runfiles`) is untouched.
- Locked by analysistests: the cts action must not input the upstream stage jsons; `metadata.json` must input both a stage log and a stage json, pinning genMetrics' feed so a future input-hygiene refactor can't silently starve it.

Note: the previous stage's own reports still reach the next stage via `DefaultInfo.files`/`ctx.files.src` — that over-feed is the OrfsDepInfo/`ctx.files.src` narrowing, the next concern in the series.

Verified: full `--nobuild //...` clean; mock squashed/abstract cts flows execute; the 24-test input suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)