### PR TITLE
fix(test): cell_count supplies METRICS_OUT

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -413,14 +413,31 @@ orfs_flow(
     verilog_files = LB_VERILOG_FILES,
 )
 
+# Demonstrates the DSE/AutoTuner contract README.md documents: the script
+# reports its objective by writing JSON to METRICS_OUT, which the caller
+# names. cell_count.tcl errors out when METRICS_OUT is unset, so it is
+# part of the contract rather than an option. It rides on extra_args
+# rather than arguments= because the value has to name a declared output
+# under $WORK_HOME, and only extra_args is shell-expanded -- a
+# "$(WORK_HOME)/..." in arguments= reaches the script verbatim.
 orfs_run(
     name = "cell_count",
     src = ":lb_32x128_floorplan",
     outs = [
+        "cell_count_metrics.json",
         "test.txt",
     ],
-    extra_args = "> $WORK_HOME/test.txt",
+    extra_args = "METRICS_OUT=$WORK_HOME/cell_count_metrics.json > $WORK_HOME/test.txt",
     script = ":cell_count.tcl",
+)
+
+# ci.yml runs `bazelisk test ... --build_tests_only`, so a target no test
+# depends on is never built there. cell_count is such a target, and it
+# silently stopped building when cell_count.tcl grew its METRICS_OUT
+# requirement. Naming it in a build_test is what puts it back under CI.
+build_test(
+    name = "cell_count_build_test",
+    targets = [":cell_count"],
 )
 
 filegroup(


### PR DESCRIPTION
`//test:cell_count` has been failing to build. `cell_count.tcl` is the DSE/AutoTuner objective function `README.md` documents driving from Python — it reports its result by writing JSON to `METRICS_OUT` and errors out when that is unset. The `orfs_run_executable` callers pass it; this older `orfs_run` demo of the same script never did.

Pass it, and declare the JSON as an output so the target demonstrates the whole contract rather than just capturing stdout:

```json
{ "density": 0.65, "tns": 0.0, "wns": 38.58924306641866, "cell_count": 32 }
```

It rides on `extra_args` rather than `arguments=` because the value has to name a declared output under `$WORK_HOME`, and only `extra_args` is shell-expanded — a `"$(WORK_HOME)/..."` in `arguments=` reaches the script verbatim.

## Why nothing caught it

`ci.yml` runs `bazelisk test ... --build_tests_only`, which never builds a target no test depends on:

```
$ bazelisk query 'rdeps(//..., //test:cell_count) except //test:cell_count'
(empty)
```

A `build_test` puts it back under CI. There are ~220 further non-manual targets in the same blind spot; `//slang` and the `//sram` flows are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)