### PR TITLE
build: load sh_binary/py_binary/py_test explicitly

### DIFF
--- a/gnumake.bzl
+++ b/gnumake.bzl
@@ -36,6 +36,8 @@ One-time setup (any path of the user's choosing):
     EOF
     chmod +x ~/.config/bazel/host_make/make.sh
     cat > ~/.config/bazel/host_make/BUILD.bazel <<'EOF'
+    load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
     sh_binary(
         name = "make",
         srcs = ["make.sh"],

--- a/mock/kepler-formal/MODULE.bazel
+++ b/mock/kepler-formal/MODULE.bazel
@@ -2,3 +2,5 @@ module(
     name = "kepler-formal",
     version = "1.0.0",
 )
+
+bazel_dep(name = "rules_shell", version = "0.8.0")

--- a/mock/kepler-formal/src/bin/BUILD.bazel
+++ b/mock/kepler-formal/src/bin/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 sh_binary(
     name = "kepler-formal",
     srcs = ["kepler-formal.sh"],

--- a/mock/klayout/MODULE.bazel
+++ b/mock/klayout/MODULE.bazel
@@ -2,3 +2,5 @@ module(
     name = "mock-klayout",
     version = "0.0.1",
 )
+
+bazel_dep(name = "rules_shell", version = "0.8.0")

--- a/mock/klayout/src/bin/BUILD.bazel
+++ b/mock/klayout/src/bin/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
 sh_binary(
     name = "klayout",
     srcs = ["klayout.sh"],

--- a/naja/BUILD
+++ b/naja/BUILD
@@ -1,4 +1,5 @@
 load("//:openroad.bzl", "orfs_deps", "orfs_synth")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 load(":orfs_libs.bzl", "orfs_libs")
 
 orfs_synth(

--- a/private/BUILD.bazel
+++ b/private/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(default_visibility = [
     "//:__pkg__",
     "//private:__subpackages__",


### PR DESCRIPTION
Bazel 9 drops the autoloading that let a `BUILD` file call a native rule that now lives in `rules_shell` or `rules_python` without a `load()`. Four BUILD files relied on it — the two mock tool modules, `//naja` and `//private` — and so did the host-make example in `gnumake.bzl`'s docstring.

Under 9.1.1 this is what `bazel query //...` says today:

```
ERROR: mock/klayout/src/bin/BUILD.bazel:1:1: name 'sh_binary' is not defined
ERROR: private/BUILD.bazel:11:1: name 'py_test' is not defined
ERROR: mock/kepler-formal/src/bin/BUILD.bazel:1:1: name 'sh_binary' is not defined
```

The loads name the same symbols Bazel 8 autoloads, so this is a no-op on the pinned 8.6.0 and a prerequisite for moving off it.

The two mock tool modules are separate bzlmod modules and cannot see the root module's dependencies, so each gets its own `bazel_dep(name = "rules_shell")`.

Verified: `bazel query //...` and `bazel build --nobuild //...` clean on both 8.6.0 and 9.1.1.

First of a series that makes the tree Bazel 9 ready before `.bazelversion` moves.