### PR TITLE
test(downstream): sync the consumer's simulation and python deps

### DIFF
--- a/test/downstream/MODULE.bazel
+++ b/test/downstream/MODULE.bazel
@@ -154,12 +154,12 @@ bazel_dep(name = "yosys", version = "0.68.bcr.1")
 bazel_dep(name = "sv-elab", version = "2026-07-07")
 
 # --- Verilator simulation + Google Test ---
-bazel_dep(name = "rules_verilog", version = "1.1.1")
-bazel_dep(name = "rules_verilator", version = "0.3.2")
-bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "rules_verilog", version = "1.4.2")
+bazel_dep(name = "rules_verilator", version = "1.1.2")
+bazel_dep(name = "googletest", version = "1.18.0.bcr.1")
 
 # --- Python 3.13 toolchain (required by bazel-orfs pip deps) ---
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.0.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(


### PR DESCRIPTION
The downstream consumer test is its own root module, so its pins don't follow the workspace's — and they had drifted:

| module | from | to |
|---|---|---|
| `rules_verilog` | 1.1.1 | 1.4.2 |
| `rules_verilator` | 0.3.2 | 1.1.2 |
| `googletest` | 1.17.0.bcr.2 | 1.18.0.bcr.1 |
| `rules_python` | 1.9.0 | 2.0.0 |

`rules_verilator` 1.1.2 requires `rules_verilog >= 1.4.2`, so those two move together whether or not `rules_verilog` is bumped explicitly; naming both keeps the declared pins honest rather than leaving one to MVS.

`rules_python` is a no-op in resolution — the test depends on `bazel-orfs`, which requires 2.0.0, so MVS already selected it — but the declaration now says what is actually built, and the neighbouring `rules_pycross` comment already talks about 2.0.0's `MINOR_MAPPING`.

### Why this should be safe across the bump

- `verilator_cc_library` still takes `module` / `module_top` / `trace`, and `verilog_library` still takes `srcs` — the attributes `BUILD.bazel` uses. Neither load path moved.
- `rules_verilator` 1.1.2 pins the **same** `verilator` 5.046.bcr.3 as 0.3.2, so the `-latomic` `patch_cmds` override above it still applies to the version it was written for.
- The `//verilator:verilator_toolchain` registration is unchanged between the two.

### Verification

- `bazelisk mod graph` in `test/downstream` resolves and selects all four, with `verilator` still at 5.046.bcr.3.
- The downstream build itself was **not** run locally (it builds OpenROAD and verilator from source) — left to the CI *"Submodule: downstream consumer"* step, which is the real gate on the two-major-series `rules_verilator` jump.

Independent of #862, #863 and #864 — this touches only `test/downstream/MODULE.bazel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)