### PR TITLE
docs: fix stale yosys-test comment and downstream override list

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1838,10 +1838,11 @@ deps_output_group_test(
     target = ":lb_32x128_substeps_floorplan_deps_tar",
 )
 
-# --- Patched external target tests ---
-# Verify yosys patches applied via single_version_override work.
-# Header-only: no compilation, just glob + analysis validation.
-# BCR yosys is already fetched for @yosys//:yosys_share.
+# --- BCR yosys module layout tests ---
+# Smoke tests over the BCR yosys module's layout (plugin hdrs, share
+# tree): glob + analysis only, no compilation. A yosys bump that
+# reorganizes the module fails here first. BCR yosys is already
+# fetched for @yosys//:yosys_share.
 
 build_test(
     name = "yosys_hdrs_build_test",

--- a/test/downstream/README.md
+++ b/test/downstream/README.md
@@ -65,7 +65,7 @@ register it as the default toolchain via `python.toolchain(is_default = True)`.
 Building OpenROAD (and yosys) from source needs the zero-sysroot BCR `llvm`
 toolchain: `bazel_dep(name = "llvm", …)` + `register_toolchains("@llvm//toolchain:all")`,
 plus the small set of hermetic-llvm compatibility `single_version_override`s
-(sed, bison, boost.icl, gawk, m4, tcl_lang) mirrored from bazel-orfs's root
+(sed, bison, boost.icl, gawk, m4, verilator) mirrored from bazel-orfs's root
 MODULE.bazel. Without the toolchain the build falls back to the host compiler
 and breaks on newer glibc (e.g. `@scip`/`tinycthread` on glibc 2.41). These
 overrides are root-module-only, so every downstream repeats them.


### PR DESCRIPTION
Two comment/doc spots that drifted from the code:

- `test/BUILD` described `yosys_hdrs_build_test` / `yosys_share_build_test` as verifying "yosys patches applied via `single_version_override`" — there is no yosys override and no yosys patch anymore. They are layout smoke tests over the BCR yosys module (plugin hdrs, share tree); the comment now says so.
- `test/downstream/README.md` listed the mirrored hermetic-llvm overrides as `(sed, bison, boost.icl, gawk, m4, tcl_lang)`, but `test/downstream/MODULE.bazel` mirrors no `tcl_lang` override and does carry a `verilator` one. The list now matches the code.

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)