### PR TITLE
deps: pin Bazel 9-compatible rules_flex, rules_bison and scip

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -133,6 +133,42 @@ single_version_override(
     ],
 )
 
+# rules_flex (transitive: openroad -> rules_flex): 0.3.1 uses the global
+# `CcInfo` symbol, which Bazel 9 removed in favour of an explicit
+# `load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")`. 0.4 adds that load
+# and changes nothing else, so it is a no-op on Bazel 8.
+#
+# Not 0.4.1: it deletes flex/internal/toolchain_info.bzl, which is what puts
+# `M4` (and the rest of m4_env) into `flex_toolchain.flex_env`. 0.4.1 sets M4
+# inside its own flex_action instead, so a rule that drives flex from the
+# toolchain directly gets an empty environment and flex dies looking for m4.
+# @openroad's bazel/flex.bzl genlex is exactly such a rule -- it reads
+# flex_env and rewrites the .runfiles/ paths in it -- so 0.4.1 breaks every
+# OpenSTA lexer with a bare `flex failed: (Exit 1)`.
+single_version_override(
+    module_name = "rules_flex",
+    version = "0.4",
+)
+
+# scip (transitive: openroad -> or-tools -> scip): 9.2.3's BUILD overlay
+# calls cc_library with no load(); Bazel 9 removed the autoloaded native
+# rules. 9.2.3.bcr.1 is the same SCIP with the load() added.
+single_version_override(
+    module_name = "scip",
+    version = "9.2.3.bcr.1",
+)
+
+# rules_bison (transitive: openroad -> rules_bison): the BUILD its
+# bison_repository generates calls cc_binary/cc_library with no load(),
+# which Bazel 9 rejects. 0.4.bcr.1 emits the loads; its toolchain_info.bzl is
+# unchanged from 0.3.1, so @openroad's bazel/bison.bzl genyacc -- which reads
+# `bison_env["M4"]` and `["BISON_PKGDATADIR"]` straight off the toolchain --
+# keeps working.
+single_version_override(
+    module_name = "rules_bison",
+    version = "0.4.bcr.1",
+)
+
 # gawk (transitive: abc -> ncurses -> gawk; yosys -> gawk): same gnulib
 # libc-header shadowing as sed (BCR #7642); 5.3.2.bcr.7 has the fix (BCR #7989).
 single_version_override(


### PR DESCRIPTION
Three transitive deps of `@openroad` still write BUILD files the way Bazel 8 tolerates and Bazel 9 rejects:

| module | pinned via | what Bazel 9 says |
| --- | --- | --- |
| `rules_flex` 0.3.1 → **0.4** | openroad | `The CcInfo symbol has been removed, add ... load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")` |
| `scip` 9.2.3 → 9.2.3.bcr.1 | openroad → or-tools | `cc_library` in the BUILD overlay: `This rule has been removed from Bazel. Please add a load() statement for it.` |
| `rules_bison` 0.3.1 → 0.4.bcr.1 | openroad | same, for the `cc_binary`/`cc_library` in the BUILD its `bison_repository` generates |

Each pinned successor adds the `load()` and changes nothing else that matters here, so the pins cost nothing on the pinned 8.6.0 and are a prerequisite for moving off it.

They are `single_version_override` pins rather than upgrades of a direct dependency because none of the three is ours — `@openroad` pulls them in, and it has not moved yet. They sit with the other "compatibility fixes we repeat as the root module" overrides already in `MODULE.bazel`, and come out when `@openroad` catches up.

## Why rules_flex stops at 0.4 and not the newest 0.4.1

0.4.1 deletes `flex/internal/toolchain_info.bzl`, which is what puts `M4` (and the rest of `m4_env`) into `flex_toolchain.flex_env`; 0.4.1 sets `M4` inside its own `flex_action` instead. `@openroad`'s `bazel/flex.bzl` `genlex` drives flex straight off the toolchain — it reads `flex_env` and rewrites the `.runfiles/` paths in it — so under 0.4.1 flex runs with a completely empty environment, cannot find m4, and every OpenSTA lexer dies with a bare:

```
Generating .../LibExprLex.cc from .../LibExprLex.ll failed: (Exit 1): flex failed
```

0.4 has the `CcInfo` load and the old `toolchain_info.bzl`, so it fixes Bazel 9 without breaking `genlex`.

`rules_bison` 0.4.bcr.1 is safe by the same test: its `toolchain_info.bzl` is unchanged from 0.3.1, so `@openroad`'s `genyacc` — which reads `bison_env["M4"]` and `bison_env["BISON_PKGDATADIR"]` straight off the toolchain — keeps working.

## Verified

- `bazel build --nobuild //...` clean on 8.6.0 with this change alone.
- On 9.1.1 (together with the sibling `load()` PR): `bazel build --nobuild //...` clean, and `@openroad//src/sta:LibExprLex`, `:LibExprParse` and `:LibertyLex` all actually build — i.e. flex and bison both run, not just analyze.