### PR TITLE
OrfsDepInfo.files stops re-feeding the previous-previous stage

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -2092,7 +2092,13 @@ def _yosys_impl(ctx):
     # stage's action inputs (ctx.files.src → source_inputs) and re-run
     # floorplan+ on every raw-SDC edit; the downstream contract is the
     # canonicalized 1_synth.sdc.
-    outputs = [canon_output, variables] + [
+    #
+    # 1_synth.vars likewise leaves DefaultInfo.files: no stage reads it,
+    # so it has no business in downstream action inputs — but it MUST
+    # stay in the runfiles and the deploy set: odb-debug-style tooling
+    # recovers LIB_FILES by globbing *.vars in a synth target's runfiles
+    # and fails silently without it.
+    outputs = [canon_output] + [
         f
         for name, f in synth_outputs.items()
         if name != "1_2_yosys.sdc"
@@ -2166,7 +2172,7 @@ def _yosys_impl(ctx):
         exe,
         config = config_short,
         make = make,
-        genfiles = [config_short] + outputs + canon_logs + synth_logs + synth_jsons,
+        genfiles = [config_short, variables] + outputs + canon_logs + synth_logs + synth_jsons,
     )
 
     # Collect all files needed for deployment (tools, PDK, stage inputs).
@@ -2206,7 +2212,7 @@ def _yosys_impl(ctx):
         name = ctx.attr.name + "_deps",
     )
 
