### PR TITLE
fix(design): one helper for SYNTH_KEEP_MODULES, and reject the unsupported case

### DIFF
--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -14,6 +14,10 @@ load(
     "//private:flow.bzl",
     "orfs_flow",
 )
+load(
+    "//private:stages.bzl",
+    "keep_modules",
+)
 
 def _convert_sources(sources, pkg):
     """Convert absolute source labels to relative when in the current package.
@@ -227,12 +231,26 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
     # is identical across machines and remote cache hits are possible.  Users
     # who prefer local parallelism over caching can pass NUM_CPUS explicitly.
     if arguments.get("SYNTH_HIERARCHICAL") == "1":
+        kept = keep_modules(arguments)
+        if not kept:
+            fail(
+                ("%s sets SYNTH_HIERARCHICAL=1 with no SYNTH_KEEP_MODULES.\n" +
+                 "Parallel synthesis declares one per-module " +
+                 "re-canonicalization action per kept module, so the names " +
+                 "must be known at analysis time. Discovered inside a build " +
+                 "action they come too late: the partition actions are still " +
+                 "emitted, no per-module checkpoint exists to feed them, and " +
+                 "every partition fails with\n" +
+                 "  ERROR: per-module checkpoint missing: " +
+                 "partition_<Module>_canonical.rtlil\n" +
+                 "Pin the list in the design's config.mk; capture it with\n" +
+                 "  make DESIGN_CONFIG=<config.mk> SYNTH_KEEP_MODULES= " +
+                 "clean_synth synth\n" +
+                 "then read results/<platform>/<design>/base/" +
+                 "kept_modules.json.") % name,
+            )
         if "SYNTH_NUM_PARTITIONS" not in arguments:
-            keep_modules = arguments.get("SYNTH_KEEP_MODULES", "")
-            if keep_modules:
-                arguments["SYNTH_NUM_PARTITIONS"] = str(len(keep_modules.split()))
-            else:
-                arguments["SYNTH_NUM_PARTITIONS"] = "32"
+            arguments["SYNTH_NUM_PARTITIONS"] = str(len(kept))
 
     orfs_flow(
         name = name,

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -72,6 +72,7 @@ load(
     "STAGE_SUBSTEPS",
     "get_sources",
     "get_stage_args",
+    "keep_modules",
 )
 
 # --- Shared helpers ---
@@ -1357,7 +1358,7 @@ def _yosys_parallel_synth(ctx, config, canon_output, synth_outputs, synth_logs, 
 
     # Compute the kept-module list once so the per-module canonicalize
     # actions and the partition loop below agree on names and ordering.
-    kept_modules_list = [m for m in all_arguments.get("SYNTH_KEEP_MODULES", "").split(" ") if m]
+    kept_modules_list = keep_modules(all_arguments)
 
     # Actions 2c (one per kept module): re-canonicalize each kept module
     # into its own RTLIL slice. The slice has all other kept modules
@@ -2044,7 +2045,7 @@ def _yosys_impl(ctx):
     if num_partitions == 0 and all_arguments.get("SYNTH_KEEP_MODULES"):
         # SYNTH_KEEP_MODULES implies parallel synthesis; default to 1 partition
         # when NUM_CPUS-based auto-detection hasn't run (direct orfs_synth call).
-        kept_count = len(all_arguments["SYNTH_KEEP_MODULES"].split(" "))
+        kept_count = len(keep_modules(all_arguments))
         num_partitions = max(1, kept_count)
     if use_syn:
         # Parallel/hierarchical synthesis is a yosys-flow concept; the

--- a/private/stages.bzl
+++ b/private/stages.bzl
@@ -164,6 +164,23 @@ ALL_VARIABLE_TO_STAGES = {
     for variable in union(*ALL_STAGE_TO_VARIABLES.values())
 }
 
+def keep_modules(arguments):
+    """The kept-module names from SYNTH_KEEP_MODULES, as a list.
+
+    Parallel synthesis declares one per-module re-canonicalization action
+    per kept module, so bazel needs these names at analysis time; the
+    count also sets SYNTH_NUM_PARTITIONS.
+
+    The value arrives from a config.mk, where the list is usually spread
+    over backslash-continued lines and reaches us as a single string with
+    runs of spaces. Empty fields must therefore be dropped, or the count
+    is inflated by the separators. This helper exists because the same
+    string was being parsed three different ways -- correctly in one
+    place, miscounted in another, and with a bare split() (which Starlark
+    rejects, it requires a separator) in a third.
+    """
+    return [m for m in arguments.get("SYNTH_KEEP_MODULES", "").split(" ") if m]
+
 def check_variables(variables, label):
     """Checks that all variable names are known in ORFS variables.yaml.
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -7,6 +7,7 @@ load("//:openroad.bzl", "orfs_arguments", "orfs_floorplan", "orfs_flow", "orfs_g
 load("//:orfs_genrule.bzl", "orfs_genrule")
 load("//:sweep.bzl", "orfs_sweep")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
+load(":keep_modules_test.bzl", "keep_modules_test_suite")
 load(":provider_test_rule.bzl", "lib_pre_layout_test")
 load(":quick_pins_test_rule.bzl", "quick_pins_data_dep_test")
 load(":sdc_clock_period_test.bzl", "runfiles_contents_test", "synth_action_inputs_test")
@@ -622,6 +623,8 @@ source_input_propagation_test(
 )
 
 # Unit tests for the stage variable filtering helpers (stages.bzl).
+keep_modules_test_suite(name = "keep_modules_test")
+
 stages_filter_test_suite(name = "stages_filter_test")
 
 # Test SYNTH_KEEP_MODULES: skip keep-hierarchy discovery, go straight to

--- a/test/keep_modules_test.bzl
+++ b/test/keep_modules_test.bzl
@@ -1,0 +1,97 @@
+"""Unit tests for keep_modules() in private/stages.bzl.
+
+SYNTH_KEEP_MODULES arrives from a config.mk where the list is spread over
+backslash-continued lines, so the string reaches bazel with runs of
+spaces. Its length sets SYNTH_NUM_PARTITIONS and its entries decide which
+per-module re-canonicalization actions get declared, so a miscount is not
+cosmetic: too few partitions under-parallelises, and a bare split() is
+rejected outright by Starlark.
+
+Before this helper the same string was parsed three different ways in
+three places -- correctly once, miscounted once, and with a separator-less
+split() once. These tests pin the one behaviour.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//private:stages.bzl", "keep_modules")
+
+def _absent_is_empty_test(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, [], keep_modules({}))
+    asserts.equals(env, [], keep_modules({"SYNTH_KEEP_MODULES": ""}))
+    return unittest.end(env)
+
+def _single_module_test(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, ["dbg"], keep_modules({"SYNTH_KEEP_MODULES": "dbg"}))
+    return unittest.end(env)
+
+def _runs_of_spaces_do_not_inflate_the_count_test(ctx):
+    env = unittest.begin(ctx)
+
+    # What a backslash-continued config.mk list actually looks like once
+    # make has joined it: single names separated by runs of whitespace.
+    # A plain split(" ") yields empty fields here and overcounts.
+    value = "  exu   dec_ib_ctl    lsu_stbuf  "
+    asserts.equals(
+        env,
+        ["exu", "dec_ib_ctl", "lsu_stbuf"],
+        keep_modules({"SYNTH_KEEP_MODULES": value}),
+    )
+    asserts.equals(env, 3, len(keep_modules({"SYNTH_KEEP_MODULES": value})))
+    return unittest.end(env)
+
+def _order_is_preserved_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Partition assignment is positional, so the caller's order must
+    # survive: this helper must not sort.
+    asserts.equals(
+        env,
+        ["b", "a", "c"],
+        keep_modules({"SYNTH_KEEP_MODULES": "b a c"}),
+    )
+    return unittest.end(env)
+
+def _generated_names_survive_test(ctx):
+    env = unittest.begin(ctx)
+
+    # Chisel/yosys-generated module names carry characters the partition
+    # filename sanitiser rewrites; the list itself must keep them intact.
+    names = "Queue_41 data_arrays_0_ext DCacheModuleanon2 ram_2048x39"
+    asserts.equals(
+        env,
+        ["Queue_41", "data_arrays_0_ext", "DCacheModuleanon2", "ram_2048x39"],
+        keep_modules({"SYNTH_KEEP_MODULES": names}),
+    )
+    return unittest.end(env)
+
+def _other_arguments_are_ignored_test(ctx):
+    env = unittest.begin(ctx)
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "SYNTH_KEEP_MODULES": "exu dbg",
+        "CORE_UTILIZATION": "30",
+    }
+    asserts.equals(env, ["exu", "dbg"], keep_modules(arguments))
+    return unittest.end(env)
+
+absent_is_empty_test = unittest.make(_absent_is_empty_test)
+single_module_test = unittest.make(_single_module_test)
+runs_of_spaces_do_not_inflate_the_count_test = unittest.make(
+    _runs_of_spaces_do_not_inflate_the_count_test,
+)
+order_is_preserved_test = unittest.make(_order_is_preserved_test)
+generated_names_survive_test = unittest.make(_generated_names_survive_test)
+other_arguments_are_ignored_test = unittest.make(_other_arguments_are_ignored_test)
+
+def keep_modules_test_suite(name):
+    unittest.suite(
+        name,
+        absent_is_empty_test,
+        single_module_test,
+        runs_of_spaces_do_not_inflate_the_count_test,
+        order_is_preserved_test,
+        generated_names_survive_test,
+        other_arguments_are_ignored_test,
+    )


### PR DESCRIPTION
## The bug

`SYNTH_KEEP_MODULES` was parsed three different ways in three places, with three different behaviours:

| site | expression | behaviour |
|---|---|---|
| `rules.bzl:1360` | `[m for m in ...split(" ") if m]` | correct |
| `rules.bzl:2047` | `len(...split(" "))` | **miscounts** |
| `orfs_design.bzl:233` | `len(keep_modules.split())` | **crashes** |

The value comes from a `config.mk` where the list is spread over backslash-continued lines, so it arrives as one string with runs of spaces. Dropping the empty fields matters — the length sets `SYNTH_NUM_PARTITIONS`, so a miscount silently over-parallelises synthesis. And the third form is not valid Starlark at all (`split()` requires a separator), so **any design setting both `SYNTH_HIERARCHICAL=1` and `SYNTH_KEEP_MODULES` failed at analysis**:

```
Error in split: split() missing 1 required positional argument: sep
```

## The fix

Extract `keep_modules()` into `stages.bzl` beside the other stage-variable helpers, and use it in all three places.

Also **reject `SYNTH_HIERARCHICAL=1` with no `SYNTH_KEEP_MODULES`**, which cannot work: `rules.bzl` declares one per-module re-canonicalization action per kept module, so with no list it declares none — while `SYNTH_NUM_PARTITIONS` still defaulted to 32. Every partition then died with

```
ERROR: per-module checkpoint missing: partition_<Module>_canonical.rtlil
```

which says nothing about the cause. The names genuinely must be static: discovery runs inside a build action, far too late for bazel to declare actions from. Failing at analysis with the reason and the capture recipe turns an afternoon of archaeology into a sentence.

## Verification

`nangate45/tinyRocket` is the first design to exercise this path — before, all 32 partitions failed; after, with its list pinned, synthesis completes in **65 s**.

`test/keep_modules_test.bzl` pins the parsing behaviour (runs of spaces, order preservation since partition assignment is positional, generated module names like `Queue_41` / `DCacheModuleanon2`). **15/15 tests pass**, including the existing `stages_filter` suite.

Found while running a macro-placement experiment through bazel; details in [ORFS#4492](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4492).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
