### PR TITLE
feat: the <flow>_estimate report — fast PPA estimate for differential use

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,7 @@ exports_files([
     "compute_slack_margin.tcl",
     "config_mk_parser.py",
     "deploy.tpl",
+    "estimate.tcl",
     "html_timing_report.tcl",
     "make.tpl",
     "mock_area.tcl",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ and easily actionable github issues for the OpenROAD and ORFS maintainers.
 | Upgrade bazel-orfs or ORFS | [Upgrade bazel-orfs](#upgrade-bazel-orfs) |
 | Override configuration variables | [Override configuration variables](#override-configuration-variables) |
 | Diagnose a build failure on my host | [docs/debugging.md](docs/debugging.md#host-platform--older-distributions) |
+| Fast PPA estimate / gate a PR against merge-base | [docs/estimate.md](docs/estimate.md) |
 
 ## Requirements
 

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -364,6 +364,25 @@ ranking that candidate on wirelength would have shipped a design that
 does not build. Feasibility is a separate outcome from score, and
 "fraction of candidates infeasible" is worth tracking as its own number.
 
+**A near miss at small n is often not near anything.** The best of the
+cheap readouts landed at rho +0.39 [-0.01, +0.72] -- short of clearing
+zero by 0.01, which invites one more turn of the crank. Taking that turn
+(doubling the readout's support) moved it to +0.42 [-0.02, +0.73] at
+2.3x the cost, and it *still* straddled zero. At n=23 those two are the
+same measurement, and the 0.01 shortfall was where the interval happened
+to fall rather than a gap that tuning could close. Before spending on a
+variant of a near miss, ask what the interval width says the measurement
+can resolve; here it could not resolve the difference the variant was
+built to produce.
+
+**A coarsening rung pays for every exception it makes.** The same
+experiment held instances near macro pins out of the clusters to keep
+their pin geometry exact. Going from one hop to two raised that
+exempt set from 1458 instances to 2380 and cut the speedup over the flat
+scorer from 4.3x to 1.8x -- most of the rung's reason to exist, spent on
+fidelity that bought no ranking. Exemptions from an abstraction are
+charged at the un-abstracted rate, so they need their own budget.
+
 **A confidence interval spanning [-1, +1] is not a pass.** On a
 four-candidate population a gate phrased as "rho lands inside the
 reference interval" reported PASS at rho +0.80 with a bootstrap interval

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -142,6 +142,28 @@ Pending, tracked in the campaign plan:
   optimistic; differential use does not need the correction, absolute
   use does).
 
+## Own your scoring function
+
+The impossible thing was a universal, accurate estimator — so the
+achievable thing is a local, owned, revisable ranking function. Write
+your own scoring for your design and the development phase you are
+in, and plan to revise it as the design progresses. The measured
+basis for each clause:
+
+- Corrections fitted on one design transfer worse than no correction
+  at all (the estimation ladder's transfer study — its most flexible
+  fit memorized its own design and then lost to nothing on the next).
+- The live KPI moves with the operating point: at loose constraints
+  the period axis is dead and area/macro-path slack are what a score
+  can see; near the design's capability wall, period wakes up. Gate
+  on the axis that is alive where you are.
+- The noise floor is a property of the operating point too (measured
+  48.8 -> 15.4 -> 7.3 ps across one design's clock sweep), so even a
+  perfect scorer's thresholds go stale as constraints tighten.
+
+This report ships a general-purpose default; treat it as the
+starting point the protocol calibrates, not as the answer.
+
 ## Limits
 
 - **A speedometer, not a map**: the estimate tracks *whether* the

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -314,6 +314,69 @@ basis for each clause:
 This report ships a general-purpose default; treat it as the
 starting point the protocol calibrates, not as the answer.
 
+## Negative findings of importance
+
+Results that did not go the way the programme assumed. They are recorded
+because each one invalidates something a later experiment would otherwise
+have built on.
+
+**"Drop the STA" does not reproduce.** The estimation ladder concluded
+that a raw HPWL readout was ranking-equivalent to the full proxy (+0.67
+against +0.72 on the macro-path KPI). Re-measured on an independently
+constructed population of 23 candidates with truth taken through the
+whole production tail, raw HPWL ranks that KPI at **+0.24 [-0.24, +0.65]**
+-- interval spanning zero, i.e. no demonstrable signal -- while the same
+rung's STA aggregate ranks it at **+0.61 [+0.29, +0.78]**. The
+phenomenon the ladder is built on reproduces; the claim that the STA is
+droppable does not. Anything that assumes a wirelength-only score suffices
+needs to re-derive that first.
+
+**A cheaper scorer can be faithful and still not rank.** A clustered
+global placement reproduced the flat rung's HPWL at rho +0.66
+[+0.34, +0.86] for a quarter of the runtime, and ranked the truth at
++0.26 -- statistically indistinguishable from flat HPWL's +0.24. The
+abstraction was not the limitation; the scalar it read was. Cost
+reductions and ranking accuracy are independent axes, and a reduction
+that faithfully reproduces a weak signal is still weak.
+
+**Some reductions structurally exclude their own fix.** `placement_cluster`
+places every member instance at its cluster centre, so a clustered
+placement is a few point-masses and any STA taken off it is meaningless.
+A clustered rung therefore cannot carry the readout that was measured to
+work. Check whether a proposed reduction forecloses the repair before
+adopting it.
+
+**An archived score/truth pair cannot grade a later re-run.** Regenerating
+a seeded population with the same design, the same ORFS commit and an
+OpenROAD with zero source differences still produced candidates
+uncorrelated with the archive: re-measured truth against archived truth
+rho **-0.26 [-0.65, +0.24]** on the macro-path KPI and +0.07 on achieved
+period. The archive stayed internally consistent and still reproduced its
+own published +0.72. The difference was traced to the bazel-orfs pin,
+which changes the synthesis netlist and therefore the candidates.
+**Provenance for an archived population has to include the bazel-orfs
+commit**, or the archive can only ever grade itself.
+
+**A candidate can be infeasible, and no wirelength score can say so.** One
+placement in 24 left a channel the power grid could not repair
+(`PDN-0179`); the flow cannot complete on it at any effort. A selector
+ranking that candidate on wirelength would have shipped a design that
+does not build. Feasibility is a separate outcome from score, and
+"fraction of candidates infeasible" is worth tracking as its own number.
+
+**A confidence interval spanning [-1, +1] is not a pass.** On a
+four-candidate population a gate phrased as "rho lands inside the
+reference interval" reported PASS at rho +0.80 with a bootstrap interval
+covering the entire range -- any value at all would have landed inside.
+A ranking claim needs its interval clear of zero before the point
+estimate means anything, which is the criterion the ladder's own money
+figure already used. Gates should say *inconclusive*, because an
+uninformative measurement is neither a pass nor a failure.
+
+The apparatus, evidence and per-candidate data behind these are in
+[ORFS#4492](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4492)
+and `ideas/e12-clustered-scorer.md`.
+
 ## Limits
 
 - **A speedometer, not a map**: the estimate tracks *whether* the

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -61,6 +61,30 @@ It claims something weaker that turns out to be sufficient: a
   its side, and the comparison is a file diff. Built nightly, the
   same artifact is a trend line at roughly one percent of flow cost.
 
+## Why the estimator is shaped this way
+
+The estimator's design is not aesthetic — it is shaped by where the
+noise turned out to live. In the campaign work this document distills
+(breadcrumbs below), we decomposed a flow's run-to-run variance stage
+by stage and found it is not spread evenly: downstream of a fixed
+macro placement the flow is comparatively quiet, while the placer's
+response to its inputs dominates — choosing a macro placement is
+choosing the downstream outcome. Timing-driven global placement added
+noise without adding any ability to compare. The repair stages
+flattened period differences by spending area and runtime, so at
+relaxed constraints most placements tie and the surviving signal
+lives in the macro paths. And ranking power saturated long before
+placement convergence. Each choice in `estimate.tcl` answers one of
+these findings: non-timing-driven, because determinism buys
+comparability and TD bought only noise; early-stopped, because the
+ranking is decided well before convergence; scored before repair,
+because repair's effort is largely the price of what the placement
+fields already show — and the resulting uniform optimism cancels in
+differential use; the macro-path channel reported separately, because
+it is the one quantity macro placement demonstrably controls; and a
+single deterministic draw rather than a sweep, with pinning and
+receipts carrying the burden that sweeps cannot affordably carry.
+
 ## The math of gating with a fast, imperfect signal
 
 Model development as a guided random walk toward a PPA goal G. Each
@@ -169,33 +193,48 @@ macro-path fields are the channel macro placement controls
 racing and selecting the pin is the macro-placement campaign's
 business (PR #868).
 
-## Calibration status and provenance
+## Provenance, trust, and breadcrumbs
 
-Measured, with data committed in the macro-placement campaign
-(bazel-orfs PR #868 and `test/estimation_ladder/`):
+The lessons above come from exploratory campaigns: one machine, a
+handful of designs, instruments that evolved mid-flight, data hoarded
+rather than curated. This document is a thesis, not a paper. It has
+no obligation to establish exactly where each number was measured or
+whether it was measured correctly — and you should extend it the same
+courtesy: **do not trust the numbers below, or the archived data
+behind them, without re-measuring**. They are breadcrumbs with
+pointers, left so a proper follow-up study can be done by someone
+with the time to do it right.
 
-- Early stopping at overflow 0.6: ranking power of the placement
-  saturates there (trajectory replay over 24 candidates; rho within
-  noise of full convergence at ~70% of the iterations).
-- STA-free ranking: raw HPWL ranked post-route macro-path timing at
-  rho +0.67 vs the full instrument's +0.72 (n=24, overlapping CIs).
+Observed once, pointer attached:
+
+- Early stopping at overflow 0.6: ranking power appeared to saturate
+  there (~70% of the iterations for all of the ranking).
+- STA-free ranking: raw HPWL ranked post-route macro-path timing
+  about as well as the full instrument (rho +0.67 vs +0.72, n=24,
+  overlapping CIs).
 - Estimator-vs-flow ranking across configurations: Kendall tau
-  0.80–0.87 (the estimation ladder's fronts).
+  0.80–0.87 on two small designs.
 - Area fidelity: estimate-to-route rho ≈ +0.5–0.65 across two
   designs.
-- Determinism: placements and scores bit-identical across thread
-  counts, execution shapes and a compiler/binary change (24/24).
+- Determinism held everywhere it was checked: placements and scores
+  bit-identical across thread counts, execution shapes and a
+  binary change.
 
-Pending, tracked in the campaign plan:
+Never measured at all, and needed before trusting deltas as
+magnitudes rather than ordering evidence: the PR-vs-merge-base
+transfer error for logic changes (a backtest over historical or
+synthetic commits), and a validated absolute correction (differential
+use does not need one; absolute use does).
 
-- σ_f for logic deltas — the PR-vs-merge-base transfer error — via a
-  backtest over historical or synthetic changes (E14). Until it
-  lands, treat est_achievable deltas as ordering evidence with the
-  config-ranking tau above as the prior, not as calibrated
-  magnitudes.
-- A validated absolute correction (the raw estimate is uniformly
-  optimistic; differential use does not need the correction, absolute
-  use does).
+The trail: bazel-orfs PR #868 (the macro-placement selection
+campaign: noise decomposition, the seed-population experiments, the
+figures and their JSON records — the branch and its `ideas/` docs are
+the evidence and its flaws in one place), OpenROAD-flow-scripts PRs
+#4487 (floorplan-parameter racing and the config.mk pin mechanics)
+and #4492 (the clustered-scorer question, pre-registered), and
+OpenROAD issues #11277–#11279 — minimal reproducers verified against
+stock master, the most independently trustworthy artifacts in the
+pile.
 
 ## Cadence: estimate always, audit as you can afford, pin occasionally
 

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -1,0 +1,154 @@
+# The `<flow>_estimate` report
+
+Every `orfs_flow()` with a floorplan stage grows a
+`<name>[_variant]_estimate` target: a deterministic, seconds-to-a-
+minute estimate of what that floorplan can achieve — estimated
+achievable clock period, utilization, place density against its
+computed floor — produced by a non-timing-driven, early-stopped
+global placement in its own process, off the saved floorplan
+artifact. It runs in parallel with the place stage by DAG
+construction and cannot perturb any flow artifact.
+
+```sh
+bazelisk build //test:lb_32x128_estimate
+cat bazel-bin/test/lb_32x128_estimate.json
+```
+
+This document is the thesis behind the report: why a *fast, less
+accurate* signal is the right tool for gating changes, what the
+numbers mean, how far to trust them, and the math of using them.
+
+## A flow result is a draw
+
+A global-route PPA number is a draw from a population. Kahng and
+Mantik measured this across industry tools a generation ago
+(*Measurement of Inherent Noise in EDA Tools*, ISQED 2002):
+meaning-preserving perturbations of a tool's input move results by
+amounts comparable to claimed optimization improvements. Comparing a
+pull request against merge-base with single runs is reading lottery
+tickets; the honest comparison needs a seed sweep and a measured
+noise floor. That is slow — hours per side.
+
+The field has spent thirty-plus years failing to produce a fast,
+accurate global-route estimator, and this report does not claim one.
+It claims something weaker that turns out to be sufficient: a
+**deterministic, ranking-accurate-ish estimate used differentially**.
+
+- **Deterministic**: the same input produces the same JSON,
+  bit-for-bit. An estimate delta between two commits has no sampling
+  noise of its own — unlike a flow delta, which needs a noise floor
+  just to be readable.
+- **Differential**: pre-route estimates are uniformly optimistic (the
+  central finding of the estimation ladder this report grew out of).
+  In a this-commit-vs-merge-base diff, the shared bias cancels; what
+  remains is the response to the change.
+- **Cheap baseline**: outputs are content-addressed. The merge-base's
+  JSON already exists in cache from its own build; a PR builds only
+  its side, and the comparison is a file diff. Built nightly, the
+  same artifact is a trend line at roughly one percent of flow cost.
+
+## The math of gating with a fast, imperfect signal
+
+Model development as a guided random walk toward a PPA goal G. Each
+candidate change has a true effect δ (positive = improvement). The
+gate observes δ̂ = δ + ε, where ε has spread σ_f — the estimator's
+*transfer error* through placement, CTS and routing — and merges when
+δ̂ exceeds a threshold t. Merged work is audited by an overnight seed
+sweep with resolution d_tie (the design's measured noise floor);
+regressions larger than d_tie are caught and reverted.
+
+Progress per candidate evaluated:
+
+    v = p⁺ · μ⁺ · A⁺(σ_f, t)  −  p⁻ · E[ |δ| · A⁻ ; |δ| < d_tie ]
+
+where p⁺, μ⁺ describe the improving candidates, A⁺ their accept rate,
+and the second term — the only *permanent* damage — is bounded by
+p⁻ · d_tie. Candidates to goal: n* = G / v. Three results follow:
+
+1. **The overnight audit truncates the downside.** No bad merge can
+   cost more than d_tie permanently; the gate's errors are transient.
+   Positive drift is guaranteed whenever p⁺ · μ⁺ · A⁺ > p⁻ · d_tie —
+   a condition met with room to spare by any change population whose
+   improvements are meaningfully larger than the noise floor. The
+   audit, not the gate, is what makes fast-and-imperfect safe.
+2. **Large effects are exponentially safe in both directions.** The
+   probability of missing an improvement of size δ decays as
+   exp(−δ²/2σ_f²); the same for a large regression slipping through —
+   and the audit catches it anyway. Only the interval (−d_tie, +σ_f)
+   is murky, and everything in it is small by definition. Missed
+   improvements can be relitigated; hidden sub-floor regressions
+   accumulate as bounded drag that the nightly trend line exposes as
+   deviation from expected drift.
+3. **Throughput wins by orders of magnitude.** Illustrative numbers
+   (σ_f = 15ps, d_tie = 10ps, t = σ_f; 30% improvements at +20ps, 30%
+   regressions at −20ps, 40% null): the fast gate needs ~46 candidates
+   to the slow gate's ~30 for the same goal — and ~1 hour of gate
+   compute against ~300. The gate stops being the bottleneck; the
+   walk's speed becomes limited by candidate supply.
+
+The gate does not need to be right. It needs to keep the drift
+positive at maximum candidate throughput, with correctness delegated
+to the cheap audit and to the exponential tails.
+
+## Protocol
+
+1. Estimate delta ≫ transfer error → actionable verdict, act on it.
+2. Delta below resolution → a tie *at this fidelity*; escalate to the
+   full flow with seed pairing and delta_tie discipline, or accept
+   the tie.
+3. Overnight: seed sweep over merged work; revert what exceeds the
+   noise floor.
+4. The report carries data, not advice: absolute numbers with their
+   bases, no recommendations. Gating policy belongs to the consumer.
+
+## What is in the JSON
+
+| field | meaning |
+|---|---|
+| `clock_target` | period of the first clock, STA units |
+| `est_achievable_raw` | clock_target − wns after the estimate placement; **pre-route optimistic, differential use** |
+| `wns` | worst reg2reg slack at placement parasitics |
+| `utilization`, `core_um2`, `cell_um2` | area occupancy of the floorplan |
+| `num_macros` | macros in the design (placed by the floorplan stage) |
+| `place_density`, `density_floor` | configured density and the computed lower bound |
+| `gp_overflow_target` | the early-stop point (see below) |
+| `runtime_s` | cost of this report |
+
+## Calibration status and provenance
+
+Measured, with data committed in the macro-placement campaign
+(bazel-orfs PR #868 and `test/estimation_ladder/`):
+
+- Early stopping at overflow 0.6: ranking power of the placement
+  saturates there (trajectory replay over 24 candidates; rho within
+  noise of full convergence at ~70% of the iterations).
+- STA-free ranking: raw HPWL ranked post-route macro-path timing at
+  rho +0.67 vs the full instrument's +0.72 (n=24, overlapping CIs).
+- Estimator-vs-flow ranking across configurations: Kendall tau
+  0.80–0.87 (the estimation ladder's fronts).
+- Area fidelity: estimate-to-route rho ≈ +0.5–0.65 across two
+  designs.
+- Determinism: placements and scores bit-identical across thread
+  counts, execution shapes and a compiler/binary change (24/24).
+
+Pending, tracked in the campaign plan:
+
+- σ_f for logic deltas — the PR-vs-merge-base transfer error — via a
+  backtest over historical or synthetic changes (E14). Until it
+  lands, treat est_achievable deltas as ordering evidence with the
+  config-ranking tau above as the prior, not as calibrated
+  magnitudes.
+- A validated absolute correction (the raw estimate is uniformly
+  optimistic; differential use does not need the correction, absolute
+  use does).
+
+## Limits
+
+- **A speedometer, not a map**: the estimate tracks *whether* the
+  achievable period moved, not which path moved it (measured
+  recall@10 of critical paths barely above chance). Localization
+  needs the flow.
+- Pre-route blindness: routability catastrophes, hold and CTS
+  pathologies are invisible here.
+- The reg2reg path group comes from the platform SDC; designs without
+  it fall back to the unconstrained worst path.

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -1,18 +1,32 @@
 # The `<flow>_estimate` report
 
-Every `orfs_flow()` with a floorplan stage grows a
-`<name>[_variant]_estimate` target: a deterministic, seconds-to-a-
-minute estimate of what that floorplan can achieve — estimated
-achievable clock period, utilization, place density against its
-computed floor — produced by a non-timing-driven, early-stopped
-global placement in its own process, off the saved floorplan
-artifact. It runs in parallel with the place stage by DAG
-construction and cannot perturb any flow artifact.
+Every `orfs_flow()` that runs synthesis grows two targets:
+
+- **`<name>[_variant]_estimate`**: a deterministic, one-to-two-minute
+  estimate of what the design can achieve at its configured floorplan
+  parameters — estimated achievable clock period, the macro-path
+  channel, utilization, density against its computed bound — built
+  from the **synthesis output**: the floorplan is initialized
+  in-script from the same variables the production floorplan stage
+  reads, macros placed by the production placer, then a
+  non-timing-driven, early-stopped global placement.
+- **`<name>[_variant]_estimate_run`**: the same script as a
+  `bazelisk run` executable taking run-time `KEY=VALUE` parameter
+  overrides — one point in floorplan-parameter space per invocation.
 
 ```sh
-bazelisk build //test:lb_32x128_estimate
-cat bazel-bin/test/lb_32x128_estimate.json
+bazelisk build //test/smoketest:lb_32x128_asap7_estimate
+cat bazel-bin/test/smoketest/lb_32x128_asap7_estimate.json
+
+bazelisk run //test/smoketest:lb_32x128_asap7_estimate_run -- \
+  CORE_UTILIZATION=10 PLACE_DENSITY=0.6 OUTPUT=$PWD/point.json \
+  LOG_DIR=$PWD/logs
 ```
+
+Because the estimate builds its own floorplan, it is independent of —
+and parallel to — the flow's entire physical implementation, and it
+can measure parameter points the flow never runs. It cannot perturb
+any flow artifact.
 
 This document is the thesis behind the report: why a *fast, less
 accurate* signal is the right tool for gating changes, what the
@@ -110,11 +124,50 @@ to the cheap audit and to the exponential tails.
 | `wns` | worst reg2reg slack at placement parasitics |
 | `utilization`, `core_um2`, `cell_um2` | area occupancy of the floorplan |
 | `num_macros` | macros in the design (placed by the floorplan stage) |
-| `place_density`, `density_lb_addon` | configured density and the computed lower bound plus the configured addon |
+| `macro_paths_mean`, `macro_paths_worst`, `macro_paths_sampled` | the macro-path channel — the KPI macro placement actually controls; zeroed when the design has no macros |
+| `macros_pinned` | whether MACRO_PLACEMENT_TCL held the macro placement constant — see "Macro designs" |
+| `density_lb_addon` | the computed lower bound plus the configured addon; also the estimate's placement density |
 | `gp_overflow_target` | the early-stop point (see below) |
+| `params` | the floorplan parameters in force, under their **exact ORFS variable names** — a chosen point is directly consumable by config.mk pin machinery |
 
 Timing values are OpenSTA units (`time_unit`); the report's own
 wall-clock cost is in the run log's `Elapsed time` line.
+
+## Division of labor: recommendations here, mechanics in ORFS
+
+This report is the *oracle* half of floorplan-parameter automation:
+`_estimate_run` produces self-describing points, a session (human or
+AI) assembles the Pareto front and picks a recommendation, and ORFS's
+pin machinery writes it into config.mk (`pinAutoFloorplan.py` and the
+`<name>_auto_floorplan_pin` target of OpenROAD-flow-scripts PR #4487,
+which preserves the design's existing rect-vs-utilization form and
+density form in place). bazel-orfs computes recommendations; it never
+writes config.mk. `checkPareto.py` (same PR) then guards merged work:
+a trade along the front passes, a dominated point fails.
+
+Constraints imported from that PR's measured negative results:
+utilization enters only as constraint satisfaction — the smallest
+core no worse than the incumbent — never blended into a period
+objective (measured rho −1.0 on gcd for the blended form); and every
+parameter ladder may report "did not resolve" against its noise
+floor, which keeps the incumbent. Its in-flow scorer measures after
+global route (realistic, noise floors 22–32% of clock); this oracle
+measures pre-route (optimistic, deterministic, minutes) — the
+differential protocol is what licenses the cheap one.
+
+## Macro designs
+
+The floorplan built here includes the production macro placer's
+single default draw — and macro placement is chaotic in the netlist,
+so on macro designs an *unpinned* estimate delta between two commits
+carries placement-draw variance (measured at up-to-25%-scale swings)
+on top of the change being measured. `macros_pinned` says which
+regime a JSON was produced in: with `MACRO_PLACEMENT_TCL` set (stock
+ORFS), the draw is held constant and deltas are clean. The
+macro-path fields are the channel macro placement controls
+(measured: ~300ps spread across draws while general paths tie);
+racing and selecting the pin is the macro-placement campaign's
+business (PR #868).
 
 ## Calibration status and provenance
 

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -197,6 +197,62 @@ Pending, tracked in the campaign plan:
   optimistic; differential use does not need the correction, absolute
   use does).
 
+## Cadence: estimate always, audit as you can afford, pin occasionally
+
+Three layers, each with the cadence its measurement dictates:
+
+| layer | cadence | sweeps? | writes anything? |
+|---|---|---|---|
+| **estimate** | every commit + nightly | never | JSON only |
+| **seed-sweep audit** | overnight, over merged work | yes — its whole job | reverts |
+| **auto-floorplan re-pin** | signal-driven or on demand | yes — the race | config.mk via ORFS mechanics, plus a fresh receipt |
+
+The estimate is *purposely* sweep-free — and it is stronger than a
+choice: the estimate has no sampling noise to sweep away. It is
+deterministic end to end, so a sweep inside it would multiply cost by
+k while measuring a different quantity entirely (draw sensitivity, an
+occasional diagnostic). The chaos worth sweeping lives in the macro
+placer's draw and in the downstream stages the estimate deliberately
+does not run.
+
+**The pin receipt.** When pin machinery writes config.mk (the
+`pinAutoFloorplan.py` mechanics of OpenROAD-flow-scripts PR #4487),
+it should store the estimate JSON of that moment beside the update —
+a receipt. The always-on estimate then diffs itself against the
+receipt, and pin staleness becomes measured drift rather than a
+calendar: achievable-period headroom shifted, utilization crept,
+the density floor rose toward the configured value, the macro-path
+channel degraded against what the pinned draw delivered, or the pin
+failed to apply at all. Per the house rule the estimate reports the
+deltas, never "re-pin now" — the policy belongs to the consumer. The
+mechanism needs no new code: a committed JSON and a file diff.
+
+### The audit you can afford
+
+An explicit k-seed sweep of a large design is an adorable aspiration;
+the compute usually does not exist. What exists is the natural
+experiment: every commit changes the inputs, so **the nightly build
+over evolving commits is a seed sweep smeared across time**. Each
+point confounds two variables — the hoped-for improvement and a fresh
+draw — and per-point they cannot be separated. Beggars can't be
+choosers; the framework is built to work anyway:
+
+- Single points are weak verdicts: a bad night may be a bad draw.
+- The trend averages over draws, and large effects still stand out —
+  the exponential tails of the walk model do not care about the
+  confound.
+- **Detrended nightly residuals estimate the draw-noise floor**: the
+  natural experiment yields its own delta_tie over time, without a
+  dedicated sweep ever being purchased. The audit layer's resolution
+  degrades gracefully from measured-by-sweep to
+  estimated-from-residuals; the drift theorem's structure is
+  unchanged, only the parameter's provenance.
+- The consequence for this report's rank: when audit compute is
+  starved, the deterministic estimate delta is the **only noise-free
+  per-commit measurement in the system**. The cheap layer becomes
+  more load-bearing exactly when you are poorest — which is the
+  right way around.
+
 ## Own your scoring function
 
 The impossible thing was a universal, accurate estimator — so the

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -110,9 +110,11 @@ to the cheap audit and to the exponential tails.
 | `wns` | worst reg2reg slack at placement parasitics |
 | `utilization`, `core_um2`, `cell_um2` | area occupancy of the floorplan |
 | `num_macros` | macros in the design (placed by the floorplan stage) |
-| `place_density`, `density_floor` | configured density and the computed lower bound |
+| `place_density`, `density_lb_addon` | configured density and the computed lower bound plus the configured addon |
 | `gp_overflow_target` | the early-stop point (see below) |
-| `runtime_s` | cost of this report |
+
+Timing values are OpenSTA units (`time_unit`); the report's own
+wall-clock cost is in the run log's `Elapsed time` line.
 
 ## Calibration status and provenance
 

--- a/estimate.tcl
+++ b/estimate.tcl
@@ -1,34 +1,65 @@
 # The <flow>_estimate report: a fast, deterministic estimate of what
-# this floorplan can achieve, produced WITHOUT running the flow's
-# expensive tail. Thesis, calibration status and limits:
-# docs/estimate.md.
+# this design can achieve at a given set of floorplan parameters,
+# produced from the SYNTHESIS output without running the flow's
+# physical stages. Thesis, calibration status, the division of labor
+# with ORFS's config.mk pin machinery, and limits: docs/estimate.md.
 #
-# Runs as an orfs_run off the floorplan stage in its own process, so
-# it cannot perturb any flow artifact, and it parallelizes with the
-# place stage by construction. Pre-route estimates are uniformly
-# optimistic: the numbers are for DIFFERENTIAL use (this commit vs
-# merge-base, this nightly vs yesterday) where the bias cancels, not
-# for sign-off.
+# The floorplan is built here, in-script, from the same environment
+# variables the production floorplan stage reads -- so one estimate is
+# one point in floorplan-parameter space, and run-time overrides
+# (CORE_UTILIZATION=..., PLACE_DENSITY=..., via <flow>_estimate_run)
+# sweep the space at one point per one to two minutes. The JSON echoes
+# the parameters in force under their exact ORFS variable names, so a
+# chosen point is directly consumable by config.mk pin machinery.
 #
-# The global placement is non-timing-driven and early-stopped at
-# overflow 0.6: ranking power saturates there (measured -- see
-# docs/estimate.md), and the remaining iterations buy convergence the
-# estimate does not need.
+# Pre-route estimates are uniformly optimistic: the numbers are for
+# DIFFERENTIAL and RANKING use, where the bias cancels, not for
+# sign-off. The global placement is non-timing-driven and
+# early-stopped at overflow 0.6: ranking power saturates there
+# (measured -- docs/estimate.md).
 
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 2_floorplan.odb 2_floorplan.sdc
+load_design 1_synth.odb 1_synth.sdc
 
-# Pin placement: temporary, for wirelength realism. The result is
-# discarded with this process. IO_CONSTRAINTS is optional per
-# variables.yaml; everything else is config-guaranteed and read
-# directly -- absence is an error worth failing on.
+# Floorplan initialization: the production stage's two modes, from the
+# same variables. Anything config-guaranteed is read directly --
+# absence is an error worth failing on.
+if { [env_var_exists_and_non_empty DIE_AREA] } {
+    log_cmd initialize_floorplan -die_area $::env(DIE_AREA) \
+        -core_area $::env(CORE_AREA) \
+        -site $::env(PLACE_SITE)
+} elseif { [env_var_exists_and_non_empty CORE_UTILIZATION] } {
+    log_cmd initialize_floorplan -utilization $::env(CORE_UTILIZATION) \
+        -aspect_ratio $::env(CORE_ASPECT_RATIO) \
+        -core_space $::env(CORE_MARGIN) \
+        -site $::env(PLACE_SITE)
+} else {
+    error "estimate: no floorplan initialization method specified\
+        (neither DIE_AREA nor CORE_UTILIZATION)"
+}
+if { [env_var_exists_and_non_empty MAKE_TRACKS] } {
+    uplevel #0 [list source $::env(MAKE_TRACKS)]
+}
+
+set density_lb_addon [place_density_with_lb_addon]
+
+# Macro placement: the production placer, when the design has macros.
+# This is the flow's default draw; selection over a seed population is
+# the macro-placement campaign's business.
+if { [find_macros] != "" } {
+    lassign $::env(MACRO_PLACE_HALO) halo_x halo_y
+    log_cmd rtl_macro_placer -halo_width $halo_x -halo_height $halo_y \
+        -target_util $density_lb_addon \
+        -report_directory [file join $::env(WORK_HOME) rtlmp]
+}
+
+# Pin placement: temporary, for wirelength realism. IO_CONSTRAINTS is
+# optional per variables.yaml.
 if { [env_var_exists_and_non_empty IO_CONSTRAINTS] } {
     log_cmd source $::env(IO_CONSTRAINTS)
 }
 log_cmd place_pins -hor_layers $::env(IO_PLACER_H) \
     -ver_layers $::env(IO_PLACER_V)
-
-set density_lb_addon [place_density_with_lb_addon]
 
 log_cmd global_placement -density $density_lb_addon -overflow 0.6
 
@@ -45,20 +76,65 @@ set wns [get_property [lindex $wns_path 0] slack]
 set clk_period [get_property [lindex [get_clocks] 0] period]
 set est_achievable [expr { $clk_period - $wns }]
 
+# Macro-path channel: the KPI macro placement actually controls.
+# Classify a sample of near-critical paths by whether either end lives
+# in a macro. ODB escapes Verilog identifiers and OpenSTA does not.
 set block [ord::get_db_block]
+set macro_insts [dict create]
+foreach inst [$block getInsts] {
+    if { [[$inst getMaster] isBlock] } {
+        dict set macro_insts [string map {"\\" ""} [$inst getName]] 1
+    }
+}
+set num_macros [dict size $macro_insts]
+set macro_sum 0.0
+set macro_n 0
+set macro_worst 0.0
+set sampled 0
+if { $num_macros > 0 } {
+    foreach path [find_timing_paths -path_group reg2reg -sort_by_slack \
+        -group_path_count 200] {
+        incr sampled
+        set is_macro 0
+        foreach endname [list \
+            [get_full_name [get_property $path startpoint]] \
+            [get_full_name [get_property $path endpoint]]] {
+            set inst_name [join [lrange [split $endname "/"] 0 end-1] "/"]
+            if { [dict exists $macro_insts $inst_name] } {
+                set is_macro 1
+            }
+        }
+        if { $is_macro } {
+            set period [expr { $clk_period - [get_property $path slack] }]
+            set macro_sum [expr { $macro_sum + $period }]
+            incr macro_n
+            if { $period > $macro_worst } { set macro_worst $period }
+        }
+    }
+}
+set macro_mean [expr { $macro_n ? $macro_sum / $macro_n : 0.0 }]
+
 set core [$block getCoreArea]
 set dbu [expr { double([$block getDbUnitsPerMicron]) }]
 set core_um2 [expr { [$core dx] * [$core dy] / ($dbu * $dbu) }]
 set cell_um2 0.0
-set num_macros 0
 foreach inst [$block getInsts] {
-    if { [[$inst getMaster] isBlock] } { incr num_macros }
     set bbox [$inst getBBox]
     set cell_um2 [expr { $cell_um2 + [$bbox getDX] * [$bbox getDY] / ($dbu * $dbu) }]
 }
 set utilization [expr { $cell_um2 / $core_um2 }]
 
 set time_unit "[sta::unit_scale_abbreviation time][sta::unit_suffix time]"
+
+# The parameters in force, under their exact ORFS variable names: a
+# chosen point is directly consumable by config.mk pin machinery.
+set param_lines {}
+foreach var {DIE_AREA CORE_AREA CORE_UTILIZATION CORE_ASPECT_RATIO
+             CORE_MARGIN PLACE_DENSITY PLACE_DENSITY_LB_ADDON} {
+    if { [env_var_exists_and_non_empty $var] } {
+        lappend param_lines "  \"$var\": \"$::env($var)\""
+    }
+}
 
 set out [file join $::env(WORK_HOME) $::env(OUTPUT)]
 set fp [open $out w]
@@ -71,13 +147,21 @@ puts $fp " \"utilization\": [format %.4f $utilization],"
 puts $fp " \"core_um2\": [format %.1f $core_um2],"
 puts $fp " \"cell_um2\": [format %.1f $cell_um2],"
 puts $fp " \"num_macros\": $num_macros,"
-puts $fp " \"place_density\": $::env(PLACE_DENSITY),"
+puts $fp " \"macro_paths_mean\": [format %.3f $macro_mean],"
+puts $fp " \"macro_paths_worst\": [format %.3f $macro_worst],"
+puts $fp " \"macro_paths_sampled\": $macro_n,"
+puts $fp " \"paths_sampled\": $sampled,"
+puts $fp " \"macros_pinned\": [expr { [env_var_exists_and_non_empty MACRO_PLACEMENT_TCL] ? "true" : "false" }],"
 puts $fp " \"density_lb_addon\": $density_lb_addon,"
-puts $fp " \"gp_overflow_target\": 0.6"
+puts $fp " \"gp_overflow_target\": 0.6,"
+puts $fp " \"params\": {"
+puts $fp [join $param_lines ",\n"]
+puts $fp " }"
 puts $fp "}"
 close $fp
 
 puts "estimate: clock target ${clk_period}${time_unit}\
  (est. achievable, pre-route optimistic: [format %.1f $est_achievable]${time_unit}),\
+ macro paths mean [format %.1f $macro_mean]${time_unit} ($macro_n sampled),\
  utilization [format %.1f [expr { $utilization * 100 }]]%,\
- density $::env(PLACE_DENSITY) (lb+addon $density_lb_addon)."
+ density lb+addon $density_lb_addon."

--- a/estimate.tcl
+++ b/estimate.tcl
@@ -15,32 +15,22 @@
 # docs/estimate.md), and the remaining iterations buy convergence the
 # estimate does not need.
 
-source $::env(SCRIPTS_DIR)/open.tcl
-
-set estimate_start_ms [clock clicks -milliseconds]
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 2_floorplan.odb 2_floorplan.sdc
 
 # Pin placement: temporary, for wirelength realism. The result is
-# discarded with this process.
-if { [info exists ::env(IO_CONSTRAINTS)] && $::env(IO_CONSTRAINTS) ne "" } {
+# discarded with this process. IO_CONSTRAINTS is optional per
+# variables.yaml; everything else is config-guaranteed and read
+# directly -- absence is an error worth failing on.
+if { [env_var_exists_and_non_empty IO_CONSTRAINTS] } {
     log_cmd source $::env(IO_CONSTRAINTS)
 }
 log_cmd place_pins -hor_layers $::env(IO_PLACER_H) \
     -ver_layers $::env(IO_PLACER_V)
 
-# Density: the configured value if set, else the computed floor.
-set density_floor ""
-if { [catch { set density_floor [place_density_with_lb_addon] } msg] } {
-    set density_floor ""
-}
-if { [info exists ::env(PLACE_DENSITY)] && $::env(PLACE_DENSITY) ne "" } {
-    set gp_density $::env(PLACE_DENSITY)
-} elseif { $density_floor ne "" } {
-    set gp_density $density_floor
-} else {
-    error "estimate: neither PLACE_DENSITY nor a computable density floor"
-}
+set density_lb_addon [place_density_with_lb_addon]
 
-log_cmd global_placement -density $gp_density -overflow 0.6
+log_cmd global_placement -density $density_lb_addon -overflow 0.6
 
 estimate_parasitics -placement
 set_propagated_clock [all_clocks]
@@ -48,9 +38,8 @@ set_propagated_clock [all_clocks]
 set wns_path [find_timing_paths -path_group reg2reg -sort_by_slack \
     -group_path_count 1]
 if { [llength $wns_path] == 0 } {
-    # Fall back to the unconstrained worst path so designs without a
-    # reg2reg group still get a number.
-    set wns_path [find_timing_paths -sort_by_slack -group_path_count 1]
+    error "estimate: no reg2reg timing paths; the platform SDC defines\
+        no reg2reg group for this design"
 }
 set wns [get_property [lindex $wns_path 0] slack]
 set clk_period [get_property [lindex [get_clocks] 0] period]
@@ -63,14 +52,11 @@ set core_um2 [expr { [$core dx] * [$core dy] / ($dbu * $dbu) }]
 set cell_um2 0.0
 set num_macros 0
 foreach inst [$block getInsts] {
-    set master [$inst getMaster]
-    if { [$master isBlock] } { incr num_macros }
+    if { [[$inst getMaster] isBlock] } { incr num_macros }
     set bbox [$inst getBBox]
     set cell_um2 [expr { $cell_um2 + [$bbox getDX] * [$bbox getDY] / ($dbu * $dbu) }]
 }
 set utilization [expr { $cell_um2 / $core_um2 }]
-
-set runtime_s [expr { ([clock clicks -milliseconds] - $estimate_start_ms) / 1000.0 }]
 
 set time_unit "[sta::unit_scale_abbreviation time][sta::unit_suffix time]"
 
@@ -85,16 +71,13 @@ puts $fp " \"utilization\": [format %.4f $utilization],"
 puts $fp " \"core_um2\": [format %.1f $core_um2],"
 puts $fp " \"cell_um2\": [format %.1f $cell_um2],"
 puts $fp " \"num_macros\": $num_macros,"
-puts $fp " \"place_density\": [expr { [info exists ::env(PLACE_DENSITY)] && $::env(PLACE_DENSITY) ne "" ? $::env(PLACE_DENSITY) : "null" }],"
-puts $fp " \"density_floor\": [expr { $density_floor ne "" ? $density_floor : "null" }],"
-puts $fp " \"gp_overflow_target\": 0.6,"
-puts $fp " \"runtime_s\": $runtime_s"
+puts $fp " \"place_density\": $::env(PLACE_DENSITY),"
+puts $fp " \"density_lb_addon\": $density_lb_addon,"
+puts $fp " \"gp_overflow_target\": 0.6"
 puts $fp "}"
 close $fp
 
 puts "estimate: clock target ${clk_period}${time_unit}\
  (est. achievable, pre-route optimistic: [format %.1f $est_achievable]${time_unit}),\
  utilization [format %.1f [expr { $utilization * 100 }]]%,\
- density [expr { [info exists ::env(PLACE_DENSITY)] && $::env(PLACE_DENSITY) ne "" ? $::env(PLACE_DENSITY) : "unset" }]\
- (computed floor [expr { $density_floor ne "" ? $density_floor : "n/a" }]).\
- ${runtime_s}s."
+ density $::env(PLACE_DENSITY) (lb+addon $density_lb_addon)."

--- a/estimate.tcl
+++ b/estimate.tcl
@@ -1,0 +1,100 @@
+# The <flow>_estimate report: a fast, deterministic estimate of what
+# this floorplan can achieve, produced WITHOUT running the flow's
+# expensive tail. Thesis, calibration status and limits:
+# docs/estimate.md.
+#
+# Runs as an orfs_run off the floorplan stage in its own process, so
+# it cannot perturb any flow artifact, and it parallelizes with the
+# place stage by construction. Pre-route estimates are uniformly
+# optimistic: the numbers are for DIFFERENTIAL use (this commit vs
+# merge-base, this nightly vs yesterday) where the bias cancels, not
+# for sign-off.
+#
+# The global placement is non-timing-driven and early-stopped at
+# overflow 0.6: ranking power saturates there (measured -- see
+# docs/estimate.md), and the remaining iterations buy convergence the
+# estimate does not need.
+
+source $::env(SCRIPTS_DIR)/open.tcl
+
+set estimate_start_ms [clock clicks -milliseconds]
+
+# Pin placement: temporary, for wirelength realism. The result is
+# discarded with this process.
+if { [info exists ::env(IO_CONSTRAINTS)] && $::env(IO_CONSTRAINTS) ne "" } {
+    log_cmd source $::env(IO_CONSTRAINTS)
+}
+log_cmd place_pins -hor_layers $::env(IO_PLACER_H) \
+    -ver_layers $::env(IO_PLACER_V)
+
+# Density: the configured value if set, else the computed floor.
+set density_floor ""
+if { [catch { set density_floor [place_density_with_lb_addon] } msg] } {
+    set density_floor ""
+}
+if { [info exists ::env(PLACE_DENSITY)] && $::env(PLACE_DENSITY) ne "" } {
+    set gp_density $::env(PLACE_DENSITY)
+} elseif { $density_floor ne "" } {
+    set gp_density $density_floor
+} else {
+    error "estimate: neither PLACE_DENSITY nor a computable density floor"
+}
+
+log_cmd global_placement -density $gp_density -overflow 0.6
+
+estimate_parasitics -placement
+set_propagated_clock [all_clocks]
+
+set wns_path [find_timing_paths -path_group reg2reg -sort_by_slack \
+    -group_path_count 1]
+if { [llength $wns_path] == 0 } {
+    # Fall back to the unconstrained worst path so designs without a
+    # reg2reg group still get a number.
+    set wns_path [find_timing_paths -sort_by_slack -group_path_count 1]
+}
+set wns [get_property [lindex $wns_path 0] slack]
+set clk_period [get_property [lindex [get_clocks] 0] period]
+set est_achievable [expr { $clk_period - $wns }]
+
+set block [ord::get_db_block]
+set core [$block getCoreArea]
+set dbu [expr { double([$block getDbUnitsPerMicron]) }]
+set core_um2 [expr { [$core dx] * [$core dy] / ($dbu * $dbu) }]
+set cell_um2 0.0
+set num_macros 0
+foreach inst [$block getInsts] {
+    set master [$inst getMaster]
+    if { [$master isBlock] } { incr num_macros }
+    set bbox [$inst getBBox]
+    set cell_um2 [expr { $cell_um2 + [$bbox getDX] * [$bbox getDY] / ($dbu * $dbu) }]
+}
+set utilization [expr { $cell_um2 / $core_um2 }]
+
+set runtime_s [expr { ([clock clicks -milliseconds] - $estimate_start_ms) / 1000.0 }]
+
+set time_unit "[sta::unit_scale_abbreviation time][sta::unit_suffix time]"
+
+set out [file join $::env(WORK_HOME) $::env(OUTPUT)]
+set fp [open $out w]
+puts $fp "{"
+puts $fp " \"time_unit\": \"$time_unit\","
+puts $fp " \"clock_target\": $clk_period,"
+puts $fp " \"est_achievable_raw\": $est_achievable,"
+puts $fp " \"wns\": $wns,"
+puts $fp " \"utilization\": [format %.4f $utilization],"
+puts $fp " \"core_um2\": [format %.1f $core_um2],"
+puts $fp " \"cell_um2\": [format %.1f $cell_um2],"
+puts $fp " \"num_macros\": $num_macros,"
+puts $fp " \"place_density\": [expr { [info exists ::env(PLACE_DENSITY)] && $::env(PLACE_DENSITY) ne "" ? $::env(PLACE_DENSITY) : "null" }],"
+puts $fp " \"density_floor\": [expr { $density_floor ne "" ? $density_floor : "null" }],"
+puts $fp " \"gp_overflow_target\": 0.6,"
+puts $fp " \"runtime_s\": $runtime_s"
+puts $fp "}"
+close $fp
+
+puts "estimate: clock target ${clk_period}${time_unit}\
+ (est. achievable, pre-route optimistic: [format %.1f $est_achievable]${time_unit}),\
+ utilization [format %.1f [expr { $utilization * 100 }]]%,\
+ density [expr { [info exists ::env(PLACE_DENSITY)] && $::env(PLACE_DENSITY) ne "" ? $::env(PLACE_DENSITY) : "unset" }]\
+ (computed floor [expr { $density_floor ne "" ? $density_floor : "n/a" }]).\
+ ${runtime_s}s."

--- a/ideas/e12-clustered-scorer.md
+++ b/ideas/e12-clustered-scorer.md
@@ -1,0 +1,112 @@
+# E12: the clustered global-place scorer, measured
+
+Status: **run, and answered.** The result is not a pass or a fail on the
+gate as written -- it relocates the problem.
+
+## The question
+
+RTL-MP already builds a physical hierarchy: std-cell clusters and
+bundled nets, produced so its annealer has a tractable model. E12 asked
+whether that hierarchy can double as the *scoring* netlist -- spread the
+soft clusters around each candidate's fixed macros, read bundled-net
+HPWL, and get a ranking-accurate score for an order of magnitude fewer
+movables.
+
+The appeal was that the clustering is already paid for, so the reduction
+would be free and knob-free.
+
+## What was built
+
+Apparatus in ORFS `flow/test/macro_e12/` (see
+[ORFS#4492](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4492),
+kept as reproducible evidence): seeded candidate generation, the flat
+control rung, RTL-MP's partition dumped once from the shared base
+floorplan, the clustered rung, the production tail to grt as ground
+truth, and a grader reporting Spearman rho with bootstrap intervals.
+
+Nothing reimplements a field solver, deliberately: the thing being graded
+has to be the solver that would ship. Both halves already exist --
+`placement_cluster` makes N instances one movable, and
+`rtl_macro_placer -keep_clustering_data` commits the partition to odb.
+
+## The measurement
+
+asap7/swerv_wrapper, 24 candidates generated, 23 evaluable, ground truth
+measured through the full production tail on the same setup (~34 min per
+candidate, ~1 h wall for all 23 at 4-way parallel).
+
+| scorer | rho vs grt `macro_paths_mean` | |
+|---|---|---|
+| flat, **STA** aggregate | **+0.61 [+0.29, +0.78]** | ranks |
+| flat, STA macro aggregate | +0.59 [+0.20, +0.80] | ranks |
+| flat, raw HPWL | +0.24 [-0.24, +0.65] | no evidence |
+| clustered HPWL | +0.26 [-0.22, +0.66] | no evidence |
+| clustered **macro-cone** HPWL | +0.39 [-0.01, +0.72] | just misses |
+
+Cost, same population: clustered 14.7 s and 0.87 GB against the flat
+rung's 63.0 s and 2.43 GB. Agreement between the two on the same scalar:
+rho +0.66 [+0.34, +0.86].
+
+## What it means
+
+**The clustering worked. The readout did not.**
+
+The clustered rung reproduces the flat rung's HPWL faithfully (+0.66) at
+roughly a quarter of the cost, and its ranking of the truth (+0.26) is
+statistically indistinguishable from flat HPWL's (+0.24). So the
+abstraction is not what costs the ranking -- it inherits a scalar that
+carries no demonstrable signal on this setup. No refinement of the
+cluster model can fix that.
+
+E12's question therefore changes from *"how do we compute this number
+more cheaply"* to *"which number should we compute"*.
+
+**And the answer space is narrower than it looks.** `placement_cluster`
+places every member instance at its cluster's centre, so a clustered
+placement is a handful of point-masses; parasitics and STA taken off it
+are meaningless. The clustered rung cannot carry an STA readout at all.
+Whatever replaces HPWL has to live in the wirelength family.
+
+That leaves exactly one live thread from this run: the **macro-cone**
+readout at +0.39, best of the HPWL family and short of significance by
+0.01. It is the only variant that moved toward the live KPI, and it did
+so by restricting the sum to nets within reach of a macro pin -- i.e. by
+aiming the score at the structure the KPI actually reads.
+
+## Why the divergence was not a bug
+
+At the pre-registered default the clustered solve diverges on this
+design: overflow floors at 0.92 for 2175 iterations while the density
+penalty climbs to 4.1e+28, then the step length goes Inf/NaN (GPL-0305).
+
+That is a granularity mismatch, and both sides are behaving as intended:
+
+- `BinGrid::initBins()` sizes bins from average **dbInst** area, correct
+  for the regime `placement_cluster` was built for -- its commit
+  describes "a small group of gates" whose members are "all placed at the
+  center of the cluster", and notes that small clusters give better
+  results.
+- RTL-MP's clustering goes deliberately the other way:
+  `min_num_macros_for_multilevel = 150` forces `max_level = 1` here, and
+  `base_min_std_cell` targets 10183-50915 cells per cluster. Seven
+  clusters end up holding 98.6% of the instances.
+
+Neither tool is wrong; E12 straddles the seam. A smaller design
+(nangate45/tinyRocket, 13 clusters) converges at the default, so it is
+the granularity that diverges, not clustering as such. The swerv numbers
+above therefore use `-bin_grid_count 8`, disclosed as a knob and treated
+as exploratory rather than as a gate result.
+
+## If someone picks this up
+
+1. **Chase the cone, not the clusters.** Re-score at wider hop counts and
+   with cone-only readouts. The truth is already measured, so each
+   variant costs minutes.
+2. **Re-derive E3 before building on it.** Raw HPWL did not rank here
+   (+0.24, interval spanning zero) against a published +0.67.
+3. **Do not reuse an archived score/truth pair to grade a re-run** unless
+   the bazel-orfs pin is part of the recorded provenance -- see the
+   negative findings in `docs/estimate.md`.
+4. **Record infeasibility as an outcome.** One candidate could not be
+   built at all (PDN could not repair a channel its macro placement
+   created); no wirelength score can express that.

--- a/ideas/e12-clustered-scorer.md
+++ b/ideas/e12-clustered-scorer.md
@@ -41,7 +41,8 @@ candidate, ~1 h wall for all 23 at 4-way parallel).
 | flat, STA macro aggregate | +0.59 [+0.20, +0.80] | ranks |
 | flat, raw HPWL | +0.24 [-0.24, +0.65] | no evidence |
 | clustered HPWL | +0.26 [-0.22, +0.66] | no evidence |
-| clustered **macro-cone** HPWL | +0.39 [-0.01, +0.72] | just misses |
+| clustered **macro-cone** HPWL, 1 hop | +0.39 [-0.01, +0.72] | just misses |
+| clustered **macro-cone** HPWL, 2 hops | +0.42 [-0.02, +0.73] | still misses, 2.3x the cost |
 
 Cost, same population: clustered 14.7 s and 0.87 GB against the flat
 rung's 63.0 s and 2.43 GB. Agreement between the two on the same scalar:
@@ -73,6 +74,37 @@ readout at +0.39, best of the HPWL family and short of significance by
 so by restricting the sum to nets within reach of a macro pin -- i.e. by
 aiming the score at the structure the KPI actually reads.
 
+### That thread was pulled, and it does not lead anywhere
+
+The obvious next move is to widen the cone: if aiming the sum at
+macro-reachable nets bought +0.15 over full HPWL, aim it at more of
+them. So the whole population was re-scored at 2 hops.
+
+| | 1 hop | 2 hops |
+|---|---|---|
+| cone rho vs `macro_paths_mean` | +0.39 [-0.01, +0.72] | +0.42 [-0.02, +0.73] |
+| full clustered HPWL rho | +0.26 [-0.22, +0.66] | +0.32 [-0.13, +0.68] |
+| agreement with the flat rung | +0.66 [+0.34, +0.86] | +0.71 [+0.41, +0.89] |
+| instances held out of clusters | 1458 | 2380 |
+| nets in the cone | 2940 | 3923 |
+| `gpl` time | 14.7 s | 34.4 s |
+| cheaper than the flat rung by | 4.3x | 1.8x |
+
+The point estimate moves by +0.02 and the interval still straddles zero,
+so the second hop buys nothing that can be distinguished from noise --
+while the cost more than doubles, because holding 922 more instances out
+of the clusters is exactly what a coarsening rung must not do. At 2 hops
+the rung has spent most of its speed advantage over the flat scorer and
+bought no ranking with it.
+
+Read together, the two rows say the cone was never close: +0.39 and
++0.42 are the same number at n=23, and the +0.01 shortfall at 1 hop was
+a coincidence of where the interval fell, not a near miss to be closed
+by tuning. **The macro-cone readout is not an underpowered version of a
+working idea.** The remaining HPWL variants are the same scalar seen
+through slightly different windows, and none of them has demonstrable
+signal on this setup.
+
 ## Why the divergence was not a bug
 
 At the pre-registered default the clustered solve diverges on this
@@ -99,9 +131,12 @@ as exploratory rather than as a gate result.
 
 ## If someone picks this up
 
-1. **Chase the cone, not the clusters.** Re-score at wider hop counts and
-   with cone-only readouts. The truth is already measured, so each
-   variant costs minutes.
+1. **Do not chase the cone.** That was this document's recommendation
+   until the 2-hop re-score above was run; widening the cone costs 2.3x
+   and buys +0.02, inside noise. Any further HPWL window is the same
+   scalar reshaped, so a new rung has to leave the wirelength family --
+   and `placement_cluster`'s point-masses rule out STA on a clustered
+   placement, which is what makes this hard rather than merely unfinished.
 2. **Re-derive E3 before building on it.** Raw HPWL did not rank here
    (+0.24, interval spanning zero) against a published +0.67.
 3. **Do not reuse an archived score/truth pair to grade a re-run** unless

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -111,6 +111,39 @@ def _filter_stage_args(stage, **kwargs):
         **kwargs
     )
 
+def _orfs_estimate_report(name, src, variant = None, openroad = None, visibility = None):
+    """Emit the fast estimate report for a flow's floorplan stage.
+
+    Creates {name} (an orfs_run producing {name}.json): a deterministic,
+    ~seconds-to-a-minute estimate of what the floorplan can achieve --
+    estimated achievable clock period (pre-route optimistic; for
+    differential use where the uniform bias cancels), utilization,
+    place density vs its computed floor -- via a non-timing-driven,
+    early-stopped global placement in its own process. Runs parallel
+    to the place stage by DAG construction and cannot perturb flow
+    artifacts. Thesis, calibration and limits: docs/estimate.md.
+    """
+    run_kwargs = {}
+    if openroad != None:
+        run_kwargs["openroad"] = openroad
+    if visibility != None:
+        run_kwargs["visibility"] = visibility
+    orfs_run(
+        name = name,
+        src = src,
+        outs = [name + ".json"],
+        arguments = {
+            "OUTPUT": name + ".json",
+        },
+        script = "@bazel-orfs//:estimate.tcl",
+        stages = [
+            "floorplan",
+            "place",
+        ],
+        variant = variant or "base",
+        **run_kwargs
+    )
+
 def _orfs_html_report(name, src, variant = None, openroad = None, visibility = None):
     """Emit an HTML timing report plus a runnable opener for a single stage.
 
@@ -834,6 +867,14 @@ def _orfs_pass(
         sn = do_step(step, prev, kwargs, more_kwargs = more_kwargs)
         step_names.append(sn)
         create_deps_tar(sn, kwargs.get("visibility", None))
+        if step.stage == "floorplan" and not kwargs.get("lint"):
+            _orfs_estimate_report(
+                name = _step_name(name, variant, "estimate"),
+                src = sn,
+                variant = variant,
+                openroad = kwargs.get("openroad"),
+                visibility = kwargs.get("visibility"),
+            )
         if html and step.stage in _HTML_STAGES:
             _orfs_html_report(
                 name = sn + "_html",

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -23,6 +23,7 @@ load(
     "orfs_place_rule",
     "orfs_route_rule",
     "orfs_run",
+    "orfs_run_executable",
     "orfs_squashed",
     "orfs_synth_rule",
     "orfs_variables",
@@ -111,17 +112,22 @@ def _filter_stage_args(stage, **kwargs):
         **kwargs
     )
 
-def _orfs_estimate_report(name, src, variant = None, openroad = None, visibility = None):
-    """Emit the fast estimate report for a flow's floorplan stage.
+def _orfs_estimate_report(name, src, arguments = {}, sources = {}, variant = None, openroad = None, visibility = None):
+    """Emit the fast estimate oracle for a flow's synthesis output.
 
     Creates {name} (an orfs_run producing {name}.json): a deterministic,
-    ~seconds-to-a-minute estimate of what the floorplan can achieve --
-    estimated achievable clock period (pre-route optimistic; for
-    differential use where the uniform bias cancels), utilization,
-    place density vs its computed floor -- via a non-timing-driven,
-    early-stopped global placement in its own process. Runs parallel
-    to the place stage by DAG construction and cannot perturb flow
-    artifacts. Thesis, calibration and limits: docs/estimate.md.
+    ~one-to-two-minute estimate of what the design can achieve at a
+    given set of floorplan parameters -- the floorplan is built
+    in-script from the same variables the production stage reads, so
+    one estimate is one point in floorplan-parameter space. Also
+    creates {name}_run (an orfs_run_executable): the same script with
+    run-time KEY=VALUE parameter overrides, one Pareto point per
+    invocation. Estimated achievable clock period is pre-route
+    optimistic, for differential and ranking use where the bias
+    cancels. Parallel to the entire physical flow by DAG construction;
+    cannot perturb flow artifacts. Thesis, the division of labor with
+    ORFS's config.mk pin machinery, calibration and limits:
+    docs/estimate.md.
     """
     run_kwargs = {}
     if openroad != None:
@@ -132,11 +138,29 @@ def _orfs_estimate_report(name, src, variant = None, openroad = None, visibility
         name = name,
         src = src,
         outs = [name + ".json"],
-        arguments = {
+        arguments = arguments | {
             "OUTPUT": name + ".json",
         },
         script = "@bazel-orfs//:estimate.tcl",
+        sources = sources,
         stages = [
+            "synth",
+            "floorplan",
+            "place",
+        ],
+        variant = variant or "base",
+        **run_kwargs
+    )
+    orfs_run_executable(
+        name = name + "_run",
+        src = src,
+        arguments = arguments | {
+            "OUTPUT": name + ".json",
+        },
+        script = "@bazel-orfs//:estimate.tcl",
+        sources = sources,
+        stages = [
+            "synth",
             "floorplan",
             "place",
         ],
@@ -645,6 +669,16 @@ def _orfs_pass(
             )
         )
         create_deps_tar(step_name, kwargs.get("visibility", None))
+        if save_odb and not kwargs.get("lint"):
+            _orfs_estimate_report(
+                name = _step_name(name, variant, "estimate"),
+                src = step_name,
+                arguments = arguments,
+                sources = sources,
+                variant = variant,
+                openroad = kwargs.get("openroad"),
+                visibility = kwargs.get("visibility"),
+            )
         if html:
             _orfs_html_report(
                 name = step_name + "_html",
@@ -867,14 +901,6 @@ def _orfs_pass(
         sn = do_step(step, prev, kwargs, more_kwargs = more_kwargs)
         step_names.append(sn)
         create_deps_tar(sn, kwargs.get("visibility", None))
-        if step.stage == "floorplan" and not kwargs.get("lint"):
-            _orfs_estimate_report(
-                name = _step_name(name, variant, "estimate"),
-                src = sn,
-                variant = variant,
-                openroad = kwargs.get("openroad"),
-                visibility = kwargs.get("visibility"),
-            )
         if html and step.stage in _HTML_STAGES:
             _orfs_html_report(
                 name = sn + "_html",

--- a/test/BUILD
+++ b/test/BUILD
@@ -2143,3 +2143,13 @@ orfs_test(
     stages = ["floorplan"],
     yosys = "//mock/yosys/src/bin:yosys",
 )
+
+# The <flow>_estimate report (docs/estimate.md): generated for every
+# flow with a floorplan stage. Assert the JSON exists and carries the
+# fields the differential protocol reads.
+sh_test(
+    name = "lb_32x128_estimate_test",
+    srcs = ["estimate_test.sh"],
+    args = ["$(rootpath :lb_32x128_estimate.json)"],
+    data = [":lb_32x128_estimate.json"],
+)

--- a/test/estimate_test.sh
+++ b/test/estimate_test.sh
@@ -2,7 +2,7 @@
 set -eu
 json="$1"
 for field in clock_target est_achievable_raw wns utilization \
-    place_density density_floor gp_overflow_target runtime_s; do
+    place_density density_lb_addon gp_overflow_target; do
   grep -q "\"$field\"" "$json" || { echo "missing field: $field in $json"; cat "$json"; exit 1; }
 done
 echo "estimate json ok: $json"

--- a/test/estimate_test.sh
+++ b/test/estimate_test.sh
@@ -2,7 +2,8 @@
 set -eu
 json="$1"
 for field in clock_target est_achievable_raw wns utilization \
-    place_density density_lb_addon gp_overflow_target; do
+    num_macros macro_paths_mean macro_paths_sampled macros_pinned \
+    density_lb_addon gp_overflow_target params; do
   grep -q "\"$field\"" "$json" || { echo "missing field: $field in $json"; cat "$json"; exit 1; }
 done
 echo "estimate json ok: $json"

--- a/test/estimate_test.sh
+++ b/test/estimate_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu
+json="$1"
+for field in clock_target est_achievable_raw wns utilization \
+    place_density density_floor gp_overflow_target runtime_s; do
+  grep -q "\"$field\"" "$json" || { echo "missing field: $field in $json"; cat "$json"; exit 1; }
+done
+echo "estimate json ok: $json"


### PR DESCRIPTION
Every `orfs_flow()` that runs synthesis grows two targets:

- **`<name>[_variant]_estimate`** — a deterministic, one-to-two-minute estimate of what the design can achieve at its configured floorplan parameters, built **from the synthesis output**: floorplan initialized in-script from the same variables the production stage reads (both init modes), macros placed by the production placer when present, then a non-timing-driven global placement early-stopped at overflow 0.6.
- **`<name>[_variant]_estimate_run`** — the same script as a `bazelisk run` executable with run-time `KEY=VALUE` parameter overrides: **one point in floorplan-parameter space per invocation** (smoke: `CORE_UTILIZATION=10 PLACE_DENSITY=0.6` — floorplan rebuilt at the new point, echo reflects the override).

```sh
bazelisk run //test/smoketest:lb_32x128_asap7_estimate_run -- \
  CORE_UTILIZATION=10 PLACE_DENSITY=0.6 OUTPUT=$PWD/point.json LOG_DIR=$PWD/logs
```

**Division of labor**: this is the *oracle* half of floorplan-parameter automation. bazel-orfs computes points and recommendations — the JSON's `params` object carries the parameters in force under their **exact ORFS variable names**, so a chosen point is directly consumable by ORFS's config.mk pin machinery (`pinAutoFloorplan.py`, OpenROAD-flow-scripts#4487). bazel-orfs never writes config.mk. Constraints imported from that PR's measured negative results: utilization is constraint satisfaction, never blended into a period objective (ρ = −1.0 on gcd for the blend), and "did not resolve" keeps the incumbent.

**Properties**: parallel to the entire physical flow by DAG construction; cannot perturb flow artifacts; deterministic (an estimate delta between commits has no sampling noise of its own); content-addressed (the merge-base baseline for a PR diff is a cache hit; nightly builds are a trend line at ~1% of flow cost); pre-route optimistic **by design, for differential use** where the uniform bias cancels.

**Macro designs**: the JSON carries the macro-path channel (`macro_paths_mean/worst/sampled` — the KPI macro placement actually controls) and `macros_pinned`: unpinned estimate deltas on macro designs carry placement-draw variance; with `MACRO_PLACEMENT_TCL` set (stock ORFS) the draw is held constant and deltas are clean. Racing the pin is #868's business.

**Cadence — estimate always, audit as you can afford, pin occasionally**: the estimate is *purposely* sweep-free (it has no sampling noise to sweep away; the chaos lives in the macro draw and the stages it doesn't run). Pin machinery stores the estimate JSON at pin time — a **receipt** — and the always-on estimate's drift against the receipt is the measured re-pin signal (deltas reported, policy the consumer's, zero new code). And the honest audit economics: an explicit k-seed sweep of a large design is an adorable aspiration — the nightly build over evolving commits *is* the seed sweep, smeared across time; each point confounds improvement with a fresh draw, the trend averages over draws, large effects stand out regardless, and detrended residuals estimate the draw-noise floor for free. When audit compute is starved, the deterministic estimate delta is the only noise-free per-commit measurement in the system.

**`docs/estimate.md` is the thesis**: a flow result is a draw (Kahng & Mantik, ISQED 2002); honest comparison needs seed sweeps; the guided-random-walk model shows a fast imperfect gate plus an overnight seed-sweep audit reaches the PPA goal with orders of magnitude less gate compute; calibration provenance (measured vs pending — E14 backtest named); own-your-scoring-function guidance; stated limits (a speedometer, not a map).

This PR consolidates the *lessons* of the exploratory campaign work into one thesis; the doc's "Why the estimator is shaped this way" section gives the design rationale without the number-dump, and its "Provenance, trust, and breadcrumbs" section says plainly what a thesis owes and doesn't: the numbers were observed once on one machine with evolving instruments — **do not trust them, or the archived data, without re-measuring** — with pointers to where the evidence and its flaws live, so a proper follow-up study can be done right.

Tests: `lb_32x128_estimate_test` asserts the JSON contract; smokes on the smoketest designs. Pending before ready: capstone period-fidelity numbers into the calibration section, one macro-design smoke on the freed campaign machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)