### PR TITLE
fix(bazelrc): don't make py_binary tools depend on the host python

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,4 +19,15 @@ common --experimental_isolated_extension_usages
 # Garbage-collect disk cache to avoid exhausting CI runner disk.
 build --experimental_disk_cache_gc_max_size=2G
 
+# Don't make py_binary tools depend on the *host* python.  rules_python's
+# default `system_python` bootstrap emits the executable from
+# python_bootstrap_template.txt — a Python script the launcher runs with
+# whatever `python3` the host has — so every py_binary in the build, including
+# code generators inside third-party deps (e.g. @libxcb's c_client), needs a
+# host interpreter new enough for that bootstrap.  Hosts whose `python3`
+# predates 3.7 fail with `module 'sys' has no attribute '_base_executable'`.
+# The `script` bootstrap emits stage1_bootstrap_template.sh instead, which
+# execs the hermetic toolchain interpreter and needs no host python at all.
+build --@rules_python//python/config_settings:bootstrap_impl=script
+
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
rules_python's default `system_python` bootstrap expands a `py_binary`'s
executable from `python_bootstrap_template.txt` — a **Python** script that the
launcher runs with whatever `python3` the host provides. So every `py_binary` in
the build depends on the host interpreter, including code generators buried in
third-party deps that we never call directly. On a host whose `python3` predates
3.7, the bootstrap itself dies:

```
File "bazel-out/.../external/libxcb+/c_client", line 544, in main
  print_verbose("bootstrap sys._base_executable:", sys._base_executable)
AttributeError: module 'sys' has no attribute '_base_executable'
```

Reported on RHEL 8 (system `python3` is 3.6) in #869. The hermetic 3.13
toolchain the root registers is irrelevant here — it's the stage1 *launcher*,
not the interpreter under test, that breaks.

## Change

One line in `.bazelrc`:

```
build --@rules_python//python/config_settings:bootstrap_impl=script
```

`script` expands `stage1_bootstrap_template.sh` instead: a shell stage1 that
execs the toolchain interpreter directly and needs no host python at all.
(`bootstrap_impl` still defaults to `system_python` in rules_python 2.0.0.)

## Verification

`aquery` on the exact target from the report shows the switch:

```
# before
action 'Expanding template external/libxcb+/c_client'
  Inputs: [external/rules_python+/python/private/python_bootstrap_template.txt]
# after
action 'Expanding template external/libxcb+/c_client'
  Inputs: [external/rules_python+/python/private/stage1_bootstrap_template.sh]
```

- `bazelisk build @@libxcb+//:c_client_bigreq` — the genrule consuming that
  executable re-runs and still builds.
- `bazelisk test //test/bump/... //:guard_tool_test //:bump_compat_test` — pass
  under the new bootstrap (these are the repo's `py_test` targets, so they
  exercise the bootstrap directly). CI covers the rest.

This only affects builds run from a bazel-orfs clone; `.bazelrc` isn't
inherited by downstream roots, which need the same line in their own.