### PR TITLE
fix(make.tpl): a caller-supplied OPENROAD_EXE wins

### DIFF
--- a/make.tpl
+++ b/make.tpl
@@ -14,15 +14,22 @@ if [ -z "$FLOW_HOME" ]; then
   if [ -n "${YOSYS_PATH}" ]; then
     export YOSYS_EXE="${YOSYS_PATH}"
   fi
-  # Select the Qt-linked openroad only when the caller asked for a
-  # gui_* make target. Build-time stages and the portable tarball
-  # invoke CLI make targets and therefore keep ${OPENROAD_PATH}.
-  _openroad_exe="${OPENROAD_PATH}"
-  for _arg in "$@"; do
-    case "$_arg" in
-      gui_*|gui-*) _openroad_exe="${OPENROAD_QT_PATH}"; break ;;
-    esac
-  done
+  # A caller-supplied OPENROAD_EXE wins. Pointing a deployed reproducer at
+  # a locally built openroad is what the _deps tarball is for, and the
+  # deployed tree is the one place the binary is not a bazel label.
+  if [ -n "${OPENROAD_EXE:-}" ]; then
+    _openroad_exe="$OPENROAD_EXE"
+  else
+    # Select the Qt-linked openroad only when the caller asked for a
+    # gui_* make target. Build-time stages and the portable tarball
+    # invoke CLI make targets and therefore keep ${OPENROAD_PATH}.
+    _openroad_exe="${OPENROAD_PATH}"
+    for _arg in "$@"; do
+      case "$_arg" in
+        gui_*|gui-*) _openroad_exe="${OPENROAD_QT_PATH}"; break ;;
+      esac
+    done
+  fi
   export OPENROAD_EXE="$_openroad_exe"
   export OPENSTA_EXE="${OPENSTA_PATH}"
   export KLAYOUT_CMD="${KLAYOUT_PATH}"

--- a/test/BUILD
+++ b/test/BUILD
@@ -1721,6 +1721,16 @@ sh_test(
 )
 
 sh_test(
+    name = "deps_deploy_openroad_exe_env_test",
+    srcs = ["deps_deploy_test.sh"],
+    args = [
+        "$(location :lb_32x128_mock_floorplan_deps_tar.tar.gz)",
+        "openroad_exe_env",
+    ],
+    data = [":lb_32x128_mock_floorplan_deps_tar.tar.gz"],
+)
+
+sh_test(
     name = "deps_deploy_make_passthrough_test",
     srcs = ["deps_deploy_test.sh"],
     args = [

--- a/test/deps_deploy_test.sh
+++ b/test/deps_deploy_test.sh
@@ -105,6 +105,15 @@ case "$CHECK" in
         [ -n "$FLOW_HOME" ] || { echo "FAIL: print-FLOW_HOME returned empty"; exit 1; }
         echo "PASS: print-FLOW_HOME returned: $FLOW_HOME"
         ;;
+    openroad_exe_env)
+        # BYO openroad: the deployed make wrapper must not clobber a
+        # caller-supplied binary with its own baked path.
+        OUT=$(OPENROAD_EXE=/nonexistent/byo/openroad "$DST/make" print-OPENROAD_EXE 2>&1 | tail -1)
+        case "$OUT" in
+            *"/nonexistent/byo/openroad"*) echo "PASS: openroad_exe_env ($OUT)" ;;
+            *) echo "FAIL: caller OPENROAD_EXE ignored, got: $OUT"; exit 1 ;;
+        esac
+        ;;
     make_passthrough)
         "$DST/make" print-DESIGN_NAME || { echo "FAIL: make passthrough failed"; exit 1; }
         echo "PASS: make_passthrough"


### PR DESCRIPTION
## Summary

The deployed make wrapper unconditionally overwrote `OPENROAD_EXE` with its
baked `OPENROAD_PATH`, so a `_deps` reproducer could only be pointed at a
locally built openroad through a make command-line variable. Setting the
environment variable the wrapper itself exports looked like it should work and
silently did not — you get the baked binary, with no diagnostic.

That is a real trap: profiling or bisecting against a custom build is the
reason the `_deps` tarball exists, and the failure mode is running the wrong
binary while believing otherwise.

Honour an inherited `OPENROAD_EXE`, and keep the `gui_*` Qt selection for the
case where the caller expressed no preference.

Independent of #849 / #850 / #851.

## Type of Change

- Bug fix

## Impact

Only when the caller already has `OPENROAD_EXE` in the environment; previously
that value was discarded.

## Verification

- [x] New `deps_deploy_test.sh` mode asserting the deployed wrapper reports the
      caller's path (`deps_deploy_openroad_exe_env_test`)
- [x] `deps_deploy_floorplan_test` unaffected
- [x] **I have signed my commits (DCO).**
