### PR TITLE
fix(flow): keep user_stages out of orfs_update

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -882,6 +882,13 @@ def _orfs_pass(
             update_kwargs = dict(kwargs)
             update_kwargs.pop("substeps", None)
             update_kwargs.pop("lint", None)
+
+            # orfs_update takes only logs and rules_json. user_stages is a
+            # flow-level sidecar that was added after this pop list was
+            # written, so it reached the rule and every design with a
+            # RULES_JSON failed to load with
+            #   no such attribute 'user_stages' in 'orfs_update' rule
+            update_kwargs.pop("user_stages", None)
             orfs_update(
                 name = _step_name(name, variant, "update"),
                 rules_json = sources["RULES_JSON"][0],


### PR DESCRIPTION
## The bug

`orfs_update` takes exactly two attributes — `logs` and `rules_json` — but is called with the surrounding flow's kwargs. The pop list beside it already drops `substeps` and `lint`; **`user_stages` was added to the flow later without a matching pop**, so it reaches the rule:

```
ERROR: @orfs//flow/designs/asap7/gcd:gcd_update: no such attribute 'user_stages' in 'orfs_update' rule
ERROR: package contains errors: flow/designs/asap7/gcd
```

`orfs_design()` passes `user_stages` unconditionally — its default is `{}` — so this fires for **any design that goes through the design DSL and has a rules file**, whether or not it uses the feature. That's most of ORFS, and it's a *load*-time failure, so the package is unusable rather than just that target.

## Why it went unnoticed

It only bites when `@orfs` designs are built from a bazel-orfs workspace, which nothing did — partly because a second skew (ORFS passing a `blender` argument bazel-orfs had removed) failed even earlier in the same code path.

## Verification

Found while making `bazelisk run @orfs//flow/designs/asap7/gcd:gcd_final gui_final` work from bazel-orfs. With this fix:

```
$ bazelisk query '@orfs//flow/designs/asap7/gcd:all'
@orfs//flow/designs/asap7/gcd:gcd_final
@orfs//flow/designs/asap7/gcd:gcd_final_deps
@orfs//flow/designs/asap7/gcd:gcd_final_deps_tar
@orfs//flow/designs/asap7/gcd:gcd_test
@orfs//flow/designs/asap7/gcd:gcd_update
@orfs//flow/designs/asap7/gcd:gcd_update_rules
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
