### PR TITLE
test(bump): hard-check the yosys/abc lockstep pairing in CI

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -104,6 +104,16 @@ py_test(
     deps = [":bump_impl_lib"],
 )
 
+# Enforces the yosys<->abc lockstep pairing on this repo's MODULE.bazel.
+# The bump path only warns on a violation (BCR availability and yosys
+# release cadence don't always line up); the hard check is here.
+py_test(
+    name = "bump_yosys_abc_test",
+    srcs = ["bump_yosys_abc_test.py"],
+    data = ["MODULE.bazel"],
+    deps = [":bump_impl_lib"],
+)
+
 # Enforces the 30-day cleanup policy on the bumper's compatibility code:
 # a COMPAT(YYYY-MM-DD) marker older than the supported window fails here.
 py_test(

--- a/bump_impl.py
+++ b/bump_impl.py
@@ -1686,7 +1686,8 @@ def bump(
     # release cadence don't always line up (e.g. yosys 0.63 ships without
     # a matching abc 0.63-yosyshq on BCR), and blocking the bumper on that
     # would be more disruptive than the lurking quality risk. CI gets the
-    # hard check via the `--check-yosys-abc` entrypoint.
+    # hard check via //:bump_yosys_abc_test; consumers get it via the
+    # `--check-yosys-abc` entrypoint.
     ok, msg = check_yosys_abc_pair(content)
     if not ok:
         sys.stderr.write("WARNING: " + msg + "\n")

--- a/bump_yosys_abc_test.py
+++ b/bump_yosys_abc_test.py
@@ -1,0 +1,53 @@
+"""Enforce the yosys<->abc lockstep pairing on this repo's MODULE.bazel.
+
+The bump path only *warns* on a pairing violation: BCR availability and
+yosys release cadence don't always line up, and blocking the bumper on
+that would be more disruptive than the lurking quality risk.  The hard
+check lives here instead, on the same ``check_yosys_abc_pair`` the
+``--check-yosys-abc`` CLI entrypoint uses, so a mismatched pin cannot
+land on main.
+"""
+
+import os
+import unittest
+
+import bump_impl
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestPairingCheck(unittest.TestCase):
+    """The check itself, so a green repo check means something."""
+
+    def test_mismatched_pair_fails(self):
+        content = (
+            'bazel_dep(name = "abc", version = "0.62-yosyshq")\n'
+            'bazel_dep(name = "yosys", version = "0.64")\n'
+        )
+        ok, msg = bump_impl.check_yosys_abc_pair(content)
+        self.assertFalse(ok)
+        self.assertIn("expects abc", msg)
+
+    def test_unknown_yosys_series_fails(self):
+        content = (
+            'bazel_dep(name = "abc", version = "0.1-yosyshq")\n'
+            'bazel_dep(name = "yosys", version = "0.1")\n'
+        )
+        ok, msg = bump_impl.check_yosys_abc_pair(content)
+        self.assertFalse(ok)
+        self.assertIn("no known abc pairing", msg)
+
+
+class TestRepoModuleFile(unittest.TestCase):
+    def test_module_bazel_declares_a_known_pair(self):
+        with open(os.path.join(REPO_ROOT, "MODULE.bazel")) as f:
+            ok, msg = bump_impl.check_yosys_abc_pair(f.read())
+
+        # An empty message is the both-declared-and-matched verdict; the
+        # "only one of yosys/abc is declared" note also comes back ok, but
+        # this root module must always pin both in lockstep.
+        self.assertEqual((ok, msg), (True, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`bump_impl.py` claimed "CI gets the hard check via the `--check-yosys-abc` entrypoint", but nothing anywhere invoked it — no BUILD target, no test, no workflow step. A mismatched yosys/abc pin on `main` would only ever surface as a bump-time `WARNING`.

## How

- New `//:bump_yosys_abc_test` (modeled on `//:bump_compat_test`) runs `check_yosys_abc_pair` over the repo's `MODULE.bazel`. It requires the strict both-declared-and-matched verdict (empty message), so dropping either pin fails as well, not just mismatching them.
- Two unit tests pin the check's failure modes (mismatched pair, unknown yosys series) so a green repo check means something.
- The bump-path comment now points at the test; the CLI entrypoint remains for consumers.

Runs under the existing generic `bazelisk test` CI job; no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)