### PR TITLE
feat(stages): FLOW_INPUT_VARIANT replaces cross-variant input renaming

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,6 +49,7 @@ archive_override(
     patch_strip = 1,
     patches = [
         "//patches:0037-orfs-single-writer-1_synth-sdc.patch",
+        "//patches:0038-orfs-flow-input-variant.patch",
         "//patches:0039-orfs-slang-plugin-fallback.patch",
     ],
     strip_prefix = "OpenROAD-flow-scripts-427bd762b7b7448f8bb6bc4e14207aa3963fca30",

--- a/TESTING.md
+++ b/TESTING.md
@@ -98,7 +98,6 @@ comm -23 \
 | Feature | Notes |
 |---------|-------|
 | `stage_data` | Parameter exists in `orfs_flow`, never exercised |
-| `renamed_inputs` | Exists in flow.bzl/sweep.bzl, never tested |
 | `dissolve` in sweep | Feature exists (sweep.bzl), never used |
 | `orfs_update` | Rule exported, no test |
 | `save_odb=False` | Synthesis attribute, never tested |

--- a/deploy.tpl
+++ b/deploy.tpl
@@ -13,7 +13,6 @@ main() {
   local progname
   local config
   local genfiles
-  local renames
   local make
   local name="${NAME}"
   local package="${PACKAGE}"
@@ -32,11 +31,6 @@ main() {
       ;;
       -g|--genfiles)
         genfiles="$2"
-        shift
-        shift
-      ;;
-      -r|--renames)
-        renames="$2"
         shift
         shift
       ;;
@@ -143,17 +137,9 @@ EOF
 
   cp --force --no-preserve=all "$config" "$dst_main/config.mk"
 
-  for rename in $renames; do
-    IFS=':' read -r from to <<EOF
-$rename
-EOF
-    mkdir --parents "$dst_main"/"$(dirname "$to")"
-    cp --force --dereference --no-preserve=all "$from" "$dst_main"/"$to"
-  done
-
   if [ "$#" -gt 0 ]; then
     "$dst/make" "$@"
   fi
 }
 
-main --genfiles "${GENFILES}" --name "${NAME}" --renames "${RENAMES}" --make "${MAKE}" --config "${CONFIG}" "$@"
+main --genfiles "${GENFILES}" --name "${NAME}" --make "${MAKE}" --config "${CONFIG}" "$@"

