### PR TITLE
feat: bump yosys to 0.68.bcr.1, abc to 0.68-yosyshq.bcr.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,8 +21,8 @@ local_path_override(
     path = "mock/klayout",
 )
 
-bazel_dep(name = "abc", version = "0.64-yosyshq.bcr.2")
-bazel_dep(name = "yosys", version = "0.64")
+bazel_dep(name = "abc", version = "0.68-yosyshq.bcr.1")
+bazel_dep(name = "yosys", version = "0.68.bcr.1")
 
 # Tcl, for //fork: the fork/join extension is compiled against the same
 # @tcl_lang the openroad module embeds (MVS keeps the two in lockstep), so

--- a/bump_impl.py
+++ b/bump_impl.py
@@ -38,6 +38,7 @@ import urllib.request
 YOSYS_ABC_PAIRS = {
     "0.62": "0.62-yosyshq",
     "0.64": "0.64-yosyshq.bcr.2",
+    "0.68": "0.68-yosyshq.bcr.1",
 }
 
 

--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -146,7 +146,7 @@ bazel_dep(name = "llvm", version = "0.8.11")
 
 register_toolchains("@llvm//toolchain:all")
 
-bazel_dep(name = "yosys", version = "0.64")
+bazel_dep(name = "yosys", version = "0.68.bcr.1")
 
 # yosys-slang was renamed to sv-elab and is now published on the Bazel
 # Central Registry; the slang yosys plugin comes from


### PR DESCRIPTION
Supersedes #857 (closed while blocked; GitHub refuses to reopen a PR whose head branch was force-pushed for the rebase). Its blockers are gone: [bazelbuild/bazel-central-registry#10276](https://github.com/bazelbuild/bazel-central-registry/pull/10276) (abc@0.68-yosyshq.bcr.1) and [bazelbuild/bazel-central-registry#10277](https://github.com/bazelbuild/bazel-central-registry/pull/10277) (yosys@0.68.bcr.1) merged 2026-08-28.

## What

- `MODULE.bazel`: `yosys` 0.64 → 0.68.bcr.1, `abc` 0.64-yosyshq.bcr.2 → 0.68-yosyshq.bcr.1
- `test/downstream/MODULE.bazel`: `yosys` → 0.68.bcr.1
- `bump_impl.py`: new `YOSYS_ABC_PAIRS` entry `"0.68": "0.68-yosyshq.bcr.1"` (old entries kept — the tests read them)

## Why now / why safe

- ORFS's `tools/yosys` (at our pinned ORFS commit and at master) is exactly the yosys v0.68 release commit, so this is precisely what `//:bump`'s highest-BCR-≤-ORFS rule selects; the bumper will not fight this pin.
- The `.bcr.1` re-releases remedy what the plain 0.68 submissions dropped: abc regains the `use_readline` opt-out; yosys gains `YOSYS_ENABLE_THREADS` (multithreaded netlist ops were silently off), `YOSYS_ENABLE_LIBFFI` (DPI-C), and the `opensta`/`sdc_expand` passes.
- The sv-elab plugin machinery deliberately stays: BCR yosys does not build the slang frontend that yosys 0.67+ vendors — the `sv-elab` module is the ecosystem's Bazel channel for `read_slang`, and a plugin overrides the built-in copy on upstream builds anyway.
- sed/gawk gnulib overrides stay: ncurses persists in the graph via `abc → readline → ncurses`.

## Re-verified against the published registry (no local-registry override)

Rebased on latest main (clean rebase, no content changes). `//:bump_yosys_abc_test` (the lockstep hard check from #854), `//:bump_impl_test`, `//:bump_compat_test`, `//:yosys-check`, and `//slang/...` all pass with the modules resolved from bcr.bazel.build.

## Verified earlier (against a local registry checkout of the two BCR PRs)

- `@yosys//:yosys` and `@abc//:abc` build from source under the hermetic llvm toolchain; abc also builds with `--@abc//:use_readline=false`
- `@sv-elab//src/yosys_plugin:slang.so` compiles against yosys 0.68 hdrs
- `//slang/...`, `//test:synth_retime_select_test`, `//test:synth_keep_modules_check_test`, `//test:yosys_hdrs_build_test`, `//test:yosys_share_build_test`, `//test/bump:bump_test`, `//:bump_impl_test`, `//:bump_compat_test` all pass
- `check_yosys_abc_pair(MODULE.bazel)` returns clean; `bazelisk mod graph` resolves (the `platforms` 1.0.0-vs-1.1.0 warning was fixed on main by #858 and is gone after the rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)