### PR TITLE
fix(env): prefix WORK_HOME with external/<repo> for external designs

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -23,16 +23,36 @@ def sdc_arguments(ctx, short = False):
         return {"SDC_FILE": file_path(sdc, short)}
     return {}
 
+def work_home_relative(ctx):
+    """WORK_HOME relative to the root of a runfiles or deployed tree.
+
+    An external repository's files live under `external/<repo>/` in
+    bazel's exec root, in its runfiles layout, and in the tree deploy.tpl
+    lays out for `bazelisk run`. So a target in, say,
+    @orfs//flow/designs/asap7/gcd has to look for its results under
+    external/orfs+/flow/designs/asap7/gcd -- under the main repo's own
+    package path there is nothing of that design at all.
+
+    Args:
+      ctx: The rule context.
+
+    Returns:
+      A path string relative to the tree root, with no leading "./".
+    """
+    return "/".join([
+        part
+        for part in [_workspace_prefix(ctx), ctx.label.package]
+        if part
+    ])
+
 def _work_home(ctx):
     # For external repo targets, declared files are placed under
     # bin/external/<repo>/<package>, but genfiles_dir.path is just bin/.
     # Use the declared file path of a known output to derive the correct prefix.
     parts = [ctx.genfiles_dir.path]
-    if ctx.label.workspace_name:
-        parts.append("external")
-        parts.append(ctx.label.workspace_name)
-    if ctx.label.package:
-        parts.append(ctx.label.package)
+    rel = work_home_relative(ctx)
+    if rel:
+        parts.append(rel)
     return "/".join(parts)
 
 def orfs_environment(ctx):
@@ -383,7 +403,7 @@ def required_arguments(ctx):
         "GENERATE_ARTIFACTS_ON_FAILURE": "1",
         "PLATFORM": platform(ctx),
         "PLATFORM_DIR": platform_config(ctx).dirname,
