### PR TITLE
user_stages: scope user variables to the stages that read them

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -32,6 +32,7 @@ load(
     "//private:stages.bzl",
     "STAGE_METADATA",
     "check_stage_variables",
+    "check_user_stages",
     "get_sources",
     "get_stage_args",
 )
@@ -74,11 +75,13 @@ def _filter_stage_args(stage, **kwargs):
     stage_data = kwargs.pop("stage_data", {})
     user_arguments = kwargs.pop("user_arguments", {})
     user_sources = kwargs.pop("user_sources", {})
+    user_stages = kwargs.pop("user_stages", {})
 
     # Validate before merging: the escape hatches are exempt from the
     # spell-check, so they cannot be folded in first.  See "The two escape
     # hatches" in private/stages.bzl.
     check_stage_variables(arguments, sources, user_arguments, user_sources)
+    check_user_stages(user_stages, user_arguments, user_sources)
     arguments = arguments | user_arguments
     sources = sources | user_sources
 
@@ -99,8 +102,9 @@ def _filter_stage_args(stage, **kwargs):
             arguments = arguments,
             sources = sources,
             stage_arguments = stage_arguments,
+            user_stages = user_stages,
         ),
-        data = get_sources([stage], sources) +
+        data = get_sources([stage], sources, user_stages = user_stages) +
                stage_data.get(stage, []) +
                data,
         extra_arguments = extra_arguments.get(stage, []),
