### PR TITLE
feat(orfs): load the slang plugin when read_slang is not built in

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,7 @@ archive_override(
     patch_strip = 1,
     patches = [
         "//patches:0037-orfs-single-writer-1_synth-sdc.patch",
+        "//patches:0039-orfs-slang-plugin-fallback.patch",
     ],
     strip_prefix = "OpenROAD-flow-scripts-427bd762b7b7448f8bb6bc4e14207aa3963fca30",
     urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/427bd762b7b7448f8bb6bc4e14207aa3963fca30.tar.gz"],

--- a/patches/0039-orfs-slang-plugin-fallback.patch
+++ b/patches/0039-orfs-slang-plugin-fallback.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Wed, 26 Aug 2026 14:18:38 +0200
+Subject: [PATCH] synth: load the slang plugin when read_slang is not built in
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Yosys 0.67 vendors the slang frontend under frontends/slang, so
+read_slang is a built-in command there and the explicit plugin load
+was dropped. Yosys 0.66 and older do not have it, and the same code is
+available to them as an out-of-tree plugin (povik/sv-elab, formerly
+yosys-slang) -- which is what the Bazel build in bazel-orfs supplies,
+since the BCR yosys module is still on 0.64.
+
+On such a Yosys, SYNTH_HDL_FRONTEND=slang now fails with
+
+  ERROR: No such command: read_slang (type 'help' for a command overview)
+
+even though the plugin is on YOSYS_PLUGIN_PATH, because nothing loads
+it any more.
+
+Load it when, and only when, the command is absent. `plugin -i slang`
+resolves through YOSYS_PLUGIN_PATH, and the guard makes this a no-op
+on a Yosys that has the frontend built in, so ORFS works against
+either without the caller having to say which it has.
+
+Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
+---
+ flow/scripts/synth_preamble.tcl | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/flow/scripts/synth_preamble.tcl b/flow/scripts/synth_preamble.tcl
+index 14a9d70d7..ef142be96 100644
+--- a/flow/scripts/synth_preamble.tcl
++++ b/flow/scripts/synth_preamble.tcl
+@@ -76,7 +76,14 @@ proc read_design_sources { } {
+   }
+ 
+   if { [env_var_equals SYNTH_HDL_FRONTEND slang] } {
+-    # read_slang is built into Yosys (>=0.67); no plugin load needed.
++    # read_slang is built into Yosys >= 0.67, which vendors the frontend
++    # under frontends/slang. Older Yosys needs the same code loaded as an
++    # out-of-tree plugin; `plugin -i` finds it on YOSYS_PLUGIN_PATH. The
++    # guard makes this a no-op on a Yosys that has the frontend built in,
++    # so a build system is free to supply either one.
++    if { [info commands read_slang] eq "" } {
++      plugin -i slang
++    }
+     set slang_args [list \
+       -D SYNTHESIS --keep-hierarchy --compat=vcs --ignore-assertions --top $::env(DESIGN_NAME) \
+       {*}$vIdirsArgs {*}[env_var_or_empty VERILOG_DEFINES]]

--- a/slang/BUILD
+++ b/slang/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//:openroad.bzl", "orfs_flow", "orfs_synth")
 
 # The slang yosys plugin (slang.so) is provided from BCR sv-elab via
@@ -36,4 +37,17 @@ orfs_synth(
         "SDC_FILE": ["constraints.sdc"],
     },
     verilog_files = ["blackbox.sv"],
+)
+
+# ci.yml runs `bazelisk test ... --build_tests_only`, so these targets --
+# which no test depended on -- were never built there, and the CI
+# coverage the blackbox_synth comment above promises did not exist. They
+# had been failing since ORFS dropped the slang plugin load. Naming them
+# in a build_test is what makes that comment true.
+build_test(
+    name = "slang_build_test",
+    targets = [
+        ":blackbox_synth",
+        ":test_place",
+    ],
 )


### PR DESCRIPTION
`//slang:test_synth` and `//slang:blackbox_synth` have been failing:

```
ERROR: No such command: read_slang (type 'help' for a command overview)
```

## Root cause

Yosys 0.67 vendors the slang frontend under `frontends/slang` (confirmed: absent in v0.65/v0.66, present in v0.67/v0.68), and ORFS commit `b18e110c1` dropped the explicit plugin load on the strength of that — `synth_preamble.tcl` now reads *"read_slang is built into Yosys (>=0.67); no plugin load needed"*. It also removed `SLANG_PLUGIN_PATH` from `variables.yaml`.

The BCR `yosys` module is still on **0.64**. Yosys ships no Bazel files upstream, so that module is a hand-written overlay and nobody has carried it past 0.64. 0.64 has no built-in `read_slang`. bazel-orfs still supplies the same code as the `sv-elab` plugin on `YOSYS_PLUGIN_PATH` — but since `b18e110c1`, nothing loads it.

## Fix

`patches/0039` loads the plugin when, and only when, the command is absent:

```tcl
if { [info commands read_slang] eq "" } {
  plugin -i slang
}
```

`plugin -i slang` resolves through `YOSYS_PLUGIN_PATH`, and the guard is a no-op on a Yosys that has the frontend built in — so ORFS works against either without the caller saying which it has. Worth sending upstream separately: it un-breaks ORFS for every consumer on a BCR yosys.

## Why nothing caught it

`slang/BUILD` says of `blackbox_synth`: *"A future sv-elab bump that breaks blackboxing fails here in CI."* It does not — `ci.yml` runs `bazelisk test ... --build_tests_only`, and no test depends on these targets, so they were never built there. The `build_test` makes that comment true.

`//slang/...` now builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)