--- a/patches/0038-orfs-flow-input-variant.patch
+++ b/patches/0038-orfs-flow-input-variant.patch
@@ -1,0 +1,407 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Wed, 26 Aug 2026 12:23:40 +0200
+Subject: [PATCH] variables: FLOW_INPUT_VARIANT, read inputs from another
+ variant
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+FLOW_VARIANT names the directory a run writes to. It also names the
+directory a run reads from, which means a variant that wants to reuse
+an upstream variant's results has to physically copy them into its own
+directory first. Sharing an expensive front end across experiments —
+one synthesis, one floorplan, many routing variants — is a `cp -r` per
+fork today.
+
+Split the two. FLOW_INPUT_VARIANT names the variant a run reads from
+and gives INPUT_RESULTS_DIR, INPUT_LOG_DIR, INPUT_REPORTS_DIR and
+INPUT_OBJECTS_DIR alongside the existing output directories. It
+defaults to FLOW_VARIANT, so every INPUT_*_DIR expands to a string
+identical to its *_DIR counterpart and an unchanged run is unchanged.
+
+Reads resolve against a search path: RESULTS_DIR first,
+INPUT_RESULTS_DIR second. RESULTS_DIR has to come first because a
+stage runs several steps in one process — do-place writes
+3_1_place_gp_skip_io.odb and the next step reads it back — and a file
+this run just wrote must win over the upstream variant's copy of it.
+orfs_input_path and orfs_input_glob in util.tcl are the search; every
+write still goes straight to RESULTS_DIR.
+
+load_design is the chokepoint: all 18 stage scripts hand it a bare
+basename, so routing it through orfs_input_path covers the whole flow.
+The remaining reads are the AUTO_MEMORIES globs, find_sdc_file, the
+abstract's .spef, yosys_load's netlist, and genMetrics' log/report/
+result directories.
+
+find_sdc_file's candidate ordering now compares basenames rather than
+full paths. With one directory the two are equivalent, since every
+candidate shares a prefix; with two, the directory prefix would
+otherwise decide which .sdc wins.
+
+The Makefile's prerequisite graph is deliberately untouched: it still
+names $(RESULTS_DIR). A forked variant is driven through the do-
+targets, which is what the flow.sh path does anyway.
+
+Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
+---
+ docs/user/FlowVariables.md         | 66 +++++++++++++++++++++++++++
+ flow/scripts/generate_abstract.tcl |  4 +-
+ flow/scripts/load.tcl              |  8 ++--
+ flow/scripts/read_liberty.tcl      |  2 +-
+ flow/scripts/synth_preamble.tcl    |  2 +-
+ flow/scripts/util.tcl              | 71 ++++++++++++++++++++++++++----
+ flow/scripts/variables.mk          | 14 ++++++
+ flow/scripts/variables.yaml        |  9 ++++
+ flow/scripts/yosys_load.tcl        |  3 +-
+ flow/util/utils.mk                 | 12 ++---
+ 10 files changed, 167 insertions(+), 24 deletions(-)
+
+diff --git a/docs/user/FlowVariables.md b/docs/user/FlowVariables.md
+index cd80fc4e5..b51cfbdb8 100644
+--- a/docs/user/FlowVariables.md
++++ b/docs/user/FlowVariables.md
+@@ -84,6 +84,70 @@ These are optional variables that may be over-ridden/appended with
+ default value from the platform `config.mk` by defining in the design
+ configuration file.
+ 
++## Variant directories: reading from one variant, writing to another
++
++`FLOW_VARIANT` names the directory a run writes to: `RESULTS_DIR`,
++`LOG_DIR`, `REPORTS_DIR` and `OBJECTS_DIR` all end in the variant name.
++`FLOW_INPUT_VARIANT` names the directory a run *reads* from, through the
++matching `INPUT_RESULTS_DIR`, `INPUT_LOG_DIR`, `INPUT_REPORTS_DIR` and
++`INPUT_OBJECTS_DIR`. It defaults to `FLOW_VARIANT`, so by default the
++two are the same directory and nothing about a normal run changes.
++
++Setting it forks a variant off a shared upstream one. The forked run
++reads the upstream variant's results and writes only its own, so the
++shared stages are never re-run and never copied. Results are looked up
++in `RESULTS_DIR` first and `INPUT_RESULTS_DIR` second, so a file an
++earlier step of the same run just wrote always wins over the upstream
++variant's copy of it.
++
++This is how to share an expensive front end across experiments — run
++synthesis, floorplan, placement and CTS once as `base`, then fork a
++variant per routing experiment:
++
++```shell
++make DESIGN_CONFIG=... FLOW_VARIANT=base cts
++make DESIGN_CONFIG=... FLOW_INPUT_VARIANT=base FLOW_VARIANT=high_effort do-grt do-route do-final
++```
++
++The same mechanism lets one fork produce an input for another. A custom
++flow computes the pin layout: it runs with `FLOW_INPUT_VARIANT=base
++FLOW_VARIANT=io`, reads the shared floorplan, and writes `io.tcl` into
++the `io` variant. The main flow then re-runs from floorplan with
++`IO_CONSTRAINTS` pointing at it, still reusing the same `base`
++synthesis:
++
++```mermaid
++flowchart LR
++  subgraph base["FLOW_VARIANT=base — shared front end"]
++    S["1_synth"] --> F["2_floorplan"] --> P["3_place"] --> C["4_cts"]
++  end
++
++  subgraph io["FLOW_INPUT_VARIANT=base, FLOW_VARIANT=io"]
++    Q["quick pin placement"] --> IOTCL["io.tcl"]
++  end
++
++  subgraph main["FLOW_INPUT_VARIANT=base, FLOW_VARIANT=main"]
++    G["5_grt"] --> R["5_route"] --> FIN["6_final"]
++  end
++
++  subgraph hi["FLOW_INPUT_VARIANT=base, FLOW_VARIANT=high_effort"]
++    G2["5_grt (higher effort)"] --> R2["5_route"] --> FIN2["6_final"]
++  end
++
++  F -. "reads base results" .-> Q
++  C -. "reads base results" .-> G
++  C -. "reads base results" .-> G2
++  IOTCL -- "IO_CONSTRAINTS" --> F
++```
++
++Dashed edges are reads across variants. Without `FLOW_INPUT_VARIANT`,
++each fork needs a physical copy of the `base` directories before it can
++start.
++
++Because `INPUT_*_DIR` are `?=`, a caller that repoints an output
++directory somewhere that is not variant-shaped can repoint the matching
++input directory too, independently of `FLOW_INPUT_VARIANT`.
++
+ # Automatically generated tables from flow/scripts/variables.yaml
+ ## Variables in alphabetic order
+ 
+@@ -151,6 +215,7 @@ configuration file.
+ | <a name="FILL_CELLS"></a>FILL_CELLS| Fill cells are used to fill empty sites. If not set or empty, fill cell insertion is skipped.| |
+ | <a name="FILL_CONFIG"></a>FILL_CONFIG| JSON rule file for metal fill during chip finishing.| |
+ | <a name="FLOORPLAN_DEF"></a>FLOORPLAN_DEF| Use the DEF file to initialize floorplan. Mutually exclusive with FOOTPRINT or DIE_AREA/CORE_AREA or CORE_UTILIZATION.| |
++| <a name="FLOW_INPUT_VARIANT"></a>FLOW_INPUT_VARIANT| Flow variant a stage reads its inputs from, used in the INPUT_RESULTS_DIR/INPUT_LOG_DIR/INPUT_REPORTS_DIR/INPUT_OBJECTS_DIR directory names. Defaults to FLOW_VARIANT, i.e. a stage reads from the same variant directory it writes to. Set it to fork a variant off a shared upstream one: the forked variant reads the upstream results and writes only its own, so the shared stages are never re-run.| |
+ | <a name="FLOW_VARIANT"></a>FLOW_VARIANT| Flow variant to use, used in the flow variant directory name.| base|
+ | <a name="FOOTPRINT"></a>FOOTPRINT| Custom footprint definition file for ICeWall-based floorplan initialization. Mutually exclusive with FLOORPLAN_DEF or DIE_AREA/CORE_AREA or CORE_UTILIZATION.| |
+ | <a name="FOOTPRINT_TCL"></a>FOOTPRINT_TCL| Specifies a Tcl script with custom footprint-related commands for floorplan setup.| |
+@@ -652,6 +717,7 @@ configuration file.
+ - [ENABLE_DPO](#ENABLE_DPO)
+ - [FASTROUTE_TCL](#FASTROUTE_TCL)
+ - [FILL_CONFIG](#FILL_CONFIG)
++- [FLOW_INPUT_VARIANT](#FLOW_INPUT_VARIANT)
+ - [FLOW_VARIANT](#FLOW_VARIANT)
+ - [GDS_FILES](#GDS_FILES)
+ - [GENERATE_ARTIFACTS_ON_FAILURE](#GENERATE_ARTIFACTS_ON_FAILURE)
+diff --git a/flow/scripts/generate_abstract.tcl b/flow/scripts/generate_abstract.tcl
+index 3f860034f..4a24b6cd3 100644
+--- a/flow/scripts/generate_abstract.tcl
++++ b/flow/scripts/generate_abstract.tcl
+@@ -13,8 +13,8 @@ set sdc_file [lindex $result 1]
+ 
+ log_cmd load_design $stem.odb [file tail $sdc_file]
+ 
+-if { $design_stage >= 6 && [file exists $::env(RESULTS_DIR)/$stem.spef] } {
+-  log_cmd read_spef $::env(RESULTS_DIR)/$stem.spef
++if { $design_stage >= 6 && [file exists [orfs_input_path $stem.spef]] } {
++  log_cmd read_spef [orfs_input_path $stem.spef]
+ } elseif { $design_stage >= 3 } {
+   log_cmd estimate_parasitics -placement
+ }
+diff --git a/flow/scripts/load.tcl b/flow/scripts/load.tcl
+index 1b3a6c463..fd29176db 100644
+--- a/flow/scripts/load.tcl
++++ b/flow/scripts/load.tcl
+@@ -26,20 +26,20 @@ proc load_design { design_file sdc_file } {
+     # AUTO_MEMORIES: abstract LEFs generated pre-synthesis; globbed
+     # because the file names are only known at run time.
+     if { [env_var_equals AUTO_MEMORIES 1] } {
+-      foreach lef [glob -nocomplain $::env(RESULTS_DIR)/memories/*.lef] {
++      foreach lef [orfs_input_glob memories/*.lef] {
+         read_lef $lef
+       }
+     }
+-    read_verilog $::env(RESULTS_DIR)/$design_file
++    read_verilog [orfs_input_path $design_file]
+     log_cmd link_design {*}[hier_options] $::env(DESIGN_NAME)
+   } elseif { $ext == ".odb" } {
+-    log_cmd read_db {*}[hier_options] $::env(RESULTS_DIR)/$design_file
++    log_cmd read_db {*}[hier_options] [orfs_input_path $design_file]
+   } else {
+     error "Unrecognized input file $design_file"
+   }
+ 
+   # Read SDC file
+-  log_cmd read_sdc $::env(RESULTS_DIR)/$sdc_file
++  log_cmd read_sdc [orfs_input_path $sdc_file]
+ 
+   if { [file exists $::env(PLATFORM_DIR)/derate.tcl] } {
+     log_cmd source $::env(PLATFORM_DIR)/derate.tcl
+diff --git a/flow/scripts/read_liberty.tcl b/flow/scripts/read_liberty.tcl
+index 1c013611d..c68724646 100644
+--- a/flow/scripts/read_liberty.tcl
++++ b/flow/scripts/read_liberty.tcl
+@@ -23,7 +23,7 @@ if { [env_var_exists_and_non_empty CORNERS] } {
+ # LIB_FILES. The _pre_layout variants (ideal clock) are for pre-CTS
+ # consumers that select lib files themselves.
+ if { [env_var_equals AUTO_MEMORIES 1] } {
+-  foreach libFile [glob -nocomplain $::env(RESULTS_DIR)/memories/*.lib] {
++  foreach libFile [orfs_input_glob memories/*.lib] {
+     if { [string match *_pre_layout.lib $libFile] } {
+       continue
+     }
+diff --git a/flow/scripts/synth_preamble.tcl b/flow/scripts/synth_preamble.tcl
+index 14a9d70d7..187e0e485 100644
+--- a/flow/scripts/synth_preamble.tcl
++++ b/flow/scripts/synth_preamble.tcl
+@@ -51,7 +51,7 @@ proc auto_memories_blackboxes { } {
+   if { ![env_var_equals AUTO_MEMORIES 1] } {
+     return {}
+   }
+-  set f "$::env(RESULTS_DIR)/memories/blackboxes.txt"
++  set f [orfs_input_path memories/blackboxes.txt]
+   if { ![file exists $f] } {
+     error "AUTO_MEMORIES=1 but $f is missing;\
+       the do-auto-memories step must run before synthesis"
+diff --git a/flow/scripts/util.tcl b/flow/scripts/util.tcl
+index 5b7d98c8d..b274536ad 100644
+--- a/flow/scripts/util.tcl
++++ b/flow/scripts/util.tcl
+@@ -73,6 +73,54 @@ proc recover_power_helper { } {
+   report_power
+ }
+ 
++# The results search path: this variant's own RESULTS_DIR first, then
++# the INPUT_RESULTS_DIR it was forked from. RESULTS_DIR comes first so
++# that a stage reading a file an earlier step of the same run just wrote
++# picks up the fresh one rather than the upstream variant's copy. The
++# two are the same directory unless FLOW_INPUT_VARIANT says otherwise.
++proc orfs_input_dirs { } {
++  set dirs [list $::env(RESULTS_DIR)]
++  if {
++    [info exists ::env(INPUT_RESULTS_DIR)] &&
++    $::env(INPUT_RESULTS_DIR) ne $::env(RESULTS_DIR)
++  } {
++    lappend dirs $::env(INPUT_RESULTS_DIR)
++  }
++  return $dirs
++}
++
++# Resolve a result file by name against the results search path.
++proc orfs_input_path { name } {
++  foreach dir [orfs_input_dirs] {
++    set path [file join $dir $name]
++    if { [file exists $path] } {
++      return $path
++    }
++  }
++  # Nowhere on the path: return the RESULTS_DIR path so the caller
++  # reports the file missing where it would have been written.
++  return [file join $::env(RESULTS_DIR) $name]
++}
++
++# Glob a pattern across the results search path. Same precedence as
++# orfs_input_path: a basename present in more than one directory
++# resolves to the earliest one, and the later copies are dropped.
++proc orfs_input_glob { pattern } {
++  set result {}
++  set seen {}
++  foreach dir [orfs_input_dirs] {
++    foreach path [lsort [glob -nocomplain -directory $dir $pattern]] {
++      set name [file tail $path]
++      if { [lsearch -exact $seen $name] != -1 } {
++        continue
++      }
++      lappend seen $name
++      lappend result $path
++    }
++  }
++  return $result
++}
++
+ proc extract_stage { input_file } {
+   # Match the stage prefix on the basename, not the full path: an ancestor
+   # dir like ".../4_something/3_place.odb" would otherwise match "4_" -> stage 4.
+@@ -91,10 +139,10 @@ proc extract_stage { input_file } {
+ 
+ proc find_sdc_file { input_file } {
+   # canonicalize input file, sometimes it is called with an input
+-  # file relative to $::env(RESULTS_DIR), other times with
++  # file relative to the results search path, other times with
+   # an absolute path
+   if { ![file exists $input_file] } {
+-    set input_file [file join $::env(RESULTS_DIR) $input_file]
++    set input_file [orfs_input_path $input_file]
+   }
+   set input_file [file normalize $input_file]
+ 
+@@ -102,14 +150,19 @@ proc find_sdc_file { input_file } {
+   set design_stage [lindex $stage 0]
+   set sdc_file ""
+ 
+-  set exact_sdc [string map {.odb .sdc} $input_file]
+-  set sdc_files \
+-    [glob -nocomplain -directory $::env(RESULTS_DIR) -types f "\[1-9+\]_\[1-9_A-Za-z\]*\.sdc"]
+-  set sdc_files [lsort -decreasing -dictionary $sdc_files]
+-  set sdc_files [lmap file $sdc_files { file normalize $file }]
+-  foreach name $sdc_files {
++  # Pick the latest .sdc at or before this stage. The ordering is on the
++  # basename, not the full path: candidates can come from either
++  # directory on the results search path and the directory prefix must
++  # not decide which one wins.
++  set exact_sdc [string map {.odb .sdc} [file tail $input_file]]
++  set candidates {}
++  foreach path [orfs_input_glob "\[1-9+\]_\[1-9_A-Za-z\]*\.sdc"] {
++    lappend candidates [list [file tail $path] [file normalize $path]]
++  }
++  foreach candidate [lsort -decreasing -dictionary -index 0 $candidates] {
++    set name [lindex $candidate 0]
+     if { [lindex [lsort -decreasing -dictionary [list $name $exact_sdc]] 0] == $exact_sdc } {
+-      set sdc_file $name
++      set sdc_file [lindex $candidate 1]
+       break
+     }
+   }
+diff --git a/flow/scripts/variables.mk b/flow/scripts/variables.mk
+index 656773715..cf8bf445a 100644
+--- a/flow/scripts/variables.mk
++++ b/flow/scripts/variables.mk
+@@ -48,6 +48,20 @@ export OBJECTS_DIR = $(WORK_HOME)/objects/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_
+ export REPORTS_DIR = $(WORK_HOME)/reports/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_VARIANT)
+ export RESULTS_DIR = $(WORK_HOME)/results/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_VARIANT)
+ 
++# Where a stage reads its inputs, as opposed to where it writes its
++# outputs. FLOW_INPUT_VARIANT names the variant a stage reads from;
++# defaulting it to FLOW_VARIANT makes every INPUT_*_DIR expand to a
++# string identical to its *_DIR counterpart, so nothing changes until a
++# variant is deliberately forked off another one. The INPUT_*_DIR are
++# ?= so a caller that repoints an output directory to something not
++# variant-shaped can repoint the matching input directory too.
++export FLOW_INPUT_VARIANT ?= $(FLOW_VARIANT)
++
++export INPUT_LOG_DIR     ?= $(WORK_HOME)/logs/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_INPUT_VARIANT)
++export INPUT_OBJECTS_DIR ?= $(WORK_HOME)/objects/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_INPUT_VARIANT)
++export INPUT_REPORTS_DIR ?= $(WORK_HOME)/reports/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_INPUT_VARIANT)
++export INPUT_RESULTS_DIR ?= $(WORK_HOME)/results/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_INPUT_VARIANT)
++
+ #-------------------------------------------------------------------------------
+ ifeq (,$(strip $(NUM_CORES)))
+   # Linux (utility program)
+diff --git a/flow/scripts/variables.yaml b/flow/scripts/variables.yaml
+index f51b647ed..3cdc3578f 100644
+--- a/flow/scripts/variables.yaml
++++ b/flow/scripts/variables.yaml
+@@ -1532,6 +1532,15 @@ FLOW_VARIANT:
+   description: >
+     Flow variant to use, used in the flow variant directory name.
+   default: base
++FLOW_INPUT_VARIANT:
++  description: >
++    Flow variant a stage reads its inputs from, used in the
++    INPUT_RESULTS_DIR/INPUT_LOG_DIR/INPUT_REPORTS_DIR/INPUT_OBJECTS_DIR
++    directory names. Defaults to FLOW_VARIANT, i.e. a stage reads from
++    the same variant directory it writes to. Set it to fork a variant
++    off a shared upstream one: the forked variant reads the upstream
++    results and writes only its own, so the shared stages are never
++    re-run.
+ RULES_JSON:
+   description: >
+     json files with the metrics baseline regression rules.
+diff --git a/flow/scripts/yosys_load.tcl b/flow/scripts/yosys_load.tcl
+index 2d6fe387f..bff9781b0 100644
+--- a/flow/scripts/yosys_load.tcl
++++ b/flow/scripts/yosys_load.tcl
+@@ -1,6 +1,7 @@
+ # Load synthesis result
+ yosys -import
+ 
++source $::env(SCRIPTS_DIR)/util.tcl
+ source $::env(SCRIPTS_DIR)/synth_stdcells.tcl
+ 
+-read_verilog $::env(RESULTS_DIR)/1_synth.v
++read_verilog [orfs_input_path 1_synth.v]
+diff --git a/flow/util/utils.mk b/flow/util/utils.mk
+index c3b56a1e7..f8a756d3b 100644
+--- a/flow/util/utils.mk
++++ b/flow/util/utils.mk
+@@ -23,9 +23,9 @@ metadata-generate:
+ 	$(PYTHON_EXE) $(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
+ 	    -p $(PLATFORM) \
+ 	    -v $(FLOW_VARIANT) \
+-	    --logs $(LOG_DIR) \
+-	    --reports $(REPORTS_DIR) \
+-	    --results $(RESULTS_DIR) \
++	    --logs $(INPUT_LOG_DIR) \
++	    --reports $(INPUT_REPORTS_DIR) \
++	    --results $(INPUT_RESULTS_DIR) \
+ 	    -o $(REPORTS_DIR)/metadata.json 2>&1 \
+ 	    | tee $(abspath $(REPORTS_DIR)/metadata-generate.log)
+ 
+@@ -100,9 +100,9 @@ update_metadata_autotuner:
+ 	$(PYTHON_EXE) $(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
+ 	    -p $(PLATFORM) \
+ 	    -v $(FLOW_VARIANT) \
+-	    --logs $(LOG_DIR) \
+-	    --reports $(REPORTS_DIR) \
+-	    --results $(RESULTS_DIR) \
++	    --logs $(INPUT_LOG_DIR) \
++	    --reports $(INPUT_REPORTS_DIR) \
++	    --results $(INPUT_RESULTS_DIR) \
+ 	    -o $(DESIGN_DIR)/metadata-$(FLOW_VARIANT)-at.json -x
+ 
+ #-------------------------------------------------------------------------------

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -178,13 +178,6 @@ def yosys_only_attrs():
         ),
     }
 
-def renamed_inputs_attr():
-    return {
-        "renamed_inputs": attr.string_keyed_label_dict(
-            default = {},
-        ),
-    }
-
 def synth_attrs():
     return {
         "deps": attr.label_list(

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -650,49 +650,6 @@ def generation_commands(optional_files):
         ]
     return []
 
-def _remap(s, a, b):
-    # Replace only the last occurrence of the variant path segment to avoid
-    # clobbering unrelated path components that happen to match the variant
-    # name (e.g., a Bazel package named "test" sharing a name with variant
-    # "test").
-    suffix = "/" + a
-    if s.endswith(suffix):
-        return s[:-len(suffix)] + "/" + b
-    key = "/" + a + "/"
-    idx = s.rfind(key)
-    if idx == -1:
-        return s
-    return s[:idx] + "/" + b + "/" + s[idx + len(key):]
-
-def renames(ctx, inputs, short = False):
-    """Move inputs to the expected input locations.
-
-    Args:
-      ctx: The rule context.
-      inputs: List of input files to potentially rename.
-      short: If True, use short_path instead of path.
-
-    Returns:
-      A list of structs with src and dst fields for renaming.
-    """
-    result = []
-    for file in inputs:
-        if ctx.attr.src[OrfsInfo].variant != ctx.attr.variant:
-            src_path = file_path(file, short)
-            dst_path = _remap(
-                src_path,
-                ctx.attr.src[OrfsInfo].variant,
-                ctx.attr.variant,
-            )
-
-            # Files from a different variant than both the src and this
-            # stage (e.g., base synth outputs forwarded through a
-            # downstream-variant chain) aren't touched by _remap and end
-            # up with src == dst. Skip — `mv` would error on same file.
-            if src_path != dst_path:
-                result.append(struct(src = src_path, dst = dst_path))
-    return result
-
 def _artifact_name(ctx, category, name = None):
     return "/".join(
         [

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -307,11 +307,6 @@ def source_inputs(ctx, use_pre_layout = None, gds = True, logging = True):
         ] + lib_depsets,
     )
 
-def rename_inputs(ctx):
-    return depset(
-        transitive = [target.files for target in ctx.attr.renamed_inputs.values()],
-    )
-
 def pdk_inputs(ctx):
     return depset(transitive = [ctx.attr.pdk[PdkInfo].files, ctx.attr.pdk[PdkInfo].libs])
 
@@ -689,21 +684,6 @@ def renames(ctx, inputs, short = False):
             # up with src == dst. Skip — `mv` would error on same file.
             if src_path != dst_path:
                 result.append(struct(src = src_path, dst = dst_path))
-
-    # renamed_inputs win over variant renaming
-    for file in inputs:
-        if file.basename in ctx.attr.renamed_inputs:
-            for src in ctx.attr.renamed_inputs[file.basename].files.to_list():
-                result.append(
-                    struct(
-                        src = file_path(src, short),
-                        dst = _remap(
-                            file_path(file, short),
-                            ctx.attr.src[OrfsInfo].variant,
-                            ctx.attr.variant,
-                        ),
-                    ),
-                )
     return result
 
 def _artifact_name(ctx, category, name = None):

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -372,7 +372,7 @@ def platform_config(ctx):
     ).config.files.to_list()[0]
 
 def required_arguments(ctx):
-    return {
+    arguments = {
         "DESIGN_NAME": module_top(ctx),
         "FLOW_VARIANT": ctx.attr.variant,
         "GENERATE_ARTIFACTS_ON_FAILURE": "1",
@@ -380,6 +380,18 @@ def required_arguments(ctx):
         "PLATFORM_DIR": platform_config(ctx).dirname,
         "WORK_HOME": "./" + ctx.label.package,
     }
+
+    # A stage writes to its own variant's directories and reads its src's.
+    # ORFS resolves reads against INPUT_RESULTS_DIR, which FLOW_INPUT_VARIANT
+    # names; the two variants agree for most of the flow, and differ wherever
+    # a variant forks off a shared upstream one (a sweep, a mocked/unmocked
+    # abstract, the QoR pre-check's "<variant>_synth"). Only the variant path
+    # segment ever differs — WORK_HOME and DESIGN_NICKNAME are shared, so the
+    # ORFS-side derivation of INPUT_*_DIR lands on the src's directories.
+    if hasattr(ctx.attr, "src") and OrfsInfo in ctx.attr.src:
+        arguments["FLOW_INPUT_VARIANT"] = ctx.attr.src[OrfsInfo].variant
+
+    return arguments
 
 def orfs_additional_arguments(infos, short = False, use_pre_layout = False):
     """Returns ADDITIONAL_GDS/LEFS/LIBS arguments from OrfsInfo providers.
@@ -585,16 +597,24 @@ def log_dir_arguments(ctx):
     which names the flow's directory only when the run happens to sit in
     the same package as its src.
 
+    INPUT_LOG_DIR comes along: the src's logs are both where the run reads
+    from and where it writes to, and the ORFS-side derivation of
+    INPUT_LOG_DIR from FLOW_INPUT_VARIANT assumes this target's WORK_HOME,
+    which is the assumption this override exists to break.
+
     Args:
       ctx: Rule context.
 
     Returns:
-      {"LOG_DIR": ...} for a src that carries logs, otherwise empty.
+      {"LOG_DIR": ..., "INPUT_LOG_DIR": ...} for a src that carries logs,
+      otherwise empty.
     """
     if LoggingInfo not in ctx.attr.src:
         return {}
     log_dir = ctx.attr.src[LoggingInfo].log_dir
-    return {"LOG_DIR": log_dir} if log_dir else {}
+    if not log_dir:
+        return {}
+    return {"LOG_DIR": log_dir, "INPUT_LOG_DIR": log_dir}
 
 def fork_arguments(ctx, short = False):
     """The fork/join idiom files (see fork/fork.tcl).
@@ -629,19 +649,6 @@ def generation_commands(optional_files):
             "touch " + " ".join(sorted([result.path for result in optional_files])),
         ]
     return []
-
-def _mv_cmds(src, dst):
-    dir, _, _ = dst.rpartition("/")
-    return [
-        "mkdir -p {}".format(dir),
-        "mv {} {}".format(src, dst),
-    ]
-
-def input_commands(renames):
-    cmds = []
-    for rename in renames:
-        cmds.extend(_mv_cmds(rename.src, rename.dst))
-    return cmds
 
 def _remap(s, a, b):
     # Replace only the last occurrence of the variant path segment to avoid

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -263,7 +263,6 @@ def orfs_flow(
         sources = {},
         user_sources = {},
         stage_arguments = {},
-        renamed_inputs = {},
         arguments = {},
         user_arguments = {},
         extra_arguments = {},
@@ -304,7 +303,6 @@ def orfs_flow(
       stage_arguments: dictionary keyed by ORFS stages with lists of stage-specific arguments.
         Prefer 'arguments' which automatically assigns variables to the correct stages.
         Use stage_arguments only to override the automatic stage assignment.
-      renamed_inputs: dictionary keyed by ORFS stages to rename inputs
       arguments: dictionary of additional arguments to the flow, automatically assigned to stages
       user_arguments: dictionary of project-specific env vars to expose to every stage without
         validating against ORFS variables.yaml. Use for vars read only by user-supplied .tcl/.mk
@@ -389,7 +387,6 @@ def orfs_flow(
         sources = sources,
         user_sources = user_sources,
         stage_arguments = stage_arguments,
-        renamed_inputs = renamed_inputs,
         arguments = arguments,
         user_arguments = user_arguments,
         extra_arguments = extra_arguments,
@@ -437,7 +434,6 @@ def orfs_flow(
         sources = sources,
         user_sources = user_sources,
         stage_arguments = stage_arguments,
-        renamed_inputs = {},
         arguments = arguments | {"SYNTH_GUT": "1"},
         user_arguments = user_arguments,
         extra_arguments = _merge_extra_arguments(extra_arguments, mock_extra_arguments),
@@ -468,9 +464,6 @@ def orfs_flow(
         module_top = name,
         **_strip_tool_kwargs(**kwargs)
     )
-
-def _kwargs(stage, **kwargs):
-    return {k: v[stage] for k, v in kwargs.items() if stage in v and v[stage]}
 
 def _update_rules_impl(ctx):
     script = ctx.actions.declare_file(ctx.attr.name + "_update.sh")
@@ -534,7 +527,6 @@ def _orfs_pass(
         macros,
         sources,
         stage_arguments,
-        renamed_inputs,
         arguments,
         user_arguments,
         user_sources,
@@ -782,14 +774,7 @@ def _orfs_pass(
                 variant = variant_override or variant,
                 stage_data = stage_data,
                 data = data,
-                **(
-                    kwargs |
-                    _kwargs(
-                        step.stage,
-                        renamed_inputs = renamed_inputs,
-                    ) |
-                    more_kwargs
-                )
+                **(kwargs | more_kwargs)
             )
         )
         return step_name
@@ -838,10 +823,7 @@ def _orfs_pass(
                 src = place_src,
                 variant = pre_layout_variant,
                 stage_data = stage_data,
-                **(
-                    kwargs |
-                    _kwargs(ABSTRACT_IMPL.stage, renamed_inputs = renamed_inputs)
-                )
+                **kwargs
             )
         )
         _create_deps_tar(pre_layout_name, **kwargs)

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -912,9 +912,9 @@ def _orfs_pass(
     # The pair lives in its own "<variant>_synth" sub-variant so its
     # metadata.json and config artifacts cannot collide with the
     # full-flow chain's (both would otherwise be declared under the same
-    # variant-scoped paths). The synth inputs staged under the parent
-    # variant's tree are remapped by the stage's cross-variant renaming
-    # (rename_data on orfs_generate_metadata).
+    # variant-scoped paths). The synth inputs stay staged under the
+    # parent variant's tree; the stage reads them there because its
+    # FLOW_INPUT_VARIANT names the parent.
     if synth_target != None and not mock_area:
         test_args = get_stage_args(
             [TEST_STAGE_IMPL.stage],

--- a/private/providers.bzl
+++ b/private/providers.bzl
@@ -38,7 +38,6 @@ OrfsDepInfo = provider(
     fields = [
         "make",
         "config",
-        "renames",
         "files",
         "runfiles",
     ],

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -8,7 +8,6 @@ load(
     "openroad_attrs",
     "openroad_only_attrs",
     "orfs_attrs",
-    "renamed_inputs_attr",
     "synth_attrs",
     "yosys_attrs",
     "yosys_only_attrs",
@@ -43,7 +42,6 @@ load(
     "orfs_additional_arguments",
     "out_dir_arguments",
     "pdk_inputs",
-    "rename_inputs",
     "renames",
     "required_arguments",
     "run_arguments",
@@ -2641,7 +2639,6 @@ def _make_impl(
                         gds = include_gds,
                         logging = include_logging,
                     ),
-                    rename_inputs(ctx),
                 ],
             ),
             outputs = all_outputs,
@@ -2701,7 +2698,6 @@ def _make_impl(
             flow_inputs(ctx),
             data_inputs(ctx),
             source_inputs(ctx),
-            rename_inputs(ctx),
         ],
     )
 
@@ -2924,7 +2920,6 @@ def _squashed_impl(ctx):
 orfs_squashed = rule(
     implementation = _squashed_impl,
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "stage_name": attr.string(mandatory = True),
                 "stages": attr.string_list(default = []),
@@ -2960,7 +2955,6 @@ orfs_floorplan_rule = rule(
         substep_names = STAGE_SUBSTEPS["floorplan"] if ctx.attr.substeps else [],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "floorplan",
@@ -2986,7 +2980,6 @@ orfs_place_rule = rule(
         substep_names = STAGE_SUBSTEPS["place"] if ctx.attr.substeps else [],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "place",
@@ -3014,7 +3007,6 @@ orfs_cts_rule = rule(
         substep_names = STAGE_SUBSTEPS["cts"] if ctx.attr.substeps else [],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "cts",
@@ -3053,7 +3045,6 @@ orfs_grt_rule = rule(
         substep_names = STAGE_SUBSTEPS["grt"] if ctx.attr.substeps else [],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "grt",
@@ -3085,7 +3076,6 @@ orfs_route_rule = rule(
         substep_names = STAGE_SUBSTEPS["route"] if ctx.attr.substeps else [],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "route",
@@ -3121,7 +3111,6 @@ orfs_final_rule = rule(
         substep_names = STAGE_SUBSTEPS["final"] if ctx.attr.substeps else [],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "final",
@@ -3149,7 +3138,6 @@ orfs_gds_rule = rule(
         ],
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "final",
@@ -3184,7 +3172,7 @@ orfs_generate_metadata_rule = rule(
         # staged under the parent variant's tree.
         rename_data = True,
     ),
-    attrs = openroad_attrs() | renamed_inputs_attr() | {
+    attrs = openroad_attrs() | {
         "_stage": attr.string(default = "generate_metadata"),
     },
     provides = flow_provides(),
@@ -3202,7 +3190,7 @@ orfs_update_rules = rule(
         report_names = ["rules.json"],
         result_names = [],
     ),
-    attrs = openroad_attrs() | renamed_inputs_attr() | {
+    attrs = openroad_attrs() | {
         "_stage": attr.string(default = "update_rules"),
     },
     provides = flow_provides(),
@@ -3229,7 +3217,6 @@ orfs_abstract_rule = rule(
         ),
     ),
     attrs = openroad_attrs() |
-            renamed_inputs_attr() |
             {
                 "_stage": attr.string(
                     default = "generate_abstract",

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -33,7 +33,6 @@ load(
     "fork_arguments",
     "generation_commands",
     "hack_away_prefix",
-    "input_commands",
     "log_dir_arguments",
     "merge_and_filter_arguments",
     "merge_arguments",
@@ -2472,8 +2471,7 @@ def _make_impl(
         json_names = [],
         drc_names = [],
         substep_names = [],
-        lib_pre_layout = None,
-        rename_data = False):
+        lib_pre_layout = None):
     """
     Implementation function for the OpenROAD-flow-scripts stages.
 
@@ -2491,12 +2489,6 @@ def _make_impl(
       drc_names: The names of the DRC files.
       substep_names: Substep names whose intermediate .odb files should be
           captured as additional action outputs in per-substep output groups.
-      rename_data: Also apply cross-variant input renaming to data and
-          logging inputs, not just `src` results. Needed when a stage of
-          a sub-variant (e.g. the fast synthesis QoR pre-check's
-          "<variant>_synth") consumes logs/jsons staged under the parent
-          variant's tree — make and genMetrics.py resolve those paths
-          from this stage's FLOW_VARIANT.
       lib_pre_layout: Optional pre-layout .lib File to expose on this
           stage's OrfsInfo. Used by orfs_abstract to surface the post-place
           .lib alongside the canonical (post-final) one.
@@ -2593,15 +2585,8 @@ def _make_impl(
         for f in all_outputs:
             ctx.actions.write(output = f, content = "{}" if f in json_set else "")
     else:
-        rename_candidates = ctx.files.src
-        if rename_data:
-            rename_candidates = depset(
-                ctx.files.src,
-                transitive = [data_inputs(ctx), source_inputs(ctx)],
-            ).to_list()
         commands = (
             generation_commands(reports + logs + jsons + drcs + substep_odbs) +
-            input_commands(renames(ctx, rename_candidates)) +
             [_make_cmd(ctx)]
         )
 
@@ -3167,10 +3152,6 @@ orfs_generate_metadata_rule = rule(
             "metadata.json",
         ],
         result_names = [],
-        # The fast synthesis QoR pre-check runs this rule under a
-        # "<variant>_synth" sub-variant whose logs/jsons inputs are
-        # staged under the parent variant's tree.
-        rename_data = True,
     ),
     attrs = openroad_attrs() | {
         "_stage": attr.string(default = "generate_metadata"),

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -41,7 +41,6 @@ load(
     "orfs_additional_arguments",
     "out_dir_arguments",
     "pdk_inputs",
-    "renames",
     "required_arguments",
     "run_arguments",
     "sdc_arguments",
@@ -86,7 +85,7 @@ def _tar_paths(f):
         return [rel, "_main/external/" + rel]
     return ["_main/" + sp]
 
-def _package_stage(ctx, config, make, runfiles_depset, renames = []):
+def _package_stage(ctx, config, make, runfiles_depset):
     """Create a portable .tar.gz from stage dependencies.
 
     Returns the tar File.
@@ -114,12 +113,6 @@ def _package_stage(ctx, config, make, runfiles_depset, renames = []):
     # Config goes to _main/config.mk
     lines.append("{}\t_main/config.mk".format(config.path))
 
-    # Renames: r.src is a short_path string; resolve to actual path.
-    short_to_path = {f.short_path: f.path for f in all_files}
-    for r in renames:
-        real_src = short_to_path.get(r.src, r.src)
-        lines.append("{}\t_main/{}".format(real_src, r.dst))
-
     # Make wrapper at top level
     lines.append("{}\tmake".format(make_wrapper.path))
 
@@ -143,7 +136,7 @@ def _package_stage(ctx, config, make, runfiles_depset, renames = []):
 
     return tar
 
-def _expand_deploy_template(ctx, exe, config, make, genfiles, name = "", renames = []):
+def _expand_deploy_template(ctx, exe, config, make, genfiles, name = ""):
     """Expands the deploy template for a stage.
 
     Args:
@@ -153,7 +146,6 @@ def _expand_deploy_template(ctx, exe, config, make, genfiles, name = "", renames
       make: The make script File.
       genfiles: List of Files to include in the deploy directory.
       name: Deploy folder name. Only deps targets set this to get per-target folders.
-      renames: List of rename structs (src, dst). Only used by deps rule.
     """
     ctx.actions.expand_template(
         template = ctx.file._deploy_template,
@@ -164,9 +156,6 @@ def _expand_deploy_template(ctx, exe, config, make, genfiles, name = "", renames
             "${MAKE}": make.short_path,
             "${NAME}": name,
             "${PACKAGE}": ctx.label.package,
-            "${RENAMES}": " ".join(
-                ["{}:{}".format(r.src, r.dst) for r in renames],
-            ),
         },
     )
 
@@ -333,7 +322,6 @@ def _deploy_srcs_impl(ctx):
         make = dep.make,
         genfiles = dep.files.to_list(),
         name = ctx.attr.name,
-        renames = dep.renames,
     )
     wrapper = ctx.actions.declare_file(ctx.attr.name + "_run.sh")
     ctx.actions.write(
@@ -495,7 +483,6 @@ def _run_impl(ctx):
         OrfsDepInfo(
             make = make,
             config = config,
-            renames = [],
             files = depset([config, ctx.file.script, ctx.file._fork_tcl, ctx.file._fork_lib] + extra_files),
             runfiles = ctx.runfiles(
                 transitive_files = depset(
@@ -2333,7 +2320,6 @@ def _yosys_impl(ctx):
         OrfsDepInfo(
             make = make,
             config = config_short,
-            renames = [],
             # Include the stage data (sources= files) like the PnR stage
             # rule does: orfs_arguments/orfs_run consumers stage
             # OrfsDepInfo.files, and the synth config can reference
@@ -2676,7 +2662,6 @@ def _make_impl(
     # the OrfsDepInfo.runfiles consumed by downstream rules (orfs_step,
     # orfs_deploy_srcs) are headless paths. openroad_qt is only added to
     # DefaultInfo.runfiles below so `bazelisk run :stage gui_<stage>` works.
-    stage_renames = renames(ctx, ctx.files.src, short = True)
     deploy_files = depset(
         [config_short, make] + ctx.files.src + ctx.files.extra_configs + all_jsons,
         transitive = [
@@ -2692,7 +2677,6 @@ def _make_impl(
         config = config_short,
         make = make,
         runfiles_depset = deploy_files,
-        renames = stage_renames,
     )
 
     # Legacy deploy script (used by orfs_step for bazel run).
@@ -2704,7 +2688,6 @@ def _make_impl(
         make = make,
         genfiles = [config_short] + ctx.files.src + ctx.files.data + ctx.files.extra_configs,
         name = ctx.attr.name + "_deps",
-        renames = stage_renames,
     )
 
     _runfiles_files = (
@@ -2772,7 +2755,6 @@ def _make_impl(
         OrfsDepInfo(
             make = make,
             config = config_short,
-            renames = stage_renames,
             # This stage's OWN data (sources= files) and configs — what the
             # next stage's source_inputs() legitimately needs beyond the
             # results/reports it already takes from DefaultInfo via
@@ -2839,7 +2821,6 @@ def _step_impl(ctx):
         make = ctx.attr.src[OrfsDepInfo].make,
         genfiles = ctx.attr.src[OrfsDepInfo].files.to_list(),
         name = deploy_name,
-        renames = ctx.attr.src[OrfsDepInfo].renames,
     )
 
     # Wrapper that symlinks runfiles so the deploy script can find them,

--- a/sweep.bzl
+++ b/sweep.bzl
@@ -35,8 +35,8 @@ def orfs_sweep(
         sweep: The dictionary describing the variables to sweep
         other_variants: Dictionary with other variants to generate, but not as part of the sweep.
             Per-variant keys: arguments, dissolve, macros, openroad, previous_stage,
-            renamed_inputs, stage_arguments, description, sources, yosys,
-            abstract_stage, last_stage, tags
+            stage_arguments, description, sources, yosys, abstract_stage,
+            last_stage, tags
         stage: The stage to do the sweep on
         macros: name of modules to use as macros
         verilog_files: The Verilog files to build
@@ -61,7 +61,6 @@ def orfs_sweep(
                 "macros",
                 "openroad",
                 "previous_stage",
-                "renamed_inputs",
                 "stage_arguments",
                 "description",
                 "sources",
@@ -95,7 +94,6 @@ def orfs_sweep(
                      ] +
                      all_variants[variant].get("macros", []),
             previous_stage = all_variants[variant].get("previous_stage", {}),
-            renamed_inputs = all_variants[variant].get("renamed_inputs", {}),
             stage_arguments = all_variants[variant].get("stage_arguments", {}),
             variant = variant,
             verilog_files = verilog_files,

--- a/test/BUILD
+++ b/test/BUILD
@@ -1442,6 +1442,57 @@ synth_action_inputs_test(
     target_under_test = ":lb_32x128_top_gds_scope_final",
 )
 
+# --- Forked variants: reading one variant, writing another ---
+#
+# ORFS resolves a stage's reads through INPUT_RESULTS_DIR, which
+# FLOW_INPUT_VARIANT names, so a variant that forks off a shared
+# upstream stage reads that stage's results where they already sit.
+# Nothing is copied into the forked variant's own directory first —
+# the cross-variant `mv` that used to precede every stage's make is
+# gone, and these pin down what replaced it.
+#
+# Variant "3" of the lb_32x128 sweep forks at cts: its cts stage takes
+# base's 3_place.odb (previous_stage = {"cts": "lb_32x128_place"}).
+
+filegroup(
+    name = "lb_32x128_3_cts_config",
+    srcs = [":lb_32x128_3_cts"],
+    output_group = "4_cts.mk",
+)
+
+sh_test(
+    name = "forked_variant_input_variant_test",
+    srcs = ["check_flow_input_variant.sh"],
+    args = [
+        "$(location :lb_32x128_3_cts_config)",
+        "base",
+        "3",
+    ],
+    data = [":lb_32x128_3_cts_config"],
+)
+
+# The src's results stay at the src variant's path: the forked stage
+# never sees a copy of them under its own results directory.
+synth_action_inputs_test(
+    name = "forked_variant_reads_src_variant_test",
+    forbidden_input_path_contains = ["/lb_32x128/3/3_place.odb"],
+    output_basename = "4_cts.odb",
+    required_input_path_contains = ["/lb_32x128/base/3_place.odb"],
+    target_under_test = ":lb_32x128_3_cts",
+)
+
+# End to end: a forked stage's make now finds its inputs only because
+# FLOW_INPUT_VARIANT points at them. Naming the targets in a test keeps
+# `bazel test` covering that, not just a wildcard build.
+build_test(
+    name = "forked_variant_build_test",
+    targets = [
+        ":lb_32x128_1_floorplan",
+        ":lb_32x128_2_place",
+        ":lb_32x128_3_cts",
+    ],
+)
+
 # Upstream metrics .json / report files feed only genMetrics.py: the
 # PnR stage actions never open them, so they are declared by the
 # metadata stages and dropped everywhere else (the jsons are supposed

--- a/test/check_flow_input_variant.sh
+++ b/test/check_flow_input_variant.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Asserts a forked variant's stage config names the variant it reads from.
+#
+# A stage writes to its own FLOW_VARIANT and reads its src's. ORFS resolves
+# the reads through INPUT_RESULTS_DIR, which FLOW_INPUT_VARIANT names, and
+# nothing copies the src's results into this variant's directory first. If
+# the two ever collapse to the same value on a forked variant, the stage
+# looks for its inputs in its own (empty) results directory.
+set -euo pipefail
+
+config="$1"
+expected_input_variant="$2"
+expected_variant="$3"
+
+fail() {
+  echo "FAIL: $1" >&2
+  echo "--- $config ---" >&2
+  grep -E '^(export )?FLOW(_INPUT)?_VARIANT' "$config" >&2 || true
+  exit 1
+}
+
+# config.mk writes these as `export NAME?=value`.
+actual_input=$(sed -n 's/^\(export \)\?FLOW_INPUT_VARIANT[[:space:]]*?\?=[[:space:]]*//p' "$config" | tail -1)
+actual=$(sed -n 's/^\(export \)\?FLOW_VARIANT[[:space:]]*?\?=[[:space:]]*//p' "$config" | tail -1)
+
+[ -n "$actual_input" ] || fail "FLOW_INPUT_VARIANT is not set at all"
+[ "$actual_input" = "$expected_input_variant" ] ||
+  fail "FLOW_INPUT_VARIANT is '$actual_input', expected '$expected_input_variant'"
+[ "$actual" = "$expected_variant" ] ||
+  fail "FLOW_VARIANT is '$actual', expected '$expected_variant'"
+[ "$actual_input" != "$actual" ] ||
+  fail "FLOW_INPUT_VARIANT collapsed onto FLOW_VARIANT ('$actual')"
+
+echo "PASS: reads from '$actual_input', writes to '$actual'"

--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -25,10 +25,20 @@ local_path_override(
 # --- Non-BCR deps that bazel-orfs needs (git_override is root-only) ---
 
 bazel_dep(name = "orfs")
-git_override(
+
+# Mirrors the root MODULE.bazel: same pin, same patch list. A root
+# module carries its own overrides, so bazel-orfs's are invisible here
+# and an ORFS patch that bazel-orfs depends on has to be re-listed.
+archive_override(
     module_name = "orfs",
-    commit = "c90beac0945588840cf07b7b4cc6d1b20ac66ddf",
-    remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
+    integrity = "sha256-hAos8HgYSs5NZlc3wWPKCT7dbZB23Poyqo4cqha6YwA=",
+    patch_strip = 1,
+    patches = [
+        "//patches:0037-orfs-single-writer-1_synth-sdc.patch",
+        "//patches:0038-orfs-flow-input-variant.patch",
+    ],
+    strip_prefix = "OpenROAD-flow-scripts-427bd762b7b7448f8bb6bc4e14207aa3963fca30",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/427bd762b7b7448f8bb6bc4e14207aa3963fca30.tar.gz"],
 )
 
 bazel_dep(name = "openroad")


### PR DESCRIPTION
A stage writes to its own variant's directories and reads its `src`'s. ORFS had one variant naming both, so every stage action began by `mv`-ing its inputs from the src variant's path to its own — string surgery on the last `/<src_variant>/` path segment, plus a second, wider pass (`rename_data`) for `generate_metadata`.

That renaming had leaked into six layers: `_remap`/`renames`/`input_commands`/`_mv_cmds`, the `rename_data` flag, `OrfsDepInfo.renames` threaded into the `_deps` tar manifest, a `for rename in $renames` loop in `deploy.tpl`, and the `renamed_inputs` attr on nine rules.

## The ORFS side

`patches/0038` splits the two directions:

```make
export FLOW_INPUT_VARIANT ?= $(FLOW_VARIANT)
export INPUT_RESULTS_DIR  ?= $(WORK_HOME)/results/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_INPUT_VARIANT)
# ... and INPUT_LOG_DIR / INPUT_OBJECTS_DIR / INPUT_REPORTS_DIR
```

Defaulting to `FLOW_VARIANT` makes each `INPUT_*_DIR` expand to a string identical to its `*_DIR` counterpart, so an unchanged ORFS run is unchanged.

Reads resolve against a search path — `RESULTS_DIR` first, `INPUT_RESULTS_DIR` second. That ordering is required, not cosmetic: `do-place` runs 3_1…3_5 in one action, writing `3_1_place_gp_skip_io.odb` and reading it back, so a file this run just wrote must win over the upstream variant's copy.

`load_design` turned out to be the chokepoint — all 18 stage scripts hand it a bare basename, so routing it through `orfs_input_path` covers the whole flow. The rest is the `AUTO_MEMORIES` globs, `find_sdc_file`, the abstract's `.spef`, `yosys_load`'s netlist, and genMetrics' directories.

`find_sdc_file`'s candidate ordering now compares basenames rather than full paths. With one directory the two are equivalent (every candidate shares a prefix); with two, the directory prefix would otherwise decide which `.sdc` wins.

The Makefile's prerequisite graph is deliberately untouched — bazel-orfs drives `do-` targets.

## The bazel-orfs side

`renames()` collapses to one line beside the existing `FLOW_VARIANT`:

```python
"FLOW_INPUT_VARIANT": ctx.attr.src[OrfsInfo].variant,
```

Five commits, least-churn-first, each landing green:

1. `refactor(attrs): remove renamed_inputs` — unused in-tree, and `TESTING.md` listed it as never tested. If we want it back, the idiomatic shape is an `orfs_macro()`-style rule assembling an `OrfsInfo`, not a basename-keyed dict of file substitutions on every stage.
2. `feat(orfs): INPUT_*_DIR and FLOW_INPUT_VARIANT` — the patch alone, a no-op by construction.
3. `feat(stages): FLOW_INPUT_VARIANT replaces cross-variant input renaming` — the `mv` goes.
4. `refactor(deps): the _deps tarball stops renaming its inputs`.
5. `test(variants): pin down what replaced the cross-variant rename`.

Net: 189 lines deleted, 542 added — 407 of which are the patch, so bazel-orfs itself is a ~135-line net deletion.

## What proves it

After commit 3, **every existing test runs through the new path** — `FLOW_INPUT_VARIANT` is set unconditionally and the `mv` is gone. Full suite green (121/121).

Commit 5 adds three tests on variant "3" of the `lb_32x128` sweep, which forks at cts off base's `3_place.odb`: its `4_cts.mk` names `base` as input and `3` as output and the two have not collapsed; the action's inputs carry base's `3_place.odb` and no copy under the fork's own path; and the forked stages build under `bazel test` rather than only a wildcard build. All three fail with the `FLOW_INPUT_VARIANT` assignment removed.

`test/downstream` is a root module, so its `orfs` override repeats the patch list. It was carrying **no patches at all**, silently dropping 0037 too; it now mirrors the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)