-    _runfiles_files = [config_short, make] + outputs + canon_logs + synth_logs + synth_jsons + ctx.files.extra_configs + ctx.files.data
+    _runfiles_files = [config_short, make, variables] + outputs + canon_logs + synth_logs + synth_jsons + ctx.files.extra_configs + ctx.files.data
     _runfiles_common = depset(
         transitive = [
             deps_inputs(ctx),
@@ -2243,12 +2249,12 @@ def _yosys_impl(ctx):
             kept_macros_validation = depset(
                 [validated_kept_macros_json] if validated_kept_macros_json else [],
             ),
-            # 1_2_yosys.sdc left DefaultInfo.files (see the outputs
-            # comment above) but stays inspectable on demand:
-            # bazelisk build --output_groups=1_2_yosys.sdc <synth target>.
+            # 1_2_yosys.sdc and 1_synth.vars left DefaultInfo.files (see
+            # the outputs comment above) but stay inspectable on demand:
+            # bazelisk build --output_groups=<basename> <synth target>.
             **{
                 f.basename: depset([f])
-                for f in [config] + outputs + (
+                for f in [config, variables] + outputs + (
                     [synth_outputs["1_2_yosys.sdc"]] if "1_2_yosys.sdc" in synth_outputs else []
                 )
             }
@@ -2711,9 +2717,20 @@ def _make_impl(
             make = make,
             config = config_short,
             renames = stage_renames,
+            # This stage's OWN data (sources= files) and configs — what the
+            # next stage's source_inputs() legitimately needs beyond the
+            # results/reports it already takes from DefaultInfo via
+            # ctx.files.src. Deliberately NOT ctx.files.src: that is the
+            # PREVIOUS stage's whole DefaultInfo, and re-feeding it here
+            # handed stage N-1's results (1_synth netlist/RTLIL/…) to
+            # stage N+1's action inputs, one hop past every reader — a
+            # N-1 output change stage N absorbed still re-ran N+1. The
+            # forwarded subset (forwards) already travels via
+            # DefaultInfo.files. The deploy set (OrfsDepInfo.runfiles =
+            # deploy_files) keeps ctx.files.src — a deployed re-run of
+            # this stage's make reads the previous stage's results.
             files = depset(
                 [config_short] +
-                ctx.files.src +
                 ctx.files.data +
                 ctx.files.extra_configs,
             ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,7 +9,7 @@ load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
 load(":provider_test_rule.bzl", "lib_pre_layout_test")
 load(":quick_pins_test_rule.bzl", "quick_pins_data_dep_test")
-load(":sdc_clock_period_test.bzl", "synth_action_inputs_test")
+load(":sdc_clock_period_test.bzl", "runfiles_contents_test", "synth_action_inputs_test")
 load(":source_input_propagation_test.bzl", "source_input_propagation_test")
 load(":stages_filter_test.bzl", "stages_filter_test_suite")
 
@@ -1367,16 +1367,50 @@ synth_action_inputs_test(
 # state the dependency, nobody is fed it for convenience).
 synth_action_inputs_test(
     name = "metrics_jsons_not_in_cts_test",
-    # 2_1_floorplan.json rides only LoggingInfo and is gone. The
-    # previous stage's own reports (2_floorplan_final.rpt) still arrive
-    # through its DefaultInfo.files (ctx.files.src) — that over-feed is
-    # the OrfsDepInfo/ctx.files.src narrowing, a separate concern.
+    # 2_1_floorplan.json rides only LoggingInfo; 2_floorplan_final.rpt
+    # and 2_floorplan.odb used to arrive one hop past their readers via
+    # the src's OrfsDepInfo.files re-feeding the previous stage's whole
+    # DefaultInfo (cts legitimately reads only place's own results).
     forbidden_input_basenames = [
         "1_synth.json",
         "2_1_floorplan.json",
+        "2_floorplan.odb",
+        "2_floorplan_final.rpt",
     ],
     output_basename = "4_cts.odb",
     target_under_test = ":lb_32x128_cts",
+)
+
+# A stage's action inputs stop one hop back: place reads floorplan's
+# results (and the deliberately forwarded canonicalize RTLIL), never
+# synth's netlist or ODB — those reached place only through floorplan's
+# OrfsDepInfo.files re-feeding synth's whole DefaultInfo.
+synth_action_inputs_test(
+    name = "no_n_minus_2_inputs_place_test",
+    forbidden_input_basenames = [
+        "1_2_yosys.v",
+        "1_synth.odb",
+        "1_synth.vars",
+    ],
+    output_basename = "3_place.odb",
+    required_input_basenames = ["2_floorplan.odb"],
+    target_under_test = ":lb_32x128_top_gds_scope_place",
+)
+
+# 1_synth.vars left synth's DefaultInfo.files (no stage reads it) but
+# MUST stay in the runfiles: odb-debug-style tooling recovers LIB_FILES
+# by globbing *.vars there and fails silently without it.
+runfiles_contents_test(
+    name = "synth_vars_in_runfiles_test",
+    required_basenames = ["1_synth.vars"],
+    target_under_test = ":Mul_synth",
+)
+
+synth_action_inputs_test(
+    name = "synth_vars_not_in_floorplan_test",
+    forbidden_input_basenames = ["1_synth.vars"],
+    output_basename = "2_floorplan.odb",
+    target_under_test = ":lb_32x128_top_gds_scope_floorplan",
 )
 
 # Pins the intended consumer so an input-hygiene refactor can't

--- a/test/sdc_clock_period_test.bzl
+++ b/test/sdc_clock_period_test.bzl
@@ -105,3 +105,33 @@ synth_action_inputs_test = analysistest.make(
         ),
     },
 )
+
+def _runfiles_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+    basenames = {
+        f.basename: True
+        for f in target[DefaultInfo].data_runfiles.files.to_list()
+    }
+    for required in ctx.attr.required_basenames:
+        asserts.true(
+            env,
+            required in basenames,
+            "Expected %s in the data_runfiles of %s" % (required, target.label),
+        )
+
+    return analysistest.end(env)
+
+runfiles_contents_test = analysistest.make(
+    _runfiles_contents_test_impl,
+    attrs = {
+        "required_basenames": attr.string_list(
+            mandatory = True,
+            doc = "Basenames that must appear in the target's " +
+                  "data_runfiles — files tooling recovers by globbing " +
+                  "runfiles (e.g. *.vars) even when they are not in " +
+                  "DefaultInfo.files.",
+        ),
+    },
+)


### PR DESCRIPTION
Dependency-leak sweep, next concern (after #838).

A PnR stage's `OrfsDepInfo.files` bundled `ctx.files.src` — the PREVIOUS stage's entire DefaultInfo (results + reports + forwards) — which the NEXT stage's `source_inputs()` then staged as action inputs. Every stage carried its grandparent's results one hop past every reader: place's action had synth's netlist and ODB, cts had floorplan's ODB and final report, and an N-1 output change that stage N absorbed with byte-identical results still re-ran N+1. (This is also the path that kept feeding upstream *reports* downstream after #838 removed the LoggingInfo route.)

- `OrfsDepInfo.files` narrows to what the next stage legitimately needs beyond the results it already takes via `ctx.files.src`: this stage's OWN data (`sources=` files) and configs — the same shape the synth rule already has since the SDC isolation. Deliberately forwarded files (the canonicalize RTLIL) keep traveling via `DefaultInfo.files`; the deploy set (`OrfsDepInfo.runfiles`) keeps `ctx.files.src` so a deployed re-run of a stage's make still reads the previous stage's results.
- `1_synth.vars` gets the same demotion as `1_2_yosys.sdc` before it: no stage reads it, so it leaves synth's `DefaultInfo.files` — but it **stays in the runfiles and deploy set** (odb-debug-style tooling recovers LIB_FILES by globbing `*.vars` in a synth target's runfiles and fails silently without it) and remains an on-demand output group.

Locked by analysistests: place must input floorplan's ODB but not synth's netlist/ODB/vars; cts must not input floorplan's ODB or final report; a new `runfiles_contents_test` pins `1_synth.vars` in the synth runfiles; the floorplan→place data-propagation regression stays green. Verified: full `--nobuild //...` clean; mock hierarchy/squashed/full-hierarchy flows execute; PnR deploy tarball builds; deploy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)