### PR TITLE
feat(orfs_run): opt-in _deps reproducer companions

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -1,6 +1,5 @@
 """Flow orchestration macros for OpenROAD-flow-scripts Bazel rules."""
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//private:providers.bzl", "LoggingInfo")
 load(
@@ -11,10 +10,10 @@ load(
     "STAGE_IMPLS",
     "TEST_STAGE_IMPL",
     "UPDATE_RULES_IMPL",
+    "create_deps_tar",
     "orfs_abstract_rule",
     "orfs_arguments",
     "orfs_cts_rule",
-    "orfs_deploy_srcs",
     "orfs_final_rule",
     "orfs_floorplan_rule",
     "orfs_gds_rule",
@@ -151,32 +150,6 @@ def _orfs_html_report(name, src, variant = None, openroad = None, visibility = N
         visibility = visibility,
     )
 
-def _create_deps_tar(stage_name, **kwargs):
-    """Generate pkg_tar companion targets for a stage target.
-
-    Creates:
-      {stage_name}_deploy_srcs — thin rule exposing OrfsDepInfo.runfiles
-      {stage_name}_deps — pkg_tar with include_runfiles=True
-
-    Both targets are tagged "manual" so they are excluded from wildcard
-    builds (bazel build //pkg:all) and only built when explicitly requested.
-    """
-    visibility = kwargs.get("visibility", None)
-    orfs_deploy_srcs(
-        name = stage_name + "_deps",
-        src = ":" + stage_name,
-        visibility = visibility,
-        tags = ["manual"],
-    )
-    pkg_tar(
-        name = stage_name + "_deps_tar",
-        srcs = [":" + stage_name + "_deps"],
-        extension = "tar.gz",
-        include_runfiles = True,
-        visibility = visibility,
-        tags = ["manual"],
-    )
-
 def _orfs_stage(stage, impl, **kwargs):
     """Instantiates one stage target the way orfs_flow does.
 
@@ -192,7 +165,7 @@ def _orfs_stage(stage, impl, **kwargs):
         **kwargs: forwarded to _filter_stage_args and the rule.
     """
     impl(**_filter_stage_args(stage, **kwargs))
-    _create_deps_tar(kwargs.get("name"), **kwargs)
+    create_deps_tar(kwargs.get("name"), kwargs.get("visibility", None))
 
 def orfs_synth(**kwargs):
     """Instantiates a standalone synthesis stage target.
@@ -638,7 +611,7 @@ def _orfs_pass(
                 **kwargs
             )
         )
-        _create_deps_tar(step_name, **kwargs)
+        create_deps_tar(step_name, kwargs.get("visibility", None))
         if html:
             _orfs_html_report(
                 name = step_name + "_html",
@@ -724,7 +697,7 @@ def _orfs_pass(
                 **kwargs
             )
             step_names.append(squash_name)
-            _create_deps_tar(squash_name, **kwargs)
+            create_deps_tar(squash_name, kwargs.get("visibility", None))
             if html:
                 _orfs_html_report(
                     name = squash_name + "_html",
@@ -844,7 +817,7 @@ def _orfs_pass(
                 )
             )
         )
-        _create_deps_tar(pre_layout_name, **kwargs)
+        create_deps_tar(pre_layout_name, kwargs.get("visibility", None))
         return pre_layout_name
 
     for step, prev in zip(steps[start_stage:], steps[start_stage - 1:]):
@@ -860,7 +833,7 @@ def _orfs_pass(
 
         sn = do_step(step, prev, kwargs, more_kwargs = more_kwargs)
         step_names.append(sn)
-        _create_deps_tar(sn, **kwargs)
+        create_deps_tar(sn, kwargs.get("visibility", None))
         if html and step.stage in _HTML_STAGES:
             _orfs_html_report(
                 name = sn + "_html",

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -645,13 +645,21 @@ def _expand_sources(kwargs):
         kwargs["arguments"] = arguments
     return kwargs
 
-def orfs_run(**kwargs):
+def orfs_run(deps = False, **kwargs):
     """Rule wrapper for orfs_run to populate data dependencies and CLI arguments from explicitly specified sources.
 
     Args:
+        deps: Also emit the {name}_deps / {name}_deps_tar reproducer
+            companions, the way the flow stage macros do. Opt-in: most
+            orfs_run targets are build steps nobody reproduces by hand, and
+            the companions would be dead targets in every package. Turn it
+            on for a run whose failures get debugged interactively or filed
+            upstream.
         **kwargs: The keyword arguments to pass to the underlying _orfs_run_rule.
     """
     _orfs_run_rule(**_expand_sources(kwargs))
+    if deps:
+        create_deps_tar(kwargs.get("name"), kwargs.get("visibility", None))
 
 def _variables_impl(ctx):
     out = ctx.actions.declare_file(ctx.attr.name + ".json")

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1,5 +1,6 @@
 """Rule implementations and declarations for OpenROAD-flow-scripts Bazel rules."""
 
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load(
     "//private:attrs.bzl",
     "flow_attrs",
@@ -375,6 +376,38 @@ orfs_deploy_srcs = rule(
         ),
     },
 )
+
+def create_deps_tar(name, visibility = None):
+    """Generate the _deps reproducer companions for an ORFS target.
+
+    Creates:
+      {name}_deps — runnable orfs_deploy_srcs wrapper that installs a
+        self-contained reproducer under ./tmp
+      {name}_deps_tar — pkg_tar of the same runfiles, for offline
+        archives and upstream bug reports
+
+    Both are tagged "manual" so wildcard builds (bazel build //pkg:all) skip
+    them; they build only when named. The target must provide OrfsDepInfo.
+
+    Args:
+      name: the ORFS target to deploy, in this package. The companions are
+        named after it.
+      visibility: visibility for the generated companions.
+    """
+    orfs_deploy_srcs(
+        name = name + "_deps",
+        src = ":" + name,
+        visibility = visibility,
+        tags = ["manual"],
+    )
+    pkg_tar(
+        name = name + "_deps_tar",
+        srcs = [":" + name + "_deps"],
+        extension = "tar.gz",
+        include_runfiles = True,
+        visibility = visibility,
+        tags = ["manual"],
+    )
 
 # --- Run rule ---
 

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1028,6 +1028,36 @@ exec "$PYTHON" "$SCRIPT" {moreargs} "$@"
         ),
     )
 
+    # The executable drives make through run_executable.py, so it never
+    # needed the make wrapper script the flow rules deploy. A reproducer
+    # does: deploy.tpl runs `./make <cmd>` against config.mk. Mint one with
+    # the same arguments the wrapper bakes in, de-prefixed for the deployed
+    # tree the way orfs_run does.
+    deploy_make = _create_make_script(
+        ctx,
+        "make_{}_{}_run_executable".format(ctx.attr.name, ctx.attr.variant),
+        extra_substitutions = {
+            '"$@"': environment_string(
+                hack_away_prefix(
+                    arguments = odb_arguments(ctx) |
+                                data_arguments(ctx) |
+                                run_arguments(ctx) |
+                                fork_arguments(ctx),
+                    prefix = config.root.path,
+                ) |
+                {"DESIGN_CONFIG": "config.mk"},
+            ) + ' "$@"',
+        },
+    )
+
+    reproducer_files = [
+        config,
+        deploy_make,
+        ctx.file.script,
+        ctx.file._fork_tcl,
+        ctx.file._fork_lib,
+    ] + extra_files
+
     return [
         ctx.attr.src[PdkInfo],
         ctx.attr.src[TopInfo],
@@ -1039,6 +1069,22 @@ exec "$PYTHON" "$SCRIPT" {moreargs} "$@"
                     transitive = [
                         flow_inputs(ctx),
                         yosys_inputs(ctx),
+                        data_inputs(ctx),
+                        source_inputs(ctx),
+                    ],
+                ),
+            ),
+        ),
+        OrfsDepInfo(
+            make = deploy_make,
+            config = config,
+            renames = [],
+            files = depset(reproducer_files),
+            runfiles = ctx.runfiles(
+                transitive_files = depset(
+                    reproducer_files,
+                    transitive = [
+                        flow_inputs(ctx),
                         data_inputs(ctx),
                         source_inputs(ctx),
                     ],
@@ -1078,7 +1124,7 @@ _orfs_rule_run_executable = rule(
     executable = True,
 )
 
-def orfs_run_executable(**kwargs):
+def orfs_run_executable(deps = False, **kwargs):
     """Rule wrapper for orfs_run_executable to populate data dependencies and CLI arguments from explicitly specified sources.
 
     This rule produces a standalone executable that invokes GNU Make with the
@@ -1124,9 +1170,13 @@ def orfs_run_executable(**kwargs):
               LOG_DIR=/tmp/trial42 MY_OUT_FILE=/tmp/trial42/out.json
 
     Args:
+        deps: Also emit the {name}_deps / {name}_deps_tar reproducer
+            companions. Opt-in for the same reason as orfs_run's.
         **kwargs: The keyword arguments to pass to the underlying _orfs_rule_run_executable.
     """
     _orfs_rule_run_executable(**_expand_sources(kwargs))
+    if deps:
+        create_deps_tar(kwargs.get("name"), kwargs.get("visibility", None))
 
 # --- Synthesis rule ---
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -1675,6 +1675,38 @@ orfs_flow(
     yosys = "//mock/yosys/src/bin:yosys",
 )
 
+# --- orfs_run(deps = True): the reproducer companions on a run target ---
+# Fully mock (mock openroad + mock yosys), so this costs no real tool build.
+
+orfs_run(
+    name = "lb_32x128_mock_run_with_deps",
+    src = ":lb_32x128_mock_floorplan",
+    outs = ["lb_32x128_mock_run_with_deps.yaml"],
+    arguments = {
+        "OUTPUT": "lb_32x128_mock_run_with_deps.yaml",
+    },
+    script = ":report_named.tcl",
+    tags = ["manual"],
+    deps = True,
+)
+
+# The deployed reproducer carries a usable config.mk, same as a stage's.
+sh_test(
+    name = "deps_deploy_run_test",
+    srcs = ["deps_deploy_test.sh"],
+    args = [
+        "$(location :lb_32x128_mock_run_with_deps_deps_tar.tar.gz)",
+        "config_contains",
+        "DESIGN_NAME",
+    ],
+    data = [":lb_32x128_mock_run_with_deps_deps_tar.tar.gz"],
+)
+
+deps_output_group_test(
+    name = "deps_output_group_run_test",
+    target = ":lb_32x128_mock_run_with_deps_deps_tar",
+)
+
 # --- Deps deploy tests: verify end-to-end deploy workflow ---
 # These replace deps_integration_test.sh with Bazel-native tests
 # that receive pre-built tarballs — no nested bazelisk calls.

--- a/test/BUILD
+++ b/test/BUILD
@@ -1966,6 +1966,32 @@ py_test(
     ],
 )
 
+# orfs_run_executable(deps = True): the executable is deployable, so a bug
+# hit in a tight-loop run can be handed over as a self-contained reproducer.
+orfs_run_executable(
+    name = "mock_tuner_executable_with_deps",
+    src = ":lb_32x128_mock_floorplan",
+    script = ":cell_count.tcl",
+    tags = ["manual"],
+    deps = True,
+)
+
+deps_output_group_test(
+    name = "deps_output_group_run_executable_test",
+    target = ":mock_tuner_executable_with_deps_deps_tar",
+)
+
+sh_test(
+    name = "deps_deploy_run_executable_test",
+    srcs = ["deps_deploy_test.sh"],
+    args = [
+        "$(location :mock_tuner_executable_with_deps_deps_tar.tar.gz)",
+        "config_contains",
+        "DESIGN_NAME",
+    ],
+    data = [":mock_tuner_executable_with_deps_deps_tar.tar.gz"],
+)
+
 orfs_run_executable(
     name = "run_executable_with_args",
     src = ":lb_32x128_floorplan",

--- a/test/report_named.tcl
+++ b/test/report_named.tcl
@@ -1,0 +1,5 @@
+# Writes OUTPUT rather than a fixed filename, so several orfs_run targets in
+# one package can each declare their own out.
+set file [open [file join $::env(WORK_HOME) $::env(OUTPUT)] "w"]
+puts $file "bye"
+close $file

--- a/test/run_executable_test.py
+++ b/test/run_executable_test.py
@@ -35,6 +35,31 @@ class TestRunExecutable(unittest.TestCase):
         )
         self.assertIn("PLACE_DENSITY: 0.42", result.stdout)
 
+    def test_openroad_exe_override(self):
+        """BYO openroad: a CLI override reaches make, beating the baked path.
+
+        The rule bakes OPENROAD_EXE from its `openroad` attr into the
+        wrapper's arguments; run_executable.py appends user args after
+        those, so make's last-wins rule lets a locally-built binary be
+        substituted without rebuilding the target.
+        """
+        executable_path = "test/run_executable_with_args"
+        if not os.path.exists(executable_path):
+            self.skipTest(f"Executable not found at {executable_path}")
+
+        result = subprocess.run(
+            [
+                executable_path,
+                "OPENROAD_EXE=/nonexistent/byo/openroad",
+                "--cmd",
+                "print-OPENROAD_EXE",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertIn("OPENROAD_EXE: /nonexistent/byo/openroad", result.stdout)
+
     def test_cli_cmd_override(self):
         executable_path = "test/mock_tuner_executable"
         if not os.path.exists(executable_path):


### PR DESCRIPTION
## Summary

`orfs_run` already provides `OrfsDepInfo`, but only the flow stage macros
minted the `_deps` / `_deps_tar` companions — so a run target's failure could
not be handed to anyone as a self-contained reproducer. The report and
estimator scripts that run off a stage ODB are exactly the ones whose bugs get
filed.

Adds `deps = True`. Opt-in rather than always-on: most `orfs_run` targets are
build steps nobody reproduces by hand, and unconditional companions would put
two dead targets in every package that has one.

Stacked on #849 (which moves the helper so `rules.bzl` can reach it).

## Type of Change

- Feature

## Impact

None unless `deps = True` is passed.

## Verification

- [x] A fully-mock `orfs_run(deps = True)` (mock openroad + mock yosys, so no
      real tool build): tarball asserted to carry a usable `config.mk`, and to
      build through the output-group path
- [x] `deps_deploy_run_test`, `deps_output_group_run_test` pass
- [x] Existing stage deps tests unaffected
- [x] `buildifier` clean
- [x] **I have signed my commits (DCO).**
