### PR TITLE
build: hard-fail on a Bazel older than .bazelversion

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -126,6 +126,20 @@ py_test(
     deps = [":bump_impl_lib"],
 )
 
+# The Bazel floor that an obsolete Bazel cannot walk past. Checked during
+# module resolution, and inherited by downstream consumers of bazel-orfs.
+py_test(
+    name = "bazel_version_test",
+    srcs = ["bazel_version_test.py"],
+    # The test asserts MODULE.bazel's floor, and the one README.md quotes to
+    # consumers, both equal the pinned version.
+    data = [
+        ".bazelversion",
+        "MODULE.bazel",
+        "README.md",
+    ],
+)
+
 # The PreToolUse guard shared by Claude Code (.claude/settings.json) and
 # antigravity (.agents/hooks.json, via the .agents/scripts symlink).
 py_test(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,14 @@
 module(
     name = "bazel-orfs",
     version = "0.0.1",
+    # A hard stop, checked during module resolution before anything is
+    # fetched or built, so an obsolete Bazel fails in seconds with a clear
+    # message instead of hours later with a confusing one. It fires for
+    # downstream consumers too, not just this repo, and their .bazelversion
+    # does not have to agree with ours for it to bite.
+    #
+    # Kept equal to .bazelversion by //:bazel_version_test.
+    bazel_compatibility = [">=8.6.0"],
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.2", dev_dependency = True)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ and easily actionable github issues for the OpenROAD and ORFS maintainers.
 
 * [Bazelisk](https://bazel.build/install/bazelisk) or [Bazel](https://bazel.build/install) - if using Bazel, please refer to [.bazelversion](./.bazelversion) file for the recommended version of the tool.
 
+  That version is also a hard minimum, not merely a recommendation:
+  `MODULE.bazel` declares `bazel_compatibility = [">=8.6.0"]`, so an older
+  Bazel — including one an obsolete Bazelisk picks — stops during module
+  resolution with an explicit version error, instead of failing later in a
+  way that looks like a build bug. The floor applies to projects that depend
+  on bazel-orfs too, whatever their own `.bazelversion` says. The fix is to
+  upgrade Bazelisk, or to pin a new enough version in `.bazelversion`.
+
 That's it. Bazel builds OpenROAD, OpenSTA, Yosys, ABC, GNU Make, and Qt from source, and manages all other dependencies (Python, toolchains) hermetically. No Docker, no system packages beyond a standard Linux installation.
 
 * (Optional) Locally built [ORFS](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts). To use it, `env.sh` file from OpenROAD-flow-scripts has to be sourced or `FLOW_HOME` environment variable has to be set to the path of the local `OpenROAD-flow-scripts/flow` installation.

--- a/bazel_version_test.py
+++ b/bazel_version_test.py
@@ -1,0 +1,64 @@
+"""Keep the Bazel floor in MODULE.bazel equal to .bazelversion.
+
+``module(bazel_compatibility = ...)`` is the only version floor an obsolete
+Bazel cannot walk past: it is checked during module resolution, before
+anything is fetched or built, and it applies to downstream consumers of
+bazel-orfs as well as to this repo.  ``.bazelversion``, by contrast, is a
+bazelisk convention — a distro ``bazel``, or a consumer with its own
+``.bazelversion``, never sees ours.
+
+The two therefore have to be maintained together, and this test is what
+makes that happen: bumping ``.bazelversion`` without moving the floor turns
+the build red, with the fix named in the failure.  README.md quotes the
+floor to consumers, so it is held to the same version.
+"""
+
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+# The sole >= constraint inside the root module()'s bazel_compatibility list.
+FLOOR = re.compile(r"""bazel_compatibility\s*=\s*\[\s*['"]>=([^'"]+)['"]""")
+
+
+def read(name):
+    with open(os.path.join(REPO_ROOT, name), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class BazelVersionTest(unittest.TestCase):
+    def floor(self, filename):
+        match = FLOOR.search(read(filename))
+        self.assertIsNotNone(
+            match,
+            '%s declares no `bazel_compatibility = [">=<version>"]`; without '
+            "it an obsolete Bazel gets no hard failure." % filename,
+        )
+        return match.group(1)
+
+    def test_module_floor_matches_bazelversion(self):
+        pinned = read(".bazelversion").strip()
+        floor = self.floor("MODULE.bazel")
+        self.assertEqual(
+            floor,
+            pinned,
+            "MODULE.bazel's bazel_compatibility floor (>=%s) has drifted from "
+            ".bazelversion (%s). Set the floor to the pinned version — a stale "
+            "floor lets an obsolete Bazel through." % (floor, pinned),
+        )
+
+    def test_readme_quotes_the_same_floor(self):
+        pinned = read(".bazelversion").strip()
+        floor = self.floor("README.md")
+        self.assertEqual(
+            floor,
+            pinned,
+            "README.md tells users the minimum Bazel is %s, but .bazelversion "
+            "pins %s. Update the Requirements section." % (floor, pinned),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An obsolete Bazelisk picks an obsolete Bazel, and the failure that follows
does not look like a version problem — it looks like a build bug, and gets
reported as one.

`.bazelversion` cannot prevent that. It is a bazelisk convention: a distro
`bazel` walks straight past it, and a downstream project that depends on
bazel-orfs reads its own file, never ours.

So declare the floor where every launcher has to honour it:

```python
module(
    name = "bazel-orfs",
    version = "0.0.1",
    bazel_compatibility = [">=8.6.0"],
)
```

`bazel_compatibility` is checked during module resolution, before anything is
fetched or built, so an unsupported Bazel stops in seconds:

```
ERROR: Bazel version 8.6.0 is not compatible with module "mock-klayout@_" (bazel_compatibility: [>=99.0.0])
ERROR: Bazel compatibility check failed
```

That message is from the experiment used to confirm the mechanism: the
constraint was put on `mock-klayout`, a **non-root** module, and it still
fired. That is the property that matters here — the floor protects projects
that depend on bazel-orfs, not just this repo.

### Keeping the floor honest

A version floor is only worth having while it tracks the version actually
tested, and there are now three places naming it: `.bazelversion`,
`MODULE.bazel`, and the README paragraph that tells users what the minimum
is. `//:bazel_version_test` asserts all three agree. Bumping the pin without
moving the floor is a red build with the fix named in the failure, rather
than a silent hole.

### Testing

- `bazelisk test //:bazel_version_test` — passes; verified it fails on a
  deliberately stale floor and on a README that quotes the wrong version.
- The nine root unit tests pass.
- `bazelisk run //:fix_lint` clean.

### Not a fix for #869

This came up while looking at #869, but it does not explain that report —
the JVM there is hermetic (bazelisk unpacks JDK 21 out of the Bazel binary;
`bazel info java-home` points into `install/<hash>/embedded_tools/jdk`, and
the system `java` is never consulted). Exit code 14 / `Socket closed` means
the server process was killed, with the OOM killer the overwhelming
favourite at 16 concurrent `or-tools`/`svlang`/`drt` compiles. This PR just
removes one class of confusing failure from the neighbourhood.
