### PR TITLE
lint: silence external-path in _tar_paths, where the layout is the subject

### DIFF
--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -76,6 +76,16 @@ load(
 
 # --- Shared helpers ---
 
+# buildifier: disable=external-path
+#
+# The external-path warning exists to catch code that reaches into another
+# repository's layout by hand, which is fragile. This function is the one
+# place where that layout is the subject rather than an assumption: it
+# builds a portable tar whose entries have to match bazel's own runfiles
+# layout, in which an external repo's files appear under
+# external/<repo>/. Spelling that prefix out is what makes the archive
+# loadable by a consumer using either short_path or path references, so
+# the literal is the contract, not a shortcut around one.
 def _tar_paths(f):
     """Map a file to its archive path(s).
 


### PR DESCRIPTION
## The noise

`bazelisk run //:fix_lint` prints two advisory warnings on every invocation, regardless of what changed:

```
private/rules.bzl:81: external-path: String contains "/external/" which may indicate a dependency on external repositories that could be fragile.
private/rules.bzl:91: external-path: ...
```

They don't fail CI — the check fails on the formatting diff, not on warnings — but persistent noise trains people to skip the lint output, which is exactly where a real warning would have to show up. (I hit this myself: I ran plain `buildifier` instead of `//:fix_lint` on a PR, missed a load-ordering fix, and CI caught it.)

## Why suppression rather than a rewrite

The `external-path` warning is aimed at code that reaches into another repository's layout by hand, which is fragile. `_tar_paths` is the one place where that layout is **the subject rather than an assumption**: it builds a portable tar whose entries have to match bazel's own runfiles layout, in which an external repo's files appear under `external/<repo>/`.

Spelling that prefix out is what makes the archive loadable by a consumer using either `short_path` or `path` references. The literal is the contract, not a shortcut around one — so rewriting it to dodge the linter would obscure what the function is for. The suppression carries that reasoning inline.

No behaviour change. After this, `//:fix_lint` runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
