### PR TITLE
fix(design): warn, don't fail, when SYNTH_KEEP_MODULES is missing

### DIFF
--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -236,24 +236,28 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
     if arguments.get("SYNTH_HIERARCHICAL") == "1":
         kept = keep_modules(arguments)
         if not kept:
-            fail(
-                ("%s sets SYNTH_HIERARCHICAL=1 with no SYNTH_KEEP_MODULES.\n" +
-                 "Parallel synthesis declares one per-module " +
-                 "re-canonicalization action per kept module, so the names " +
-                 "must be known at analysis time. Discovered inside a build " +
-                 "action they come too late: the partition actions are still " +
-                 "emitted, no per-module checkpoint exists to feed them, and " +
-                 "every partition fails with\n" +
-                 "  ERROR: per-module checkpoint missing: " +
-                 "partition_<Module>_canonical.rtlil\n" +
-                 "Pin the list in the design's config.mk; capture it with\n" +
-                 "  make DESIGN_CONFIG=<config.mk> SYNTH_KEEP_MODULES= " +
-                 "clean_synth synth\n" +
-                 "then read results/<platform>/<design>/base/" +
-                 "kept_modules.json.") % name,
-            )
+            # A warning, not a failure. These designs are already broken
+            # under bazel -- with no kept-module list rules.bzl declares no
+            # per-module re-canonicalization actions, while
+            # SYNTH_NUM_PARTITIONS below still asks for partitions, so every
+            # partition dies with "per-module checkpoint missing". But
+            # fail() here stops the design's whole package from LOADING,
+            # which is worse than the build failure it replaces: 20 designs
+            # in ORFS carry this combination today (ariane133, black_parrot,
+            # mempool_group, microwatt, riscv32i, minimal, ...), and taking
+            # them out at load time also takes out every other target in
+            # their packages and any //... pattern that has to parse them.
+            #
+            # Same reasoning as the dropped-VERILOG_FILES warning: report at
+            # the point the information exists, and let the build proceed as
+            # far as it can.
+            print("%s sets SYNTH_HIERARCHICAL=1 with no SYNTH_KEEP_MODULES, so parallel synthesis will fail with 'per-module checkpoint missing'. Parallel synthesis declares one per-module re-canonicalization action per kept module, so the names must be known at analysis time; discovered inside a build action they arrive too late. Pin the list in the design's config.mk -- capture it with `make DESIGN_CONFIG=<config.mk> SYNTH_KEEP_MODULES= clean_synth synth` and read results/<platform>/<design>/base/kept_modules.json." % name)  # buildifier: disable=print
+
         if "SYNTH_NUM_PARTITIONS" not in arguments:
-            arguments["SYNTH_NUM_PARTITIONS"] = str(len(kept))
+            # 32 preserves the pre-existing default for the no-list case;
+            # it does not work, but neither did failing, and this keeps the
+            # action graph identical to what it was before.
+            arguments["SYNTH_NUM_PARTITIONS"] = str(len(kept)) if kept else "32"
 
     orfs_flow(
         name = name,


### PR DESCRIPTION
Follow-up to #882 (`2b3e3a9`). **I got the blast radius wrong** — I reviewed that `fail()` against one design and shipped it; it applies to twenty.

## The problem

At the ORFS commit `MODULE.bazel` pins, these carry `SYNTH_HIERARCHICAL=1` with no `SYNTH_KEEP_MODULES`:

`asap7/aes-block` · `asap7/minimal` · `asap7/riscv32i` · `gf12/ariane` · `gf12/ariane133` · `gf12/bp_dual` · `gf12/bp_quad` · `gf12/swerv_wrapper` · `gf12/tinyRocket` · `gf180/uart-blocks` · `nangate45/ariane133` · `nangate45/ariane136` · `nangate45/black_parrot` · `nangate45/bp_be_top` · `nangate45/bp_fe_top` · `nangate45/bp_multi_top` · `nangate45/bp_quad` · `nangate45/mempool_group` · `nangate45/tinyRocket` · `sky130hd/microwatt`

Those designs *are* genuinely broken under bazel — the diagnosis in #882 was right. With no kept-module list, `rules.bzl` declares no per-module re-canonicalization actions while `SYNTH_NUM_PARTITIONS` still asks for partitions, so each dies with `per-module checkpoint missing`.

**But failing at analysis was the wrong response.** It stops each design's whole package from *loading*, which also takes out every other target in that package and any `//...` pattern that has to parse it. A build failure you can route around; a load failure you cannot.

## The irony

This is exactly the reasoning I gave in #883 for the dropped-`VERILOG_FILES` case — *"a warning rather than a hard failure on purpose: designs carrying such an entry are already broken under bazel, and failing here would stop their whole package from loading instead of letting the rest of the repo build"* — and then contradicted one PR later.

## What changes

`fail()` → `print()`, same message content. The `split()`/miscount fixes and the `keep_modules()` helper from #882 are untouched — those were the actual bug. `SYNTH_NUM_PARTITIONS` keeps its previous `32` default when the list is absent, so the action graph for those twenty designs is byte-identical to pre-#882.

6/6 `keep_modules` tests pass; `//:fix_lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
