### PR TITLE
ci: drop the analyze-profile step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,6 @@ jobs:
       # --- Unit tests ---
       - name: Run tests
         run: bazelisk test ... --build_tests_only --test_output=errors --profile=test.profile
-      - name: Analyze test
-        if: always()
-        run: bazelisk analyze-profile test.profile
 
       # --- Submodules ---
       - name: "Submodule: lec build"


### PR DESCRIPTION
`bazel analyze-profile` is gone in Bazel 9:

```
Command 'analyze-profile' not found. Try 'bazel help'.
##[error]Process completed with exit code 2.
```

Because the step runs with `if: always()`, it turns the job red even when every test it was summarizing passed.

Nothing depended on its output — it printed a timing summary into the log. `--profile=test.profile` stays, so the JSON profile is still written and can be opened in `ui.perfetto.dev`, which is what Bazel now points at. (The `lec` build already writes `lec.profile` with nothing reading it, so this matches existing practice.)

Dropping the step is a no-op on the pinned 8.6.0, where the command still exists — one more thing off the path to Bazel 9.