### PR TITLE
docs: correct the stale bison 3.8.2.bcr.8 note

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -102,7 +102,9 @@ single_version_override(
 # that builds OpenROAD from source must repeat them. Keep in sync on each bump.
 
 # bison (transitive: rules_bison -> bison): gnulib wrapper headers must precede
-# libc via -I, not -isystem (BCR #7642). Proposed upstream as 3.8.2.bcr.8.
+# libc via -I, not -isystem (BCR #7642). Still unfixed upstream: 3.8.2.bcr.8
+# is published but is an unrelated change (its BUILD.bazel overlay is
+# byte-identical to bcr.7's), so the patch stays and the pin stays here.
 single_version_override(
     module_name = "bison",
     patch_strip = 1,


### PR DESCRIPTION
The comment above the `bison` override promised the gnulib `-I` fix was *"Proposed upstream as 3.8.2.bcr.8"*. That version has since been published — and it is **not** this fix:

- `bcr.8`'s `BUILD.bazel` overlay hash is byte-identical to `bcr.7`'s (`sha256-vh4vDJn+Pj0jjF5FvFgvPvOCCsq4mUKiSD81r+G4GYM=`).
- The only differences are its `MODULE.bazel` (`rules_cc_autoconf` 0.13.2 → 0.19.0) and `src/bazel_runfiles.cc`.

So a reader following the note would bump to `bcr.8`, drop the patch, and reintroduce the hermetic-llvm build failure. This rewords the comment to say upstream is still unfixed and why `bcr.8` isn't it.

Comment only — the pin, the patch list, and the patch file itself are unchanged. The patch file is deliberately left byte-identical to OpenROAD's copy in `bazel/bison-patches/` so the two stay diffable; OpenROAD's own `MODULE.bazel` carries the same stale wording and wants the same fix.

While checking this I also re-verified the neighbouring `boost.icl` comment, which **is** still accurate: icl#54 merged 2026-06-29 but the `boost-1.90.0` tag does not contain it (develop is 34 commits ahead of the tag), and `boost.icl` resolves to the newest published `1.90.0.bcr.1`. No change needed there.

Independent of #862 — different hunk, either order merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)