### PR TITLE
The cheap SDC/vars synth actions read one file, take one file

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -2092,7 +2092,13 @@ def _yosys_impl(ctx):
     # stage's action inputs (ctx.files.src → source_inputs) and re-run
     # floorplan+ on every raw-SDC edit; the downstream contract is the
     # canonicalized 1_synth.sdc.
-    outputs = [canon_output, variables] + [
+    #
+    # 1_synth.vars likewise leaves DefaultInfo.files: no stage reads it,
+    # so it has no business in downstream action inputs — but it MUST
+    # stay in the runfiles and the deploy set: odb-debug-style tooling
+    # recovers LIB_FILES by globbing *.vars in a synth target's runfiles
+    # and fails silently without it.
+    outputs = [canon_output] + [
         f
         for name, f in synth_outputs.items()
         if name != "1_2_yosys.sdc"
@@ -2166,7 +2172,7 @@ def _yosys_impl(ctx):
         exe,
         config = config_short,
         make = make,
-        genfiles = [config_short] + outputs + canon_logs + synth_logs + synth_jsons,
+        genfiles = [config_short, variables] + outputs + canon_logs + synth_logs + synth_jsons,
     )
 
     # Collect all files needed for deployment (tools, PDK, stage inputs).
@@ -2206,7 +2212,7 @@ def _yosys_impl(ctx):
         name = ctx.attr.name + "_deps",
     )
 