@@ -312,6 +316,10 @@ def orfs_flow(
         Use for path hooks read only by user-supplied .tcl/.mk (e.g. an extra-SDC hook
         source'd from the design's own io.tcl). Keys that collide with known ORFS variables
         are rejected — route those through 'sources' instead.
+      user_stages: additive sidecar scoping user_arguments/user_sources variables to the
+        stages that read them, e.g. {"MY_HOOK": ["floorplan"]}. Unlisted user variables keep
+        the default kept-in-every-stage behavior. Scoping a user source stops its file edits
+        from re-running stages that never read it. (Passed via **kwargs.)
       extra_arguments: dictionary keyed by ORFS stages with lists of .json argument file labels.
         These .json files are merged into the stage config, providing computed arguments
         that flow through OrfsInfo to subsequent stages.
@@ -356,6 +364,7 @@ def orfs_flow(
     # typo in a flow that instantiates no stage (last_stage past its own
     # start) still fails loudly.
     check_stage_variables(arguments, sources, user_arguments, user_sources)
+    check_user_stages(kwargs.get("user_stages", {}), user_arguments, user_sources)
     if "data" in kwargs:
         fail(
             "orfs_flow(data = ...) fans the files out to every stage — " +

--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -47,7 +47,7 @@ def _convert_sources(sources, pkg):
             result[var] = converted
     return result
 
-def orfs_design(name = None, config = "config.mk", platform = None, design = None, designs = None, mock_openroad = None, mock_yosys = None, user_arguments = [], user_sources = [], local_arguments = [], extra = None):  # buildifier: disable=unused-variable
+def orfs_design(name = None, config = "config.mk", platform = None, design = None, designs = None, mock_openroad = None, mock_yosys = None, user_arguments = [], user_sources = [], user_stages = {}, local_arguments = [], extra = None):  # buildifier: disable=unused-variable
     """Create orfs_flow() targets for a design based on its parsed config.mk.
 
     Usage:
@@ -86,6 +86,12 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
             io.tcl). Routed through orfs_flow(user_sources=...) so the
             file is still staged into the sandbox, but the variable
             name bypasses the variables.yaml validator.
+        user_stages: additive sidecar scoping user_arguments/user_sources
+            variables to the stages that read them, e.g.
+            {"MY_HOOK": ["floorplan"]}. Unlisted user variables keep the
+            default kept-in-every-stage behavior; scoping a user source
+            stops its file edits from re-running stages that never read
+            it. Routed through orfs_flow(user_stages=...).
         local_arguments: List of variable names that are only used for
             $(VAR) expansion within the same config.mk and are not read
             by ORFS or by any user .tcl/.mk (e.g. VERILOG_FILES_BLACKBOX,
@@ -94,8 +100,8 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
             validated against variables.yaml nor exposed as env vars.
         extra: optional callable invoked after the real flow with the
             fully-processed design data (name, platform, verilog_files,
-            arguments, user_arguments, sources, user_sources, macros,
-            stage_data, tags) so callers can attach additional
+            arguments, user_arguments, sources, user_sources, user_stages,
+            macros, stage_data, tags) so callers can attach additional
             per-design targets (extra flow variants, reporting targets)
             without orfs_design knowing their policy.
     """
@@ -236,6 +242,7 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
         user_arguments = user_args,
         sources = sources,
         user_sources = user_srcs,
+        user_stages = user_stages,
         macros = macros if macros else [],
         stage_data = {"synth": extra_data} if extra_data else {},
         tags = tags,
@@ -254,6 +261,7 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
             user_arguments = user_args,
             sources = sources,
             user_sources = user_srcs,
+            user_stages = user_stages,
             macros = macros if macros else [],
             stage_data = {"synth": extra_data} if extra_data else {},
             tags = tags,

--- a/private/stages.bzl
+++ b/private/stages.bzl
@@ -324,9 +324,51 @@ def _allowed_predicate(stages):
             allowed[variable] = True
     return True, allowed
 
-def _keep(arg, filtering, allowed):
+def _keep(arg, filtering, allowed, stages = [], user_stages = {}):
     # The single keep/drop predicate — see the two-time-domains block above.
-    return (not filtering) or (arg in allowed) or (arg not in ALL_VARIABLE_TO_STAGES)
+    if not filtering:
+        return True
+    if arg in user_stages:
+        # The additive user_stages sidecar: an unknown (user) variable the
+        # caller has scoped to specific stages loses the keep-everywhere
+        # escape hatch and is owned by exactly those stages.
+        return any([stage in stages for stage in user_stages[arg]])
+    return (arg in allowed) or (arg not in ALL_VARIABLE_TO_STAGES)
+
+def check_user_stages(user_stages, user_arguments, user_sources):
+    """Validates a user_stages sidecar dict.
+
+    Every key must name a variable from user_arguments/user_sources (a
+    known ORFS variable is already stage-scoped by variables.yaml — use
+    stage_arguments to override that), and every value must list known
+    stages.
+
+    Args:
+        user_stages: dict of user variable name -> list of stage names.
+        user_arguments: the user_arguments dict the keys must come from.
+        user_sources: the user_sources dict the keys may come from.
+    """
+    for variable, stages in user_stages.items():
+        if variable not in user_arguments and variable not in user_sources:
+            fail(
+                "user_stages names '{variable}', which is not in ".format(
+                    variable = variable,
+                ) +
+                "user_arguments or user_sources. Known ORFS variables are " +
+                "stage-scoped by variables.yaml; use stage_arguments to " +
+                "override that scoping.",
+            )
+        for stage in stages:
+            if stage not in ALL_STAGES:
+                fail(
+                    "user_stages['{variable}'] names unknown stage ".format(
+                        variable = variable,
+                    ) +
+                    "'{stage}'. Known stages: {known}.".format(
+                        stage = stage,
+                        known = ", ".join(ALL_STAGES),
+                    ),
+                )
 
 def dropped_variables(stages):
     """Returns the denylist that merge_arguments.py applies at execution time.
@@ -349,7 +391,7 @@ def dropped_variables(stages):
         return []
     return sorted([v for v in ALL_VARIABLE_TO_STAGES.keys() if v not in allowed])
 
-def get_stage_args(stages, stage_arguments = {}, arguments = {}, sources = {}):
+def get_stage_args(stages, stage_arguments = {}, arguments = {}, sources = {}, user_stages = {}):
     """Returns the arguments for a set of stages.
 
     Args:
@@ -361,6 +403,10 @@ def get_stage_args(stages, stage_arguments = {}, arguments = {}, sources = {}):
             test/stages_filter_test.bzl.
         arguments: a dictionary of arguments automatically assigned to a stage
         sources: a dictionary of variables and source files
+        user_stages: additive sidecar scoping user (unknown) variables to
+            the stages that read them, e.g. {"MY_HOOK": ["floorplan"]}.
+            An unlisted user variable keeps today's kept-everywhere
+            escape hatch.
     Returns:
       A dictionary of arguments for the stage(s).
     """
@@ -375,12 +421,12 @@ def get_stage_args(stages, stage_arguments = {}, arguments = {}, sources = {}):
     unsorted_dict = {
         arg: " ".join(["$(locations {})".format(v) for v in value])
         for arg, value in sources.items()
-        if _keep(arg, filtering, allowed)
+        if _keep(arg, filtering, allowed, stages, user_stages)
     }
     unsorted_dict.update({
         arg: value
         for arg, value in arguments.items()
-        if _keep(arg, filtering, allowed)
+        if _keep(arg, filtering, allowed, stages, user_stages)
     })
     unsorted_dict.update(stage_specific)
 
@@ -388,12 +434,17 @@ def get_stage_args(stages, stage_arguments = {}, arguments = {}, sources = {}):
     # — do not remove.
     return dict(sorted(unsorted_dict.items()))
 
-def get_sources(stages, sources):
+def get_sources(stages, sources, user_stages = {}):
     """Returns the sources for a set of stages.
 
     Args:
         stages: list of stage names to keep sources for (empty = keep all).
         sources: a dictionary of variable names with a list of sources to a stage
+        user_stages: additive sidecar scoping user (unknown) variables to
+            the stages that read them — MUST be the same dict handed to
+            get_stage_args: a $(locations X) arg whose label is pruned
+            from data fails location expansion, so the two prune in
+            lockstep (MORATORIUM(source-filtering-is-analysis-time)).
     Returns:
       A sorted, de-duplicated list of sources for the stage(s).
     """
@@ -407,7 +458,7 @@ def get_sources(stages, sources):
                 [
                     source_list
                     for variable, source_list in sources.items()
-                    if _keep(variable, filtering, allowed)
+                    if _keep(variable, filtering, allowed, stages, user_stages)
                 ],
             ),
         ),

--- a/test/stages_filter_test.bzl
+++ b/test/stages_filter_test.bzl
@@ -171,6 +171,40 @@ def _user_hatch_survives_the_filter_test(ctx):
     asserts.false(env, _VAR_B in merged)
     return unittest.end(env)
 
+def _user_stages_sidecar_scopes_test(ctx):
+    env = unittest.begin(ctx)
+
+    user_stages = {_UNMAPPED: [_STAGE_A]}
+    sources = {_UNMAPPED: ["//u:lu"]}
+    arguments = {_UNMAPPED: "42"}
+
+    # Owned stage keeps the variable (arg and source, in lockstep).
+    args_a = get_stage_args([_STAGE_A], arguments = arguments, user_stages = user_stages)
+    asserts.equals(env, "42", args_a.get(_UNMAPPED))
+    asserts.equals(env, ["//u:lu"], get_sources([_STAGE_A], sources, user_stages = user_stages))
+
+    # A non-owning stage drops it — the sidecar replaces the
+    # kept-everywhere escape hatch for the variables it lists.
+    args_b = get_stage_args([_STAGE_B], arguments = arguments, user_stages = user_stages)
+    asserts.false(env, _UNMAPPED in args_b)
+    asserts.equals(env, [], get_sources([_STAGE_B], sources, user_stages = user_stages))
+
+    # Union semantics match the known-variable filter.
+    args_ab = get_stage_args([_STAGE_B, _STAGE_A], arguments = arguments, user_stages = user_stages)
+    asserts.equals(env, "42", args_ab.get(_UNMAPPED))
+
+    # Empty stages still means "no filtering".
+    args_none = get_stage_args([], arguments = arguments, user_stages = user_stages)
+    asserts.equals(env, "42", args_none.get(_UNMAPPED))
+
+    # An unlisted user variable keeps today's kept-everywhere hatch
+    # (the additive-default pin: adding the sidecar changed nothing
+    # for existing callers).
+    args_unlisted = get_stage_args([_STAGE_B], arguments = arguments)
+    asserts.equals(env, "42", args_unlisted.get(_UNMAPPED))
+
+    return unittest.end(env)
+
 def _sorted_output_test(ctx):
     env = unittest.begin(ctx)
 
@@ -186,6 +220,7 @@ stage_arguments_bypass_filter_test = unittest.make(_stage_arguments_bypass_filte
 denylist_is_the_complement_of_keep_test = unittest.make(_denylist_is_the_complement_of_keep_test)
 denylist_union_over_stages_test = unittest.make(_denylist_union_over_stages_test)
 user_hatch_survives_the_filter_test = unittest.make(_user_hatch_survives_the_filter_test)
+user_stages_sidecar_scopes_test = unittest.make(_user_stages_sidecar_scopes_test)
 sorted_output_test = unittest.make(_sorted_output_test)
 
 def stages_filter_test_suite(name):
@@ -198,5 +233,6 @@ def stages_filter_test_suite(name):
         denylist_is_the_complement_of_keep_test,
         denylist_union_over_stages_test,
         user_hatch_survives_the_filter_test,
+        user_stages_sidecar_scopes_test,
         sorted_output_test,
     )


### PR DESCRIPTION
Dependency-leak sweep, final concern of the series.

Unknown (user) variables ride the keep-everywhere escape hatch: a `user_sources` path hook lands in all eleven stages' `data`, so editing an extra-SDC hook read only by floorplan's `io.tcl` re-ran cts, grt and route too. The hatch is the right default — bazel-orfs cannot know which stages a user `.tcl` reads — but the **caller** knows.

**Additive sidecar:** `user_stages = {"MY_HOOK": ["floorplan"]}` scopes a `user_arguments`/`user_sources` variable to exactly those stages, pruning the argument and its staged file in lockstep (same predicate — extends MORATORIUM(source-filtering-is-analysis-time) to user variables). Unlisted user variables keep today's behavior, so the sidecar changes nothing for existing callers (pinned by a unit test). Keys must name user variables (known ORFS variables are stage-scoped by variables.yaml; `stage_arguments` overrides that) and stages must be known — both `fail()` loudly.

Wired through `orfs_flow` (via `**kwargs`), every standalone stage macro, and `orfs_design(user_stages=...)` for config.mk-driven designs.

Unit-tested in `test/stages_filter_test.bzl`: owned stage keeps arg and source, non-owning stage drops both, union and empty-stages semantics match the known-variable filter. Full `--nobuild //...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)