### PR TITLE
feat(orfs_run_executable): provide OrfsDepInfo and opt-in _deps

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -1028,6 +1028,36 @@ exec "$PYTHON" "$SCRIPT" {moreargs} "$@"
         ),
     )
 
+    # The executable drives make through run_executable.py, so it never
+    # needed the make wrapper script the flow rules deploy. A reproducer
+    # does: deploy.tpl runs `./make <cmd>` against config.mk. Mint one with
+    # the same arguments the wrapper bakes in, de-prefixed for the deployed
+    # tree the way orfs_run does.
+    deploy_make = _create_make_script(
+        ctx,
+        "make_{}_{}_run_executable".format(ctx.attr.name, ctx.attr.variant),
+        extra_substitutions = {
+            '"$@"': environment_string(
+                hack_away_prefix(
+                    arguments = odb_arguments(ctx) |
+                                data_arguments(ctx) |
+                                run_arguments(ctx) |
+                                fork_arguments(ctx),
+                    prefix = config.root.path,
+                ) |
+                {"DESIGN_CONFIG": "config.mk"},
+            ) + ' "$@"',
+        },
+    )
+
+    reproducer_files = [
+        config,
+        deploy_make,
+        ctx.file.script,
+        ctx.file._fork_tcl,
+        ctx.file._fork_lib,
+    ] + extra_files
+
     return [
         ctx.attr.src[PdkInfo],
         ctx.attr.src[TopInfo],
@@ -1039,6 +1069,22 @@ exec "$PYTHON" "$SCRIPT" {moreargs} "$@"
                     transitive = [
                         flow_inputs(ctx),
                         yosys_inputs(ctx),
+                        data_inputs(ctx),
+                        source_inputs(ctx),
+                    ],
+                ),
+            ),
+        ),
+        OrfsDepInfo(
+            make = deploy_make,
+            config = config,
+            renames = [],
+            files = depset(reproducer_files),
+            runfiles = ctx.runfiles(
+                transitive_files = depset(
+                    reproducer_files,
+                    transitive = [
+                        flow_inputs(ctx),
                         data_inputs(ctx),
                         source_inputs(ctx),
                     ],
@@ -1078,7 +1124,7 @@ _orfs_rule_run_executable = rule(
     executable = True,
 )
 
-def orfs_run_executable(**kwargs):
+def orfs_run_executable(deps = False, **kwargs):
     """Rule wrapper for orfs_run_executable to populate data dependencies and CLI arguments from explicitly specified sources.
 
     This rule produces a standalone executable that invokes GNU Make with the
@@ -1124,9 +1170,13 @@ def orfs_run_executable(**kwargs):
               LOG_DIR=/tmp/trial42 MY_OUT_FILE=/tmp/trial42/out.json
 
     Args:
+        deps: Also emit the {name}_deps / {name}_deps_tar reproducer
+            companions. Opt-in for the same reason as orfs_run's.
         **kwargs: The keyword arguments to pass to the underlying _orfs_rule_run_executable.
     """
     _orfs_rule_run_executable(**_expand_sources(kwargs))
+    if deps:
+        create_deps_tar(kwargs.get("name"), kwargs.get("visibility", None))
 
 # --- Synthesis rule ---
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -1966,6 +1966,32 @@ py_test(
     ],
 )
 
+# orfs_run_executable(deps = True): the executable is deployable, so a bug
+# hit in a tight-loop run can be handed over as a self-contained reproducer.
+orfs_run_executable(
+    name = "mock_tuner_executable_with_deps",
+    src = ":lb_32x128_mock_floorplan",
+    script = ":cell_count.tcl",
+    tags = ["manual"],
+    deps = True,
+)
+
+deps_output_group_test(
+    name = "deps_output_group_run_executable_test",
+    target = ":mock_tuner_executable_with_deps_deps_tar",
+)
+
+sh_test(
+    name = "deps_deploy_run_executable_test",
+    srcs = ["deps_deploy_test.sh"],
+    args = [
+        "$(location :mock_tuner_executable_with_deps_deps_tar.tar.gz)",
+        "config_contains",
+        "DESIGN_NAME",
+    ],
+    data = [":mock_tuner_executable_with_deps_deps_tar.tar.gz"],
+)
+
 orfs_run_executable(
     name = "run_executable_with_args",
     src = ":lb_32x128_floorplan",

--- a/test/run_executable_test.py
+++ b/test/run_executable_test.py
@@ -35,6 +35,31 @@ class TestRunExecutable(unittest.TestCase):
         )
         self.assertIn("PLACE_DENSITY: 0.42", result.stdout)
 
+    def test_openroad_exe_override(self):
+        """BYO openroad: a CLI override reaches make, beating the baked path.
+
+        The rule bakes OPENROAD_EXE from its `openroad` attr into the
+        wrapper's arguments; run_executable.py appends user args after
+        those, so make's last-wins rule lets a locally-built binary be
+        substituted without rebuilding the target.
+        """
+        executable_path = "test/run_executable_with_args"
+        if not os.path.exists(executable_path):
+            self.skipTest(f"Executable not found at {executable_path}")
+
+        result = subprocess.run(
+            [
+                executable_path,
+                "OPENROAD_EXE=/nonexistent/byo/openroad",
+                "--cmd",
+                "print-OPENROAD_EXE",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertIn("OPENROAD_EXE: /nonexistent/byo/openroad", result.stdout)
+
     def test_cli_cmd_override(self):
         executable_path = "test/mock_tuner_executable"
         if not os.path.exists(executable_path):


### PR DESCRIPTION
## Summary

`orfs_run_executable` returned only `PdkInfo` / `TopInfo` / `DefaultInfo`, so
`orfs_deploy_srcs` — which requires `OrfsDepInfo` — could not be pointed at it
and no `_deps` companions were possible at all. A run driven in a tight loop
(an Optuna sweep, an estimator walk) is precisely where a reproducible failure
wants handing to someone else.

Provide `OrfsDepInfo`, and add the same opt-in `deps = True`.

The executable drives make through `run_executable.py` and so never minted the
make wrapper the flow rules deploy; a reproducer needs one, because
`deploy.tpl` runs `./make` against `config.mk`. Mint it with the same argument
set the wrapper bakes in, de-prefixed for the deployed tree the way `orfs_run`
does.

Stacked on #850.

## Type of Change

- Feature

## Impact

None unless `deps = True` is passed. The extra provider is additive.

## Verification

- [x] A fully-mock `orfs_run_executable(deps = True)` asserted through both the
      output-group and deploy paths
- [x] A test pinning the BYO-openroad contract: a CLI `OPENROAD_EXE=` override
      reaches make and beats the baked path (`run_executable.py` appends user
      args after the build-time ones, so make's last-wins applies), meaning a
      locally built binary needs no rebuild of the target
- [x] `deps_deploy_run_executable_test`,
      `deps_output_group_run_executable_test`, `run_executable_test` pass
- [x] `buildifier` clean
- [x] **I have signed my commits (DCO).**