-    _runfiles_files = [config_short, make] + outputs + canon_logs + synth_logs + synth_jsons + ctx.files.extra_configs + ctx.files.data
+    _runfiles_files = [config_short, make, variables] + outputs + canon_logs + synth_logs + synth_jsons + ctx.files.extra_configs + ctx.files.data
     _runfiles_common = depset(
         transitive = [
             deps_inputs(ctx),
@@ -2243,12 +2249,12 @@ def _yosys_impl(ctx):
             kept_macros_validation = depset(
                 [validated_kept_macros_json] if validated_kept_macros_json else [],
             ),
-            # 1_2_yosys.sdc left DefaultInfo.files (see the outputs
-            # comment above) but stays inspectable on demand:
-            # bazelisk build --output_groups=1_2_yosys.sdc <synth target>.
+            # 1_2_yosys.sdc and 1_synth.vars left DefaultInfo.files (see
+            # the outputs comment above) but stay inspectable on demand:
+            # bazelisk build --output_groups=<basename> <synth target>.
             **{
                 f.basename: depset([f])
-                for f in [config] + outputs + (
+                for f in [config, variables] + outputs + (
                     [synth_outputs["1_2_yosys.sdc"]] if "1_2_yosys.sdc" in synth_outputs else []
                 )
             }
@@ -2711,9 +2717,20 @@ def _make_impl(
             make = make,
             config = config_short,
             renames = stage_renames,
+            # This stage's OWN data (sources= files) and configs — what the
+            # next stage's source_inputs() legitimately needs beyond the
+            # results/reports it already takes from DefaultInfo via
+            # ctx.files.src. Deliberately NOT ctx.files.src: that is the
+            # PREVIOUS stage's whole DefaultInfo, and re-feeding it here
+            # handed stage N-1's results (1_synth netlist/RTLIL/…) to
+            # stage N+1's action inputs, one hop past every reader — a
+            # N-1 output change stage N absorbed still re-ran N+1. The
+            # forwarded subset (forwards) already travels via
+            # DefaultInfo.files. The deploy set (OrfsDepInfo.runfiles =
+            # deploy_files) keeps ctx.files.src — a deployed re-run of
+            # this stage's make reads the previous stage's results.
             files = depset(
                 [config_short] +
-                ctx.files.src +
                 ctx.files.data +
                 ctx.files.extra_configs,
             ),

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1042,7 +1042,7 @@ SYNTH_OUTPUTS = ["1_2_yosys.v", "1_2_yosys.sdc", "mem.json"]
 SYN_OUTPUTS = ["1_synth.odb", "1_synth.sdc", "1_synth.v"]
 SYNTH_REPORTS = ["synth_stat.txt", "synth_mocked_memories.txt"]
 
-def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments = {}, clock_period = None, sdc_overrides = [], synth_data_inputs = None):
+def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments = {}, clock_period = None, sdc_overrides = [], synth_data_inputs = None, sdc_only_inputs = None):
     """Parallel synthesis: keep → kept-json → N partitions → merge.
 
     Yosys is not deterministic when using host threads, so SYNTH_NUM_PARTITIONS
@@ -1078,6 +1078,8 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
     parallel_makefile = ctx.file._parallel_synth_makefile
     if synth_data_inputs == None:
         synth_data_inputs = data_inputs(ctx)
+    if sdc_only_inputs == None:
+        sdc_only_inputs = data_inputs(ctx)
     clock_period_inputs = [clock_period] if clock_period else []
 
     kept_json = declare_artifact(ctx, "results", "kept_modules.json")
@@ -1580,7 +1582,9 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
     )
 
     # Action 5: SDC copy → 1_2_yosys.sdc
-    # Uses wrapper Makefile so SDC_FILE is resolved from DESIGN_CONFIG
+    # Uses wrapper Makefile so SDC_FILE is resolved from DESIGN_CONFIG.
+    # A cp of the raw SDC: make parse (config + platform includes) plus
+    # the SDC itself — no design data, no macro collateral.
     ctx.actions.run_shell(
         arguments = [
             "--file",
@@ -1592,9 +1596,8 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
         inputs = depset(
             [config, parallel_makefile] + ctx.files.extra_configs,
             transitive = [
-                data_inputs(ctx),
+                sdc_only_inputs,
                 pdk_inputs(ctx),
-                deps_inputs(ctx, gds = False),
             ],
         ),
         outputs = [synth_outputs["1_2_yosys.sdc"]],
@@ -1801,6 +1804,14 @@ def _yosys_impl(ctx):
     # yosys and reads SDC_FILE directly, so it keeps the raw SDC.
     sdc_file_raw = all_arguments.get("SDC_FILE")
     sdc_path = ctx.expand_location(sdc_file_raw, ctx.attr.data) if sdc_file_raw else None
+
+    # The raw SDC as File(s) — for the cheap actions that read ONLY it
+    # (clock-period extraction, sdc-copy). Handing them the full data set
+    # would re-run them, harmlessly but noisily, on every data edit.
+    # Falls back to the full data set when the SDC_FILE path cannot be
+    # matched to a data file (a literal path spelled without $(location)).
+    sdc_files = [f for f in data_inputs(ctx).to_list() if f.path == sdc_path]
+    sdc_only_inputs = depset(sdc_files) if sdc_files else data_inputs(ctx)
     clock_period = None
     sdc_overrides = []
     synth_data_inputs = data_inputs(ctx)
@@ -1817,10 +1828,12 @@ def _yosys_impl(ctx):
             env = verilog_arguments([]) |
                   yosys_environment(ctx) |
                   config_environment(config),
+            # Make parse (config + platform includes) plus the SDC the
+            # period is regexed out of — nothing else is opened.
             inputs = depset(
                 [config] + ctx.files.extra_configs,
                 transitive = [
-                    data_inputs(ctx),
+                    sdc_only_inputs,
                     pdk_inputs(ctx),
                 ],
             ),
@@ -1963,7 +1976,7 @@ def _yosys_impl(ctx):
             progress_message = "OpenROAD-SYN synthesis for %s" % module_top(ctx),
         )
     elif num_partitions > 0:
-        validated_kept_macros_json = _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments, clock_period, sdc_overrides, synth_data_inputs)
+        validated_kept_macros_json = _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, synth_jsons, synth_reports, num_partitions, save_odb, all_arguments, clock_period, sdc_overrides, synth_data_inputs, sdc_only_inputs)
     else:
         # Serial path, split into three actions mirroring the parallel
         # path so the raw SDC feeds only the cheap sdc-copy step:
@@ -1991,7 +2004,8 @@ def _yosys_impl(ctx):
                     sdc = sdc_path,
                     out = synth_outputs["1_2_yosys.sdc"].path,
                 ),
-                inputs = data_inputs(ctx),
+                # A cp of the raw SDC reads exactly one file.
+                inputs = sdc_only_inputs,
                 outputs = [synth_outputs["1_2_yosys.sdc"]],
                 progress_message = "Generating SDC for %s" % module_top(ctx),
             )
@@ -2073,12 +2087,13 @@ def _yosys_impl(ctx):
                   flow_environment(ctx) |
                   yosys_environment(ctx) |
                   config_environment(config),
+            # A pure make-variable expansion: parses the config and the
+            # platform includes, opens no design file — neither the
+            # canonicalized RTLIL nor the data/macro collateral.
             inputs = depset(
-                [canon_output, config] + ctx.files.extra_configs,
+                [config] + ctx.files.extra_configs,
                 transitive = [
-                    synth_data_inputs,
                     pdk_inputs(ctx),
-                    deps_inputs(ctx, gds = False),
                 ],
             ),
             outputs = [variables],

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,7 +9,7 @@ load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
 load(":provider_test_rule.bzl", "lib_pre_layout_test")
 load(":quick_pins_test_rule.bzl", "quick_pins_data_dep_test")
-load(":sdc_clock_period_test.bzl", "synth_action_inputs_test")
+load(":sdc_clock_period_test.bzl", "runfiles_contents_test", "synth_action_inputs_test")
 load(":source_input_propagation_test.bzl", "source_input_propagation_test")
 load(":stages_filter_test.bzl", "stages_filter_test_suite")
 
@@ -1367,16 +1367,50 @@ synth_action_inputs_test(
 # state the dependency, nobody is fed it for convenience).
 synth_action_inputs_test(
     name = "metrics_jsons_not_in_cts_test",
-    # 2_1_floorplan.json rides only LoggingInfo and is gone. The
-    # previous stage's own reports (2_floorplan_final.rpt) still arrive
-    # through its DefaultInfo.files (ctx.files.src) — that over-feed is
-    # the OrfsDepInfo/ctx.files.src narrowing, a separate concern.
+    # 2_1_floorplan.json rides only LoggingInfo; 2_floorplan_final.rpt
+    # and 2_floorplan.odb used to arrive one hop past their readers via
+    # the src's OrfsDepInfo.files re-feeding the previous stage's whole
+    # DefaultInfo (cts legitimately reads only place's own results).
     forbidden_input_basenames = [
         "1_synth.json",
         "2_1_floorplan.json",
+        "2_floorplan.odb",
+        "2_floorplan_final.rpt",
     ],
     output_basename = "4_cts.odb",
     target_under_test = ":lb_32x128_cts",
+)
+
+# A stage's action inputs stop one hop back: place reads floorplan's
+# results (and the deliberately forwarded canonicalize RTLIL), never
+# synth's netlist or ODB — those reached place only through floorplan's
+# OrfsDepInfo.files re-feeding synth's whole DefaultInfo.
+synth_action_inputs_test(
+    name = "no_n_minus_2_inputs_place_test",
+    forbidden_input_basenames = [
+        "1_2_yosys.v",
+        "1_synth.odb",
+        "1_synth.vars",
+    ],
+    output_basename = "3_place.odb",
+    required_input_basenames = ["2_floorplan.odb"],
+    target_under_test = ":lb_32x128_top_gds_scope_place",
+)
+
+# 1_synth.vars left synth's DefaultInfo.files (no stage reads it) but
+# MUST stay in the runfiles: odb-debug-style tooling recovers LIB_FILES
+# by globbing *.vars there and fails silently without it.
+runfiles_contents_test(
+    name = "synth_vars_in_runfiles_test",
+    required_basenames = ["1_synth.vars"],
+    target_under_test = ":Mul_synth",
+)
+
+synth_action_inputs_test(
+    name = "synth_vars_not_in_floorplan_test",
+    forbidden_input_basenames = ["1_synth.vars"],
+    output_basename = "2_floorplan.odb",
+    target_under_test = ":lb_32x128_top_gds_scope_floorplan",
 )
 
 # Pins the intended consumer so an input-hygiene refactor can't

--- a/test/BUILD
+++ b/test/BUILD
@@ -672,6 +672,19 @@ synth_action_inputs_test(
     target_under_test = ":Mul_synth",
 )
 
+# print-LIB_FILES is a pure make-variable expansion: config + platform
+# includes only — it opens neither the RTLIL nor the SDC, so neither
+# may re-run it.
+synth_action_inputs_test(
+    name = "sdc_serial_vars_test",
+    forbidden_input_basenames = [
+        "1_1_yosys_canonicalize.rtlil",
+        "constraints-combinational.sdc",
+    ],
+    output_basename = "1_synth.vars",
+    target_under_test = ":Mul_synth",
+)
+
 # Same split on the parallel/hierarchical path (kept_modules_synth).
 synth_action_inputs_test(
     name = "sdc_parallel_partition_test",

--- a/test/sdc_clock_period_test.bzl
+++ b/test/sdc_clock_period_test.bzl
@@ -105,3 +105,33 @@ synth_action_inputs_test = analysistest.make(
         ),
     },
 )
+
+def _runfiles_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    target = analysistest.target_under_test(env)
+    basenames = {
+        f.basename: True
+        for f in target[DefaultInfo].data_runfiles.files.to_list()
+    }
+    for required in ctx.attr.required_basenames:
+        asserts.true(
+            env,
+            required in basenames,
+            "Expected %s in the data_runfiles of %s" % (required, target.label),
+        )
+
+    return analysistest.end(env)
+
+runfiles_contents_test = analysistest.make(
+    _runfiles_contents_test_impl,
+    attrs = {
+        "required_basenames": attr.string_list(
+            mandatory = True,
+            doc = "Basenames that must appear in the target's " +
+                  "data_runfiles — files tooling recovers by globbing " +
+                  "runfiles (e.g. *.vars) even when they are not in " +
+                  "DefaultInfo.files.",
+        ),
+    },
+)


### PR DESCRIPTION
Dependency-leak sweep, cleanup concern. Stacked on #840 (retarget to `main` once that merges).

The sub-second synth helper actions declared far more than they open:

- **clock-period extraction** (`do-sdc-clock-period`): took the full data set; the recipe regexes exactly the SDC at make parse time. Now config + platform includes + the SDC.
- **sdc-copy**, serial (plain `cp`) and parallel (`do-yosys-sdc-copy`): took all data plus, on the parallel path, every macro's lef/lib; a cp of the raw SDC reads one file.
- **print-LIB_FILES** (`1_synth.vars`): took the canonicalized RTLIL, the full data set and the macro collateral for a pure make-variable expansion that opens none of them. Now config + platform includes.

Cache-stability leaks, not wall-time: any design-data or macro edit re-ran them and dirtied their downstream consumers. The SDC file is matched from `data` by the expanded `SDC_FILE` path, with a conservative fallback to the full data set when `SDC_FILE` is spelled as a literal path without `$(location)`.

Locked by an analysistest (the `1_synth.vars` action must input neither the RTLIL nor the SDC); the full 26-test input suite and the mock/serial/parallel synth flows execute green; `--nobuild //...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)