-        "WORK_HOME": "./" + ctx.label.package,
+        "WORK_HOME": "./" + work_home_relative(ctx),
     }
 
 def orfs_additional_arguments(infos, short = False, use_pre_layout = False):

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -52,6 +52,7 @@ load(
     "source_inputs",
     "test_inputs",
     "verilog_arguments",
+    "work_home_relative",
     "write_stage_filter",
     "yosys_environment",
     "yosys_inputs",
@@ -805,13 +806,7 @@ def _test_impl(ctx):
     else:
         # For external repo targets, WORK_HOME must include the external/<repo>/
         # prefix so Make finds results/reports at the correct runfiles path.
-        if ctx.label.workspace_name:
-            parts = ["external", ctx.label.workspace_name]
-            if ctx.label.package:
-                parts.append(ctx.label.package)
-            work_home = "/".join(parts)
-        else:
-            work_home = None
+        work_home = work_home_relative(ctx) if ctx.label.workspace_name else None
 
         if hasattr(ctx.attr, "script") and ctx.file.script:
             script_inputs = [ctx.file.script]
@@ -974,14 +969,7 @@ def _run_executable_impl(ctx):
 
     # For external repo targets, WORK_HOME must include the external/<repo>/
     # prefix so Make finds results/reports at the correct runfiles path.
-    # Matches orfs_test's handling.
-    if ctx.label.workspace_name:
-        parts = ["external", ctx.label.workspace_name]
-        if ctx.label.package:
-            parts.append(ctx.label.package)
-        work_home = "/".join(parts)
-    else:
-        work_home = None
+    work_home = work_home_relative(ctx) if ctx.label.workspace_name else None
 
     tool_env = {
         "OPENROAD_EXE": ctx.executable.openroad.short_path,

--- a/test/BUILD
+++ b/test/BUILD
@@ -13,6 +13,7 @@ load(":quick_pins_test_rule.bzl", "quick_pins_data_dep_test")
 load(":sdc_clock_period_test.bzl", "runfiles_contents_test", "synth_action_inputs_test")
 load(":source_input_propagation_test.bzl", "source_input_propagation_test")
 load(":stages_filter_test.bzl", "stages_filter_test_suite")
+load(":work_home_test.bzl", "work_home_test_suite")
 
 exports_files(
     glob([
@@ -624,6 +625,8 @@ source_input_propagation_test(
 
 # Unit tests for the stage variable filtering helpers (stages.bzl).
 keep_modules_test_suite(name = "keep_modules_test")
+
+work_home_test_suite(name = "work_home_test")
 
 stages_filter_test_suite(name = "stages_filter_test")
 

--- a/test/work_home_test.bzl
+++ b/test/work_home_test.bzl
@@ -1,0 +1,96 @@
+"""Unit tests for work_home_relative() in private/environment.bzl.
+
+WORK_HOME tells ORFS's Makefile where RESULTS_DIR, LOG_DIR and
+OBJECTS_DIR live. It used to be built as `"./" + ctx.label.package`,
+which is right only for a design in the main repository. An external
+repository's files sit under `external/<repo>/` in the exec root, in
+bazel's runfiles layout, and in the tree deploy.tpl lays out for
+`bazelisk run` -- so for @orfs//flow/designs/asap7/gcd the unprefixed
+path pointed at a directory holding none of that design's results.
+
+The failure is quiet and confusing, because ORFS derives its interactive
+targets from a wildcard:
+
+    RESULTS_ODB = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.odb)))
+
+With WORK_HOME wrong the wildcard matches nothing, so `open_%`/`gui_%`
+are never even declared and make reports a missing *prerequisite*
+rather than a missing directory:
+
+    make: *** No rule to make target 'open_1_synth.odb',
+          needed by 'open_synth'.  Stop.
+
+Two other call sites already prefixed WORK_HOME by hand; these tests pin
+the one shared behaviour so the three cannot drift apart again.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//private:environment.bzl", "work_home_relative")
+
+def _ctx(workspace_name, package):
+    """A stand-in for a rule ctx: work_home_relative reads only the label."""
+    return struct(label = struct(
+        workspace_name = workspace_name,
+        package = package,
+    ))
+
+def _main_repo_is_unprefixed_test(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(
+        env,
+        "test",
+        work_home_relative(_ctx("", "test")),
+    )
+    return unittest.end(env)
+
+def _external_repo_is_prefixed_test(ctx):
+    env = unittest.begin(ctx)
+
+    # The case that motivated this: building an ORFS design from a
+    # bazel-orfs workspace.
+    asserts.equals(
+        env,
+        "external/orfs+/flow/designs/asap7/gcd",
+        work_home_relative(_ctx("orfs+", "flow/designs/asap7/gcd")),
+    )
+    return unittest.end(env)
+
+def _no_trailing_slash_when_package_is_empty_test(ctx):
+    env = unittest.begin(ctx)
+
+    # A design at the root of an external repo must not yield
+    # "external/orfs+/", which make would join into a doubled slash.
+    asserts.equals(env, "external/orfs+", work_home_relative(_ctx("orfs+", "")))
+    asserts.equals(env, "", work_home_relative(_ctx("", "")))
+    return unittest.end(env)
+
+def _canonical_repo_names_survive_test(ctx):
+    env = unittest.begin(ctx)
+
+    # bzlmod canonical names carry '+' (and '~' on older bazel); the
+    # prefix has to reproduce them verbatim, since that is the directory
+    # name bazel actually creates.
+    asserts.equals(
+        env,
+        "external/rules_foo+1.2.3/pkg",
+        work_home_relative(_ctx("rules_foo+1.2.3", "pkg")),
+    )
+    return unittest.end(env)
+
+main_repo_is_unprefixed_test = unittest.make(_main_repo_is_unprefixed_test)
+external_repo_is_prefixed_test = unittest.make(_external_repo_is_prefixed_test)
+no_trailing_slash_when_package_is_empty_test = unittest.make(
+    _no_trailing_slash_when_package_is_empty_test,
+)
+canonical_repo_names_survive_test = unittest.make(
+    _canonical_repo_names_survive_test,
+)
+
+def work_home_test_suite(name):
+    unittest.suite(
+        name,
+        main_repo_is_unprefixed_test,
+        external_repo_is_prefixed_test,
+        no_trailing_slash_when_package_is_empty_test,
+        canonical_repo_names_survive_test,
+    )


### PR DESCRIPTION
Found by running an ORFS design interactively from a bazel-orfs workspace:

```
$ bazelisk run @orfs//flow/designs/asap7/gcd:gcd_synth -- open_synth
...
make: *** No rule to make target 'open_1_synth.odb', needed by 'open_synth'.  Stop.
```

`required_arguments()` built `WORK_HOME` as `"./" + ctx.label.package`, correct only for a design in the main repository. An external repository's files live under `external/<repo>/` in bazel's exec root, in its runfiles layout, and in the tree `deploy.tpl` lays out for `bazelisk run` — so `@orfs//flow/designs/asap7/gcd` got `./flow/designs/asap7/gcd`, a path holding none of that design's results.

## Why the error names a prerequisite, not a directory

ORFS declares its interactive targets from a wildcard over the results directory (`scripts/variables.mk`):

```make
RESULTS_ODB = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.odb)))
```

and then `$(foreach file,$(RESULTS_ODB),$(eval $(call OPEN_GUI,$(file),ODB_FILE)))`. With `WORK_HOME` wrong the wildcard matches nothing at parse time, so `open_1_synth.odb` is never declared — while `open_synth` still exists, because `OPEN_GUI_SHORTCUT` is unconditional. Hence a missing *prerequisite* for a target that does exist, which reads like a bug in the shortcut rather than a wrong path.

`gui_synth` and `web_synth` fail the same way, for the same reason.

## The fix

`orfs_test` and `orfs_run_executable` had already hit this and each carried its own copy of the same six lines. All three now share one helper, expressed in terms of the `_workspace_prefix()` already in `environment.bzl`, so they cannot drift apart again — and `_work_home()` (the build-action variant) is folded onto it too.

The main-repository case is unchanged by construction: the prefix is empty there, leaving `"./" + package`.

## Verified

- `//test:work_home_test` — 4 tests; reverting either half of the fix fails 3 of them
- `//test:keep_modules_test` and the rest of the suite still pass
- `bazelisk build --nobuild --keep_going //...` — 1,004 targets analyzed, 0 errors
- `//:fix_lint` clean

## Note on scope

This is a prerequisite for building `@orfs` designs from here, but it's an independent bug on `main` and reviewable on its own — no dependency on #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)