### PR TITLE
test(sram): build_test coverage for the SRAM/macro flows

### DIFF
--- a/sram/BUILD
+++ b/sram/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//:openroad.bzl", "orfs_flow", "orfs_macro", "orfs_run")
 
 FAST_SETTINGS = {
@@ -165,4 +166,34 @@ orfs_flow(
     },
     variant = "megaboom",
     verilog_files = [":megaboom/top.v"],
+)
+
+# ci.yml runs `bazelisk test ... --build_tests_only`, which builds only
+# what a test depends on. No test reached anything in this package, so
+# none of its 57 non-manual targets was ever built in CI -- the whole
+# SRAM/macro story (mocked vs unmocked abstracts, fakeram, the megaboom
+# and mix hierarchies) was covered by local wildcard builds only.
+#
+# These 11 pull the other 46 in transitively: each flow's terminal
+# generate_abstract drags its synth -> floorplan -> place -> cts chain,
+# and each _variables target drags the macro collateral. Verified with
+#
+#   bazelisk query --keep_going 'deps(set(<these>), 10)'
+#
+# covering every non-manual target in the package.
+build_test(
+    name = "sram_build_test",
+    targets = [
+        ":lef_file",
+        ":sdq_17x64_megaboom_variables",
+        ":sdq_17x64_variables",
+        ":top_fakeram_generate_abstract",
+        ":top_fakeram_variables",
+        ":top_generate_abstract",
+        ":top_megaboom_generate_abstract",
+        ":top_megaboom_variables",
+        ":top_mix_generate_abstract",
+        ":top_mix_variables",
+        ":top_variables",
+    ],
 )


### PR DESCRIPTION
`ci.yml` runs `bazelisk test ... --build_tests_only`, which builds only what a test depends on. No test reaches anything in `//sram`, so **none of its 57 non-manual targets has ever been built in CI**:

```
$ bazelisk query 'kind(rule, //sram:*) except attr(tags, "manual", //sram:*)'   # 57
$ ... minus deps(tests(//...))                                                  # still 57
```

The whole SRAM/macro story — mocked vs unmocked abstracts, `generate_area`, fakeram, and the megaboom and mix hierarchies — has been covered by local wildcard builds only. That is exactly how `//slang` (#845) and `//test:cell_count` (#844) came to be red without anyone noticing.

## Eleven targets, all 57 covered

Each flow's terminal `generate_abstract` drags its `synth → floorplan → place → cts` chain, and each `_variables` target drags the macro collateral. Verified by subtracting `deps(set(<these>), 10)` from the package's non-manual set and getting the empty set.

One trap worth recording, since it silently produced a wrong answer first time: an **unbounded** `deps()` query aborts here on an unrelated missing `@or-tools+//third_party/cbc` package, and the aborted query returns nothing rather than failing loudly — which looks identical to "this target has no deps". The depth bound and `--keep_going` are load-bearing.

## Cost

Warm: **102 s / 132 sandbox actions**. The cold cost is whatever five more designs through `generate_abstract` costs; I can't measure that honestly without discarding the local cache, so CI on this PR is the real number — worth a look before merging.

## The broader hole

This closes `//sram`. Roughly 150 non-manual targets across `//test` and `//subpackage` remain unreached by any test, mostly sweep-variant stages. If the bookkeeping isn't wanted long-term, the alternative is a plain `bazelisk build ... --keep_going` step in `ci.yml` alongside the test step — self-maintaining, no `build_test` list to forget, at the cost of building every non-manual target on every PR. Happy to do that instead or as well.

Full suite green: 121/121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)