### PR TITLE
fix: sync the platforms pin to the resolved 1.1.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0", dev_dependency = True)
 
-bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "platforms", version = "1.1.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 


### PR DESCRIPTION
`bazelisk mod graph` warned on every invocation:

```
WARNING: For repository 'platforms', the root module requires module version platforms@1.0.0, but got platforms@1.1.0 in the resolved dependency graph.
```

Other modules in the graph (bazel_skylib 1.9.0, the llvm toolchain's deps) request 1.1.0 and MVS picks the highest, so the root's stated pin was stale. `platforms` 1.1.0 only adds constraint values — nothing is removed — and the resolved graph is unchanged by this PR; only the declaration catches up. `mod graph` is warning-free after the sync.

One-line change, no functional effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)