### PR TITLE
fix(downstream): make the consumer module resolve again, and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,17 @@ jobs:
         run: >-
           bazelisk build ... --keep_going --profile=lec.profile
 
+      # test/downstream is a root module in .bazelignore, so //... never
+      # reaches it and nothing else here would notice it rotting. It went
+      # unbuildable for months precisely because no step ran it. Builds
+      # OpenROAD and yosys from source, so it is slow on a cold cache
+      # (~55 min on 16 cores; near-instant warm) -- the disk cache saved
+      # on main is what keeps it viable as a per-PR step.
+      - name: "Submodule: downstream consumer"
+        working-directory: test/downstream
+        run: >-
+          bazelisk test ... --keep_going --profile=downstream.profile
+
       # --- Save caches (main branch only) ---
       - name: Save Repository cache
         if: always() && github.ref == 'refs/heads/main'

--- a/test/downstream/BUILD.bazel
+++ b/test/downstream/BUILD.bazel
@@ -21,7 +21,6 @@ orfs_flow(
         "PLACE_DENSITY": "0.65",
         # slang is required for SystemVerilog `automatic` keyword
         "SYNTH_HDL_FRONTEND": "slang",
-        "SLANG_PLUGIN_PATH": "$(location @sv-elab//src/yosys_plugin:slang.so)",
     },
     sources = {
         "SDC_FILE": [":constraints.sdc"],

--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -16,19 +16,23 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "bazel-orfs-verilog")
-local_path_override(
-    module_name = "bazel-orfs-verilog",
-    path = "../../verilog",
-)
-
 # --- Non-BCR deps that bazel-orfs needs (git_override is root-only) ---
 
 bazel_dep(name = "orfs")
-git_override(
+
+# Mirrors the root MODULE.bazel: same pin, same patch list. A root
+# module carries its own overrides, so bazel-orfs's are invisible here
+# and every @orfs patch it depends on has to be re-listed.
+archive_override(
     module_name = "orfs",
-    commit = "c90beac0945588840cf07b7b4cc6d1b20ac66ddf",
-    remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
+    integrity = "sha256-hAos8HgYSs5NZlc3wWPKCT7dbZB23Poyqo4cqha6YwA=",
+    patch_strip = 1,
+    patches = [
+        "//patches:0037-orfs-single-writer-1_synth-sdc.patch",
+        "//patches:0039-orfs-slang-plugin-fallback.patch",
+    ],
+    strip_prefix = "OpenROAD-flow-scripts-427bd762b7b7448f8bb6bc4e14207aa3963fca30",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/427bd762b7b7448f8bb6bc4e14207aa3963fca30.tar.gz"],
 )
 
 bazel_dep(name = "openroad")
@@ -108,15 +112,14 @@ single_version_override(
     version = "1.4.21.bcr.4",
 )
 
-# tcl_lang: tclZipfs.c's #include "crypt.h" resolves to glibc's crypt.h under
-# hermetic-llvm's explicit -isystem glibc dirs; include the vendored minizip
-# header by path instead. Drop when fixed in a tcl_lang BCR release.
+# verilator: the BCR overlay's BUILD.bazel hardcodes "-latomic" in the
+# linux linkopts, but the zero-sysroot hermetic-llvm toolchain ships no
+# libatomic -- clang lowers x86-64 atomics inline, so the library is not
+# needed here. ld.lld fails with "unable to find library -latomic"
+# otherwise.
 single_version_override(
-    module_name = "tcl_lang",
-    patch_strip = 1,
-    patches = [
-        "//patches:0001-tclZipfs-include-vendored-minizip-crypt.h-by-path.patch",
-    ],
+    module_name = "verilator",
+    patch_cmds = ["sed -i '/\"-latomic\",/d' BUILD.bazel"],
 )
 
 # sv-lang pulls in rules_pycross, whose toolchain extension fails on Python

--- a/test/downstream/README.md
+++ b/test/downstream/README.md
@@ -34,6 +34,21 @@ bazelisk test ...     # verilator simulation via cc_test + gtest
 
 ## Remaining issues
 
+### Every @orfs patch must be re-listed here
+
+This is a root module, so bazel-orfs's own `archive_override` is invisible
+to it and its `orfs` override has to repeat the full patch list. When it
+carried none, it was silently running unpatched ORFS. Adding a patch to
+the root `MODULE.bazel` without adding it here reintroduces that.
+
+### verilator and the hermetic toolchain
+
+verilator's BCR overlay hardcodes `-latomic` in its linux `linkopts`, and
+the zero-sysroot `llvm` toolchain ships no libatomic, so `ld.lld` fails
+with `unable to find library -latomic`. Dropped via a `patch_cmds` on a
+`single_version_override`; clang lowers x86-64 atomics inline, so nothing
+needs the library. Drop the override if the BCR module stops hardcoding it.
+
 ### Non-BCR deps require root-module overrides
 
 `orfs`, `openroad`, and `qt-bazel` are not on BCR. Downstream consumers


### PR DESCRIPTION
> **Stacked.** Based on `slang-plugin-load` (#845), which is itself based on `orfs-input-dirs` (#846) — this cannot be verified without both. Review the last commit; rebase onto main once those land.

`test/downstream` is a root module listed in `.bazelignore`, so `//...` never reaches it, and `ci.yml` has no step for it — `lec` gets one, this does not. Nothing has resolved this module in months.

It would not even compute its repo mapping. Five independent breakages, each hiding the next:

1. `bazel_dep(name = "bazel-orfs-verilog")` → `../../verilog`, deleted by 9bc8c74 (the rules_chisel migration updated the root and `gallery/MODULE.bazel`, and missed this one).
2. `single_version_override(tcl_lang)` naming `0001-tclZipfs-…crypt.h-by-path.patch`, deleted by 1eab895 — while the root moved to `tcl_lang 9.0.2.bcr.2`, which needs no patch.
3. `SLANG_PLUGIN_PATH` in `arguments=`, which ORFS removed from `variables.yaml` in `b18e110c1`, so the flow failed analysis with `Unknown ORFS variable(s)`.
4. `patches/0039` missing from the `orfs` override — this is a root module, so it repeats the root's patch list or runs unpatched ORFS. (0037/0038 handled in #846.)
5. verilator's BCR overlay hardcoding `-latomic` in its linux `linkopts` against a zero-sysroot hermetic toolchain that ships no libatomic:

```
ld.lld: error: unable to find library -latomic
```

(5) is dropped with a `patch_cmds` sed on a `single_version_override` — clang lowers x86-64 atomics inline, so nothing needs the library. `README.md` gains it and the re-list-every-patch rule under "Remaining issues".

## Result

All 5 targets build, `//:counter_test` passes.

## The CI step

Adding it is the point — without it this recurs. Measured on 16 cores:

| | |
|---|---|
| cold (builds OpenROAD + yosys from source) | **~55 min** |
| warm | **~100 s** |

`main` already saves the disk cache the step needs. If ~55 min on a cold cache is too much to gate every PR, the alternative is a nightly cron alongside the existing `github-actions-cron-*` workflows — happy to switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)