### PR TITLE
deps: bump bazel_skylib, rules_pkg, rules_cc, rules_shell, rules_pycross

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,15 +5,15 @@ module(
     version = "0.0.1",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.9.2", dev_dependency = True)
 
 bazel_dep(name = "platforms", version = "1.1.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 
-bazel_dep(name = "rules_pkg", version = "1.2.0")
-bazel_dep(name = "rules_cc", version = "0.2.20")
-bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "rules_pkg", version = "1.3.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_shell", version = "0.8.0")
 
 bazel_dep(name = "mock-klayout", version = "0.0.1", dev_dependency = True)
 local_path_override(
@@ -174,7 +174,7 @@ single_version_override(
     patches = ["//patches:rules_jvm_external_quiet.patch"],
 )
 
-bazel_dep(name = "rules_pycross", version = "0.8.1")
+bazel_dep(name = "rules_pycross", version = "0.8.3")
 
 pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")
 pycross.configure_environments(python_versions = ["3.13"])


### PR DESCRIPTION
Five BCR pins that were behind their newest published version, with no code change required by any of them:

| module | from | to |
|---|---|---|
| `bazel_skylib` | 1.9.0 | 1.9.2 |
| `rules_pkg` | 1.2.0 | 1.3.0 |
| `rules_cc` | 0.2.20 | 0.2.22 |
| `rules_shell` | 0.6.1 | 0.8.0 |
| `rules_pycross` | 0.8.1 | 0.8.3 |

Each was already the *selected* version before this change — `bazelisk mod graph --include_unused` puts the older transitive requests (e.g. `rules_cc@0.2.4`) in the `(unused)` set — so every line here is a real bump rather than a pin MVS was outranking anyway.

`rules_pycross` keeps its patched `single_version_override`: the hunk the patch targets in `pycross/private/bzlmod/pycross.bzl` is byte-identical in 0.8.3, so it still applies.

**`buildifier_prebuilt` is deliberately not bumped here.** 8.x replaces the `//:buildifier` file target with a bash runner (`buildifier.bash`), which `fix_lint.py`'s hardcoded `buildifier_prebuilt+/buildifier/buildifier` runfiles path does not find — `bazelisk run //:fix_lint` fails with `buildifier not found in runfiles`. That needs a code change, so it is left out.

### Verification

- `bazelisk mod graph` resolves, and selects all five new versions.
- `bazelisk run //:fix_lint` is clean and reformats nothing.
- The test suite was **not** run locally (it builds OpenROAD from source) — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)