### PR TITLE
feat(floorplan): derive a design's floorplan, and pin it into config.mk

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,8 +16,12 @@ exports_files([
     "orfs_design_builds.bzl",
     "record_orfs_builds.py",
     "run_executable.py",
+    "auto_floorplan.tcl",
+    "auto_floorplan_candidate.tcl",
+    "auto_floorplan_flow.tcl",
     "bump.py",
     "bump_impl.py",
+    "check_pareto.py",
     "compute_floorplan_shape.tcl",
     "compute_slack_margin.tcl",
     "config_mk_parser.py",
@@ -30,6 +34,7 @@ exports_files([
     "open_html.sh",
     "package_stage.py",
     "parallel_synth.mk",
+    "pin_auto_floorplan.py",
     "power.bzl",
     "power.tcl",
     "power_base.tcl",
@@ -268,4 +273,47 @@ compile_pip_requirements(
     name = "requirements_dev",
     src = "requirements_dev.in",
     requirements_txt = "requirements_dev_lock_3_13.txt",
+)
+
+# --- floorplan derivation ------------------------------------------------
+#
+# compute_floorplan_shape.tcl predicts CORE_UTILIZATION and CORE_MARGIN
+# from synth-stage area. This derives them instead, by running the
+# production flow per candidate floorplan and reading what it achieved.
+# The two are not rivals yet: the derivation is what can grade the
+# heuristic, per design, because it produces the flow's own answer on the
+# same ladder.
+
+py_binary(
+    name = "pin_auto_floorplan",
+    srcs = ["pin_auto_floorplan.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "pin_auto_floorplan_test",
+    srcs = ["pin_auto_floorplan_test.py"],
+    deps = [":pin_auto_floorplan"],
+)
+
+py_test(
+    name = "check_pareto_test",
+    srcs = ["check_pareto_test.py"],
+    data = ["check_pareto.py"],
+)
+
+# Fails if auto_floorplan_flow.tcl stops being flow.tcl's tail. flow.tcl
+# is read from the pinned @orfs archive so the comparison is against the
+# sequence that actually runs; see patches/0047.
+py_test(
+    name = "auto_floorplan_flow_test",
+    srcs = ["auto_floorplan_flow_test.py"],
+    data = [
+        "auto_floorplan_flow.tcl",
+        "@orfs//flow:scripts/flow.tcl",
+    ],
+    env = {
+        "AF_FLOW_TCL": "$(location auto_floorplan_flow.tcl)",
+        "ORFS_FLOW_TCL": "$(location @orfs//flow:scripts/flow.tcl)",
+    },
 )

--- a/auto_floorplan.tcl
+++ b/auto_floorplan.tcl
@@ -1,0 +1,658 @@
+# Floorplan derivation: measure the floorplan shape instead of guessing it.
+#
+# Run by <name>_auto_floorplan_data, off a design's synthesised netlist.
+# Races candidate outlines and densities, each evaluated by running the
+# production flow to finish, and writes the winner and every candidate to
+# $AF_EVIDENCE. <name>_auto_floorplan_pin turns that into config.mk
+# values. Nothing here runs during an ordinary build.
+#
+# WHAT IS BEING RETIRED
+#
+# CORE_UTILIZATION (or DIE_AREA/CORE_AREA), CORE_ASPECT_RATIO and
+# PLACE_DENSITY (or PLACE_DENSITY_LB_ADDON) are the last hand-carried
+# numbers in a config.mk. Each is a human prediction of downstream
+# behaviour standing where a measurement should be: the right utilization
+# is "the smallest core in which this netlist still closes", which is a
+# question about repair_design, CTS and routing -- none of which have
+# happened when the number is read.
+#
+# THE ORACLE IS THE FLOW
+#
+# An earlier version scored candidates with a fast pre-route proxy. It
+# does not rank the utilization axis: measured against the finished flow
+# over a utilization ladder, rho = -1.000 on gcd (perfectly inverted) and
+# +0.100 on gcd-ccs -- the two designs whose noise floor is small enough
+# for the question to have an answer. So each candidate runs the real
+# flow and reports what it achieved. That is expensive, and it is why
+# this is a job you run rather than something the flow does.
+#
+# Every ladder is a dimensionless fraction. There is no per-design
+# constant anywhere in this file.
+
+proc af_env { name { default "" } } {
+  if { [info exists ::env($name)] && $::env($name) ne "" } {
+    return $::env($name)
+  }
+  return $default
+}
+
+proc af_log { msg } {
+  puts "AUTO_FLOORPLAN: $msg"
+}
+
+# Fractions of the incumbent utilization. Above 1.0 is a smaller core;
+# one point below is kept so the walk can report that loosening was
+# better rather than only ever being able to tighten.
+set ::af_util_ladder [af_env AF_UTIL_LADDER {0.9 1.0 1.1 1.2 1.3 1.4}]
+
+# Fractions of the headroom above the measured density lower bound. This
+# is exactly what PLACE_DENSITY_LB_ADDON means; the ladder makes it
+# measured instead of guessed.
+set ::af_addon_ladder [af_env AF_ADDON_LADDER {0.00 0.05 0.10 0.15 0.20}]
+
+# Aspect ratios to try at the winning area point. Often a tie, which is a
+# result: the folklore value gets graded rather than assumed.
+set ::af_aspect_ladder [af_env AF_ASPECT_LADDER {0.8 1.0 1.25}]
+
+# Placer seeds for the noise floor. Eight rather than three: the range of
+# a small sample is a poor estimator of spread, biased low and with an
+# expectation that grows with n, so a range-based floor would move every
+# threshold purely by changing the seed count. These run concurrently.
+set ::af_tie_seeds [af_env AF_TIE_SEEDS {1 2 3 4 5 6 7 8}]
+
+# The exchange rate between area and period: one percent of achieved
+# period is worth this many percent of core area. A product decision --
+# how much silicon a percent of speed is worth -- not a tuning constant,
+# which is why it is a rate and not a threshold.
+#
+# Validated once against an asap7 sweep rather than searched per design:
+# lambda = 3 rejects the trades that gave up a lot of period for little
+# area (ethmac +13.4% period for -16.7% area, aes +5.6% for -8.7%) and
+# accepts every win and every cheap trade (gcd-ccs +0.78% for -24.2%,
+# mock-alu +0.92% for -28.8%, aes_lvt +1.37% for -28.5%). Every verdict
+# is unchanged for lambda in [2, 5], so this is the shape of a policy
+# rather than a fitted number.
+set ::af_lambda [af_env AF_LAMBDA 3.0]
+
+# Width of the handover around the target period, as a fraction of the
+# clock. Verdicts unchanged for tau in [0.01, 0.10].
+set ::af_tau_frac [af_env AF_TAU_FRAC 0.02]
+
+# ---------------------------------------------------------------------
+# The objective
+# ---------------------------------------------------------------------
+
+# ln(1 + e^x), computed so neither tail overflows.
+proc af_softplus { x } {
+  if { $x > 0 } {
+    return [expr { $x + log(1.0 + exp(-$x)) }]
+  }
+  return [expr { log(1.0 + exp($x)) }]
+}
+
+# What the derivation minimises:
+#
+#   P_eff = T + tau * ln(1 + e^((p - T)/tau))
+#   J     = ln(area) + lambda * ln(P_eff)
+#
+# P_eff is a smooth one-sided penalty: it tracks the achieved period p
+# when the design is slower than its target T and flattens to T when it
+# is faster. Speed beyond what the SDC asked for has no value, so area
+# spent buying it is never repaid; a design short of target pays the full
+# exchange rate for every percent it gives up.
+#
+# There is no regime switch to get wrong. The same expression minimises
+# area down to the target on a design that closes -- the period term goes
+# flat, leaving ln(area) -- and trades period against area on one that
+# does not. The derivative says it plainly:
+#
+#   dA/A = -lambda * sigma((p - T)/tau) * dp/P_eff
+#
+# The effective rate is lambda*sigma, scaling itself down as the design
+# gets comfortably faster than target. A hard max(p, T) gives identical
+# verdicts on every design measured, but its kink treats two candidates
+# either side of the target very differently on a noisy measurement; the
+# softplus removes that cliff for free.
+proc af_objective { area period target } {
+  if { $area <= 0 || $target <= 0 } {
+    return 1e30
+  }
+  set tau [expr { $::af_tau_frac * $target }]
+  set p_eff [expr { $target + $tau * [af_softplus [expr { ($period - $target) / $tau }]] }]
+  return [expr { log($area) + $::af_lambda * log($p_eff) }]
+}
+
+proc af_period { r } {
+  return [dict get $r achieved]
+}
+
+# How much J a period difference of delta_tie could account for on its
+# own, at a given operating point. Used as hysteresis: a winner must beat
+# the incumbent by more than the noise could have produced.
+#
+# Area is exact -- the same coordinates give the same core every time --
+# so only the period term carries noise, and this converts the measured
+# period floor into the J units the comparison is made in.
+proc af_objective_tie { r target delta_tie } {
+  set p [af_period $r]
+  set a [dict get $r core_um2]
+  return [expr {
+    abs([af_objective $a [expr { $p + $delta_tie }] $target] -
+      [af_objective $a $p $target])
+  }]
+}
+
+proc af_select_objective { results target } {
+  set best ""
+  set best_j 0
+  foreach r $results {
+    set j [af_objective [dict get $r core_um2] [af_period $r] $target]
+    if { $best eq "" || $j < $best_j } {
+      set best $r
+      set best_j $j
+    }
+  }
+  return $best
+}
+
+# ---------------------------------------------------------------------
+# Running candidates
+# ---------------------------------------------------------------------
+
+proc af_shell_quote { s } {
+  return "'[string map {' '\\''} $s]'"
+}
+
+# A candidate expresses its density in exactly one of the two forms the
+# flow supports: a raced headroom fraction (addon), or a fixed
+# PLACE_DENSITY. The second form exists so the incumbent can be run as
+# the design actually is -- see af_incumbent_density.
+proc af_cand { tag util aspect margin addon seed { density "" } } {
+  return [dict create tag $tag util [format %.4g $util] aspect $aspect \
+    margin $margin addon $addon seed $seed density_fixed $density]
+}
+
+# The candidate writes a Tcl dict, so reading it is a validity check.
+proc af_parse_result { text } {
+  set text [string trim $text]
+  if { [catch { dict size $text }] } {
+    return ""
+  }
+  if { ![dict exists $text ok] } {
+    return ""
+  }
+  if { ![dict exists $text reason] } {
+    dict set text reason ""
+  }
+  return $text
+}
+
+# Echo the tail of a failed candidate's log. Its own log lives in a
+# scratch dir a sandboxed build discards, so without this a bare "it
+# failed" would be undebuggable.
+proc af_log_tail { path n } {
+  if { ![file exists $path] } {
+    af_log "  (no log at $path)"
+    return
+  }
+  set fh [open $path r]
+  set lines [split [string trimright [read $fh]] "\n"]
+  close $fh
+  set start [expr { [llength $lines] - $n }]
+  if { $start < 0 } {
+    set start 0
+  }
+  foreach line [lrange $lines $start end] {
+    puts "  | $line"
+  }
+}
+
+# Run candidates as parallel subprocesses, bounded by AF_JOBS.
+#
+# The fan-out is deliberately ours and not the build system's: bazel
+# provisions roughly one core per action, so expressing each candidate as
+# its own target would overprovision by the thread count of every
+# concurrent flow. One action, explicit pool. Note that building several
+# designs' data targets at once multiplies AF_JOBS by bazel's --jobs.
+# These three scripts ship together from bazel-orfs, while SCRIPTS_DIR
+# points at ORFS's flow/scripts -- so the driver cannot find its siblings
+# the way it did when all three lived there. The build passes their
+# locations; the SCRIPTS_DIR fallback keeps a plain `make` invocation
+# working, where they are copied in beside the stage scripts.
+proc af_candidate_tcl { } {
+  return [af_env AF_CANDIDATE_TCL \
+    [file join $::env(SCRIPTS_DIR) auto_floorplan_candidate.tcl]]
+}
+
+proc af_flow_tcl { } {
+  return [af_env AF_FLOW_TCL \
+    [file join $::env(SCRIPTS_DIR) auto_floorplan_flow.tcl]]
+}
+
+proc af_run_batch { cands work } {
+  set jobs [af_env AF_JOBS 2]
+  af_log "running [llength $cands] candidates, $jobs at a time"
+
+  set pending $cands
+  set running {}
+  set results {}
+
+  while { [llength $pending] > 0 || [llength $running] > 0 } {
+    while { [llength $pending] > 0 && [llength $running] < $jobs } {
+      set c [lindex $pending 0]
+      set pending [lrange $pending 1 end]
+      set tag [dict get $c tag]
+      set result [file join $work "$tag.rec"]
+      set done [file join $work "$tag.done"]
+      file delete -force $result $done
+
+      set assigns {}
+      foreach { k v } [list \
+        AF_UTIL [dict get $c util] \
+        AF_ASPECT [dict get $c aspect] \
+        AF_MARGIN [dict get $c margin] \
+        AF_ADDON [dict get $c addon] \
+        AF_DENSITY [dict get $c density_fixed] \
+        AF_SEED [dict get $c seed] \
+        AF_WORK [file join $work $tag] \
+        AF_RESULT $result \
+        AF_FLOW_TCL [af_flow_tcl] \
+        AF_SRC_RESULTS $::env(RESULTS_DIR)] {
+        lappend assigns "$k=[af_shell_quote $v]"
+      }
+      # A wrapper shell so a crashed candidate still records a status:
+      # the driver must tell "eliminated" from "still running" without a
+      # timeout heuristic.
+      set cmd "[join $assigns { }] \
+[af_shell_quote $::env(OPENROAD_EXE)] -no_init -exit \
+[af_shell_quote [af_candidate_tcl]] \
+> [af_shell_quote $work/$tag.log] 2>&1; echo \$? > [af_shell_quote $done]"
+      exec sh -c $cmd &
+      lappend running [list $tag $result $done]
+    }
+
+    # Candidates are minutes long, so a coarse poll costs nothing.
+    after 1000
+    set still {}
+    foreach r $running {
+      lassign $r tag result done
+      if { ![file exists $done] } {
+        lappend still $r
+        continue
+      }
+      set fh [open $done r]
+      set rc [string trim [read $fh]]
+      close $fh
+      if { $rc ne "0" || ![file exists $result] } {
+        af_log "candidate $tag eliminated (exit $rc); last lines of its log:"
+        af_log_tail [file join $work "$tag.log"] 15
+        continue
+      }
+      set fh [open $result r]
+      set d [af_parse_result [read $fh]]
+      close $fh
+      if { $d eq "" } {
+        af_log "candidate $tag eliminated (unparseable record)"
+        continue
+      }
+      dict set d tag $tag
+      if { ![dict get $d ok] } {
+        af_log "candidate $tag eliminated ([dict get $d reason])"
+        continue
+      }
+      lappend results $d
+    }
+    set running $still
+  }
+  return $results
+}
+
+# A floorplan that routes with violations is not a cheaper floorplan.
+# This is a hard filter and not a term in the objective: no amount of
+# area buys past it.
+proc af_survivors { results } {
+  set out {}
+  foreach r $results {
+    if { [dict get $r drc] > 0 } {
+      af_log "candidate [dict get $r tag] eliminated:\
+ [dict get $r drc] DRC violations"
+      continue
+    }
+    lappend out $r
+  }
+  return $out
+}
+
+# The design's own noise floor, from re-running one candidate under
+# different placer seeds. Measured, never chosen: a threshold from
+# anywhere else would let the derivation be rewarded for predicting
+# noise. Two standard deviations rather than the range, so it does not
+# grow with the seed count.
+proc af_measure_delta_tie { winner work } {
+  set cands {}
+  foreach seed [lrange $::af_tie_seeds 1 end] {
+    lappend cands [af_cand "tie_s$seed" [dict get $winner util] \
+      [dict get $winner aspect] [dict get $winner margin] \
+      [dict get $winner addon] $seed]
+  }
+  set periods [list [af_period $winner]]
+  foreach r [af_run_batch $cands $work] {
+    lappend periods [af_period $r]
+  }
+  set n [llength $periods]
+  if { $n < 2 } {
+    af_log "noise floor could not be measured (n=$n); treating every\
+ difference as real"
+    return [list 0.0 $n]
+  }
+  set sum 0.0
+  foreach p $periods {
+    set sum [expr { $sum + $p }]
+  }
+  set mean [expr { $sum / $n }]
+  set ss 0.0
+  foreach p $periods {
+    set ss [expr { $ss + ($p - $mean) * ($p - $mean) }]
+  }
+  set spread [expr { 2.0 * sqrt($ss / ($n - 1)) }]
+  set clk [dict get $winner clock_period]
+  af_log "noise floor over $n seeds: 2 sigma = [format %.4g $spread]\
+ ([format %.2f [expr { $clk > 0 ? 100.0 * $spread / $clk : -1 }]]% of the\
+ clock period)"
+  return [list $spread $n]
+}
+
+# ---------------------------------------------------------------------
+# The incumbent
+# ---------------------------------------------------------------------
+
+# The utilization the design uses today. A design that states an explicit
+# rectangle gets an equivalent derived from it, so every design enters
+# the walk with its own configuration as a candidate regardless of form.
+proc af_incumbent_util { } {
+  if { [env_var_exists_and_non_empty CORE_UTILIZATION] } {
+    return $::env(CORE_UTILIZATION)
+  }
+  if { [env_var_exists_and_non_empty CORE_AREA] } {
+    lassign $::env(CORE_AREA) x1 y1 x2 y2
+    set core_um2 [expr { ($x2 - $x1) * ($y2 - $y1) }]
+    set blk [ord::get_db_block]
+    set dbu [$blk getDbUnitsPerMicron]
+    set scale [expr { double($dbu) * double($dbu) }]
+    set cell_um2 0.0
+    foreach inst [$blk getInsts] {
+      set m [$inst getMaster]
+      if { [$m isBlock] || [$m isCore] } {
+        set cell_um2 [expr {
+          $cell_um2 + [$m getWidth] * double([$m getHeight]) / $scale
+        }]
+      }
+    }
+    if { $core_um2 > 0 && $cell_um2 > 0 } {
+      return [expr { 100.0 * $cell_um2 / $core_um2 }]
+    }
+  }
+  return 50.0
+}
+
+proc af_incumbent_aspect { } {
+  return [af_env CORE_ASPECT_RATIO 1.0]
+}
+
+proc af_incumbent_margin { } {
+  return [af_env CORE_MARGIN 1.0]
+}
+
+proc af_incumbent_addon { } {
+  return [af_env PLACE_DENSITY_LB_ADDON ""]
+}
+
+# The density the design actually runs at when it states one directly.
+# Only meaningful when there is no incumbent addon: PLACE_DENSITY_LB_ADDON
+# overrides PLACE_DENSITY rather than adding to it, so a design that sets
+# both is already expressing the addon form.
+proc af_incumbent_density { } {
+  if { [af_incumbent_addon] ne "" } {
+    return ""
+  }
+  return [af_env PLACE_DENSITY ""]
+}
+
+# ---------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------
+
+proc af_dict_get_or { d key default } {
+  if { [dict exists $d $key] } {
+    return [dict get $d $key]
+  }
+  return $default
+}
+
+# Write one JSON object to a channel, field by field.
+#
+# Deliberately not built as one Tcl string and printed: a long line
+# assembled with lappend + join came back with fragments of itself
+# spliced in under OpenROAD's Tcl once the record grew past a few hundred
+# characters. Short writes are unaffected.
+proc af_json_obj_to { fh pairs } {
+  puts -nonewline $fh "{"
+  set first 1
+  foreach { k v } $pairs {
+    if { $v eq "" } {
+      set v "null"
+    } elseif { [string is double -strict $v] } {
+      set v [format %.10g $v]
+    }
+    if { !$first } {
+      puts -nonewline $fh ", "
+    }
+    set first 0
+    puts -nonewline $fh "\"$k\": $v"
+  }
+  puts -nonewline $fh "}"
+}
+
+# Every candidate, what it achieved, why it was eliminated if it was, the
+# measured noise floor, and the winner. A verdict without its evidence is
+# an assertion.
+proc af_write_evidence { path phases winner delta_tie tie_n incumbent } {
+  set fields {
+    util aspect margin density addon seed clock_period wns achieved
+    core_um2 stdcell_um2 macro_um2 drc total_ms
+  }
+  set fh [open $path w]
+  puts $fh "{"
+  puts $fh "  \"design\": \"$::env(DESIGN_NAME)\","
+  puts $fh "  \"platform\": \"$::env(PLATFORM)\","
+  puts $fh "  \"oracle\": \"production flow, floorplan to finish, per candidate\","
+  puts $fh "  \"search\": \"coordinate descent: utilization, then density, then aspect\","
+  puts $fh "  \"lambda\": $::af_lambda,"
+  puts $fh "  \"tau_frac\": $::af_tau_frac,"
+  puts $fh "  \"delta_tie\": [format %.10g $delta_tie],"
+  puts $fh "  \"delta_tie_n\": $tie_n,"
+  puts -nonewline $fh "  \"incumbent\": "
+  af_json_obj_to $fh [list \
+    util [dict get $incumbent util] \
+    aspect [dict get $incumbent aspect] \
+    addon [dict get $incumbent addon]]
+  puts $fh ","
+  puts -nonewline $fh "  \"winner\": "
+  if { $winner eq "" } {
+    puts -nonewline $fh "null"
+  } else {
+    set wp [list tag "\"[dict get $winner tag]\""]
+    foreach f { util aspect margin density addon achieved clock_period core_um2 drc } {
+      lappend wp $f [af_dict_get_or $winner $f -1]
+    }
+    foreach f { die_rect core_rect } {
+      if { [dict exists $winner $f] } {
+        lappend wp $f "\"[dict get $winner $f]\""
+      }
+    }
+    af_json_obj_to $fh $wp
+  }
+  puts $fh ","
+  puts $fh "  \"candidates\": \["
+  set first 1
+  foreach ph $phases {
+    lassign $ph name results
+    foreach r $results {
+      if { !$first } {
+        puts $fh ","
+      }
+      set first 0
+      set pairs [list phase "\"$name\"" tag "\"[dict get $r tag]\""]
+      foreach f $fields {
+        lappend pairs $f [af_dict_get_or $r $f -1]
+      }
+      puts -nonewline $fh "    "
+      af_json_obj_to $fh $pairs
+    }
+  }
+  puts $fh ""
+  puts $fh "  \]"
+  puts $fh "}"
+  close $fh
+}
+
+# ---------------------------------------------------------------------
+# The walk
+# ---------------------------------------------------------------------
+
+proc af_run { } {
+  # A die that is a constraint is not a choice: a DEF-initialised
+  # floorplan or an ICeWall footprint describes a package and pad ring,
+  # and deriving the outline underneath it would be meaningless.
+  if {
+    [env_var_exists_and_non_empty FLOORPLAN_DEF] ||
+    [env_var_exists_and_non_empty FOOTPRINT]
+  } {
+    af_log "FLOORPLAN_DEF/FOOTPRINT set: the die is a constraint, not derived"
+    return 0
+  }
+
+  set work [af_env AF_WORK_DIR [file join $::env(OBJECTS_DIR) auto_floorplan]]
+  file mkdir $work
+  set evidence $::env(AF_EVIDENCE)
+
+  set u0 [af_incumbent_util]
+  set a0 [af_incumbent_aspect]
+  set m0 [af_incumbent_margin]
+  set addon0 [af_incumbent_addon]
+  set incumbent [dict create util $u0 aspect $a0 \
+    addon [expr { $addon0 eq "" ? -1 : $addon0 }]]
+  af_log "incumbent: utilization $u0, aspect $a0, margin $m0, addon\
+ [expr { $addon0 eq "" ? "(fixed PLACE_DENSITY)" : $addon0 }]"
+
+  # What the utilization phase holds constant while it moves the core.
+  #
+  # A design stating a fixed PLACE_DENSITY has no incumbent headroom
+  # fraction. Substituting a ladder rung for it -- which this used to do --
+  # means the phase's 1.0 rung is not the incumbent at all but the design
+  # at a density it has never run, so the hysteresis guard compares the
+  # winner against a floorplan that does not exist. On aes_lvt that
+  # strawman read 9.3 ps pessimistic and accounted for most of an
+  # apparent win that the production flow scored as a lost closure.
+  #
+  # So hold the design's own density, in the design's own form. The
+  # density phase then races the addon from the winning area point.
+  set hold_density [af_incumbent_density]
+  set hold_addon [expr { $addon0 eq "" ? 0.0 : $addon0 }]
+
+  # --- utilization ------------------------------------------------------
+  set cands {}
+  foreach f $::af_util_ladder {
+    set u [expr { $u0 * $f }]
+    if { $u >= 100.0 } {
+      continue
+    }
+    lappend cands [af_cand "u[string map {. p} $f]" $u $a0 $m0 $hold_addon \
+      1 $hold_density]
+  }
+  set r_util [af_survivors [af_run_batch $cands $work]]
+  if { [llength $r_util] == 0 } {
+    af_log "no utilization candidate survived; nothing to derive"
+    af_write_evidence $evidence [list [list utilization {}]] "" 0.0 0 $incumbent
+    return 0
+  }
+
+  set inc_cand ""
+  foreach r $r_util {
+    if { [dict get $r util] == [format %.4g $u0] } {
+      set inc_cand $r
+      break
+    }
+  }
+  if { $inc_cand eq "" } {
+    set inc_cand [lindex $r_util 0]
+  }
+  set target [dict get $inc_cand clock_period]
+
+  lassign [af_measure_delta_tie $inc_cand $work] delta_tie tie_n
+  set w [af_select_objective $r_util $target]
+  af_log "utilization phase: [dict get $w util] minimises the objective\
+ ([format %.4g [dict get $w core_um2]] um2, achieved\
+ [format %.4g [af_period $w]]; incumbent\
+ [format %.4g [dict get $inc_cand core_um2]] um2, achieved\
+ [format %.4g [af_period $inc_cand]])"
+
+  # --- density ----------------------------------------------------------
+  set cands {}
+  foreach f $::af_addon_ladder {
+    lappend cands [af_cand "d[string map {. p} $f]" [dict get $w util] \
+      $a0 $m0 $f 1]
+  }
+  set r_dens [af_survivors [af_run_batch $cands $work]]
+
+  # --- aspect, at the winning area and density --------------------------
+  set best_addon [dict get [af_select_objective \
+    [concat [list $w] $r_dens] $target] addon]
+  set cands {}
+  foreach ar $::af_aspect_ladder {
+    if { $ar == $a0 } {
+      continue
+    }
+    lappend cands [af_cand "a[string map {. p} $ar]" [dict get $w util] \
+      $ar $m0 $best_addon 1]
+  }
+  set r_asp [af_survivors [af_run_batch $cands $work]]
+
+  # --- select -----------------------------------------------------------
+  set all [concat $r_util $r_dens $r_asp]
+  set winner [af_select_objective $all $target]
+
+  # Hysteresis, in the units the decision is made in. A winner must beat
+  # the incumbent by more J than the measured period noise could have
+  # produced on its own; otherwise the design keeps what it has and the
+  # derivation reports a tie rather than churning a config.mk on noise.
+  set j_win [af_objective [dict get $winner core_um2] [af_period $winner] $target]
+  set j_inc [af_objective [dict get $inc_cand core_um2] \
+    [af_period $inc_cand] $target]
+  set j_tie [af_objective_tie $inc_cand $target $delta_tie]
+  af_log "objective: winner J [format %.5f $j_win], incumbent J\
+ [format %.5f $j_inc], noise could account for [format %.5f $j_tie]"
+  if { $j_win > $j_inc - $j_tie } {
+    af_log "the winner does not beat the incumbent by more than the noise\
+ floor could account for; keeping the incumbent"
+    set winner $inc_cand
+  }
+
+  af_write_evidence $evidence \
+    [list [list utilization $r_util] [list density $r_dens] \
+      [list aspect $r_asp]] \
+    $winner $delta_tie $tie_n $incumbent
+
+  af_log "winner [dict get $winner tag]: utilization [dict get $winner util],\
+ aspect [dict get $winner aspect], density\
+ [format %.4g [dict get $winner density]], core\
+ [format %.4g [dict get $winner core_um2]] um2, achieved\
+ [format %.4g [af_period $winner]] against a target of [format %.4g $target]"
+  af_log "evidence written to $evidence"
+  return 1
+}
+
+# Entry point when run as an orfs_run script.
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_synth.odb 1_synth.sdc
+af_run

--- a/auto_floorplan_candidate.tcl
+++ b/auto_floorplan_candidate.tcl
@@ -1,0 +1,216 @@
+# One floorplan candidate: the production flow, floorplan to finish, run
+# against one set of floorplan coordinates in its own OpenROAD process.
+#
+# Launched by auto_floorplan.tcl with the derivation's environment plus
+# the AF_* overrides below. Writes a Tcl dict to $AF_RESULT and exits 0;
+# a failure of the flow is recorded as an eliminated candidate rather
+# than a crash, because a floorplan that cannot be built is a legitimate
+# answer about that floorplan.
+#
+# THE ORACLE IS THE FLOW
+#
+# An earlier version scored candidates with a fast pre-route proxy --
+# global placement plus a sampled-path timing readout. Measured against
+# the finished flow over a utilization ladder, that proxy did not rank:
+# rho = -1.000 on gcd (perfectly inverted) and +0.100 on gcd-ccs, the two
+# designs whose noise floor is small enough for the question to have an
+# answer. So the derivation asks the flow itself and pays for it, which
+# is what ideas/auto-floorplan.md meant by "the race is the oracle inside
+# a utilization shmoo".
+#
+# Why a subprocess per candidate rather than fork or an in-process loop:
+#   - rtl_macro_placer is not re-entrant in a single process
+#     (OpenROAD#11277), and every candidate re-places the macros.
+#   - the parent's database stays untouched.
+#   - candidates are embarrassingly parallel, and the driver bounds how
+#     many run at once. Bazel would provision one core per action, so the
+#     fan-out is ours to control rather than the build system's.
+#
+# Synthesis is shared: every candidate starts from the same 1_synth.odb,
+# staged below. Re-running it per candidate would be the most expensive
+# part of the walk and would measure nothing.
+#
+# Inputs (environment):
+#   AF_UTIL, AF_ASPECT, AF_MARGIN   the outline to try
+#   AF_ADDON                        headroom fraction above the measured
+#                                   density lower bound
+#   AF_SEED                         placer seed, for the noise floor walk
+#   AF_WORK                         scratch dir for this candidate
+#   AF_RESULT                       result dict output path
+#   AF_SRC_RESULTS                  the shared RESULTS_DIR, holding 1_synth.*
+
+source $::env(SCRIPTS_DIR)/load.tcl
+
+proc af_env { name { default "" } } {
+  if { [info exists ::env($name)] && $::env($name) ne "" } {
+    return $::env($name)
+  }
+  return $default
+}
+
+set af_work $::env(AF_WORK)
+file mkdir $af_work
+
+# Redirect every output the stage scripts write into this candidate's own
+# scratch dir, so nothing lands in the real results/reports/logs tree.
+# Seed it with the synthesis outputs the floorplan stage reads.
+foreach { var sub } { RESULTS_DIR results REPORTS_DIR reports LOG_DIR logs OBJECTS_DIR objects } {
+  set d [file join $af_work $sub]
+  file mkdir $d
+  set ::env($var) $d
+}
+foreach f { 1_synth.odb 1_synth.sdc } {
+  file copy -force [file join $::env(AF_SRC_RESULTS) $f] \
+    [file join $::env(RESULTS_DIR) $f]
+}
+
+# Feed the candidate coordinates in through the same variables a
+# config.mk would set, so the production stage code is what runs.
+# Anything that would select a different init method has to go.
+set ::env(CORE_UTILIZATION) $::env(AF_UTIL)
+set ::env(CORE_ASPECT_RATIO) $::env(AF_ASPECT)
+set ::env(CORE_MARGIN) $::env(AF_MARGIN)
+foreach v { DIE_AREA CORE_AREA FLOORPLAN_DEF FOOTPRINT } {
+  if { [info exists ::env($v)] } {
+    unset ::env($v)
+  }
+}
+
+set af_t0 [clock milliseconds]
+
+# --- density -------------------------------------------------------------
+# Hand the candidate its headroom fraction and let production resolve it.
+# place_density_with_lb_addon() computes the measured lower bound once core
+# rows exist and adds the addon; doing that here instead would be a second
+# implementation of the same rule, and would resolve it against a different
+# placement state than the one global placement actually sees.
+#
+# The resolved value is captured by wrapping the proc rather than recomputed
+# afterwards, so what is recorded is exactly the density production used.
+# AF_DENSITY, when set, means "run this candidate at a fixed
+# PLACE_DENSITY" -- the form the incumbent uses when the design states a
+# density directly. The two are not additive: place_density_with_lb_addon
+# returns the addon form whenever the addon is set and only falls back to
+# PLACE_DENSITY otherwise, so exactly one of them may be present or the
+# candidate silently runs at a density nobody asked for.
+set af_fixed_density [af_env AF_DENSITY ""]
+if { $af_fixed_density ne "" } {
+  set ::env(PLACE_DENSITY) $af_fixed_density
+  if { [info exists ::env(PLACE_DENSITY_LB_ADDON)] } {
+    unset ::env(PLACE_DENSITY_LB_ADDON)
+  }
+} else {
+  set ::env(PLACE_DENSITY_LB_ADDON) [af_env AF_ADDON 0.0]
+  if { [info exists ::env(PLACE_DENSITY)] } {
+    unset ::env(PLACE_DENSITY)
+  }
+}
+set ::af_used_density -1
+proc af_after_global_place { } {
+  set ::af_used_density [place_density_with_lb_addon]
+}
+
+# Bound this candidate's own threading. Total concurrency is bazel's
+# --jobs times AF_JOBS times this, and OpenROAD otherwise takes every
+# core it can see, so a pool of candidates would each try to use the
+# whole machine. Two is a reasonable default: most of the flow is
+# single-threaded anyway, and the parallelism that matters here is
+# across candidates.
+set_thread_count [af_env AF_THREADS 2]
+
+# Vary the placer seed so the noise floor measures something. Without
+# this every seed runs an identical flow and 2 sigma comes out at 1e-13,
+# which would make the hysteresis inert and every difference look real.
+set ::env(GPL_RANDOM_SEED) [af_env AF_SEED 1]
+
+# --- the production flow, floorplan to finish ----------------------------
+# The oracle. A pre-route proxy was measured not to rank the utilization
+# axis at all -- rho -1.00 on gcd against the finished flow -- so the
+# derivation asks the flow itself. Every stage below is the production
+# script; see auto_floorplan_flow.tcl.
+set af_flow_tcl [af_env AF_FLOW_TCL \
+  [file join $::env(SCRIPTS_DIR) auto_floorplan_flow.tcl]]
+if { [catch { source $af_flow_tcl } af_err] } {
+  set f [open $::env(AF_RESULT) w]
+  puts $f [list ok 0 reason "flow failed: [string map {"\n" " "} $af_err]"]
+  close $f
+  exit 0
+}
+set af_t1 [clock milliseconds]
+
+# --- what the flow achieved ----------------------------------------------
+set af_blk [ord::get_db_block]
+set af_dbu [$af_blk getDbUnitsPerMicron]
+
+proc af_rect_um { rect dbu } {
+  return [list \
+    [expr { [$rect xMin] / double($dbu) }] \
+    [expr { [$rect yMin] / double($dbu) }] \
+    [expr { [$rect xMax] / double($dbu) }] \
+    [expr { [$rect yMax] / double($dbu) }]]
+}
+set af_die_rect [af_rect_um [$af_blk getDieArea] $af_dbu]
+set af_core_rect [af_rect_um [$af_blk getCoreArea] $af_dbu]
+
+set af_core [$af_blk getCoreArea]
+set af_scale [expr { double($af_dbu) * double($af_dbu) }]
+set af_core_um2 [expr { [$af_core dx] * double([$af_core dy]) / $af_scale }]
+
+set af_stdcell_um2 0.0
+set af_macro_um2 0.0
+foreach inst [$af_blk getInsts] {
+  set m [$inst getMaster]
+  set a [expr { [$m getWidth] * double([$m getHeight]) / $af_scale }]
+  if { [$m isBlock] } {
+    set af_macro_um2 [expr { $af_macro_um2 + $a }]
+  } elseif { [$m isCore] } {
+    set af_stdcell_um2 [expr { $af_stdcell_um2 + $a }]
+  }
+}
+
+# The achieved period, post-route: clock - WNS. Never WNS on its own --
+# it lives near zero, so a fractional change in it means nothing.
+set af_clk 0
+set af_wns 0
+set af_clks [get_clocks]
+if { [llength $af_clks] > 0 } {
+  set af_clk [get_property [lindex $af_clks 0] period]
+}
+if { ![catch { sta::worst_slack_cmd "max" } af_ws] && abs($af_ws) < 1.0e20 } {
+  set af_wns [sta::time_sta_ui $af_ws]
+}
+
+# DRC: detail_route.tcl writes its violations to a report; an empty or
+# absent file is zero. A candidate with DRCs is not a cheaper floorplan.
+set af_drc 0
+set af_drc_rpt [file join $::env(REPORTS_DIR) 5_route_drc.rpt]
+if { [file exists $af_drc_rpt] } {
+  set fh [open $af_drc_rpt r]
+  set af_drc [regexp -all {violation type:} [read $fh]]
+  close $fh
+}
+
+set af_rec [list \
+  ok 1 \
+  util [af_env AF_UTIL -1] \
+  aspect [af_env AF_ASPECT -1] \
+  margin [af_env AF_MARGIN -1] \
+  addon [af_env AF_ADDON -1] \
+  density $::af_used_density \
+  seed [af_env AF_SEED 1] \
+  clock_period $af_clk \
+  wns $af_wns \
+  achieved [expr { $af_clk - $af_wns }] \
+  core_um2 $af_core_um2 \
+  stdcell_um2 $af_stdcell_um2 \
+  macro_um2 $af_macro_um2 \
+  die_rect $af_die_rect \
+  core_rect $af_core_rect \
+  drc $af_drc \
+  total_ms [expr { $af_t1 - $af_t0 }]]
+
+set f [open $::env(AF_RESULT) w]
+puts $f $af_rec
+close $f
+
+exit 0

--- a/auto_floorplan_flow.tcl
+++ b/auto_floorplan_flow.tcl
@@ -1,0 +1,108 @@
+# The production flow from floorplan to finish, in one OpenROAD process.
+#
+# This is scripts/flow.tcl with its synthesis stage removed. A floorplan
+# derivation evaluates several candidate outlines against the same
+# netlist, so synthesis is run once into a shared 1_synth.odb and each
+# candidate starts from there; re-running it per candidate would be the
+# most expensive part of the walk and would measure nothing.
+#
+# The stage sequence below is duplicated from flow.tcl rather than
+# derived from it, because flow.tcl defines its own helpers and runs
+# immediately on source, leaving no seam to enter at. Duplication of a
+# sequence that must stay in step is exactly the kind of thing that
+# rots, so auto_floorplan_flow_test.py extracts the stage order from
+# both files and fails if this one stops being flow.tcl's tail.
+
+set ::env(KEEP_VARS) 1
+set ::env(WRITE_ODB_AND_SDC_EACH_STAGE) 0
+
+set ::flow_expected [glob -nocomplain -directory $::env(RESULTS_DIR) *.odb *.sdc]
+
+proc flow_source { script } {
+  # Source in the global scope: stage scripts set top-level variables
+  # that later stages read via $::, which a proc-scoped source would
+  # silently shadow.
+  uplevel #0 [list source $::env(SCRIPTS_DIR)/$script]
+  foreach f [glob -nocomplain -directory $::env(RESULTS_DIR) *.odb *.sdc] {
+    if { [lsearch -exact $::flow_expected $f] == -1 } {
+      error "$script wrote $f: with WRITE_ODB_AND_SDC_EACH_STAGE=0 stage\
+             scripts must not write .odb/.sdc files"
+    }
+  }
+}
+
+proc flow_write_db { name } {
+  set path [file join $::env(RESULTS_DIR) $name]
+  log_cmd write_db $path
+  lappend ::flow_expected $path
+}
+
+proc flow_write_sdc { name } {
+  set path [file join $::env(RESULTS_DIR) $name]
+  log_cmd write_sdc -no_timestamp $path
+  lappend ::flow_expected $path
+}
+
+# Floorplan
+flow_source floorplan.tcl
+flow_write_db 2_1_floorplan.odb
+flow_write_sdc 2_1_floorplan.sdc
+flow_source macro_place.tcl
+flow_write_db 2_2_floorplan_macro.odb
+flow_source tapcell.tcl
+flow_write_db 2_3_floorplan_tapcell.odb
+flow_source pdn.tcl
+flow_write_db 2_4_floorplan_pdn.odb
+flow_write_db 2_floorplan.odb
+flow_write_sdc 2_floorplan.sdc
+
+# Place
+flow_source global_place_skip_io.tcl
+flow_write_db 3_1_place_gp_skip_io.odb
+flow_source io_placement.tcl
+flow_write_db 3_2_place_iop.odb
+flow_source global_place.tcl
+flow_write_db 3_3_place_gp.odb
+# Hook for the derivation: the placement density production just used.
+# It cannot be captured by wrapping place_density_with_lb_addon, because
+# load.tcl re-sources util.tcl at the top of every stage script and would
+# redefine the wrapper away. Called here because
+# gpl::get_global_placement_uniform_density is instance-area over
+# whitespace and so does not depend on the placement that just ran --
+# the number is the same one global_place.tcl resolved.
+if { [info procs af_after_global_place] ne "" } {
+  af_after_global_place
+}
+flow_source resize.tcl
+flow_write_db 3_4_place_resized.odb
+flow_source detail_place.tcl
+flow_write_db 3_5_place_dp.odb
+flow_write_db 3_place.odb
+flow_write_sdc 3_place.sdc
+
+# CTS
+flow_source cts.tcl
+flow_write_db 4_1_cts.odb
+flow_write_db 4_cts.odb
+flow_write_sdc 4_cts.sdc
+
+# Route
+flow_source global_route.tcl
+flow_write_db 5_1_grt.odb
+flow_write_sdc 5_1_grt.sdc
+flow_source detail_route.tcl
+flow_write_db 5_2_route.odb
+flow_source fillcell.tcl
+flow_write_db 5_3_fillcell.odb
+flow_write_db 5_route.odb
+flow_write_sdc 5_route.sdc
+
+# Finish. final_report.tcl is split around its 6_final.odb write so
+# this top level can write at the same point.
+flow_source density_fill.tcl
+flow_write_db 6_1_fill.odb
+flow_write_sdc 6_1_fill.sdc
+flow_source final_connect.tcl
+flow_write_db 6_final.odb
+flow_write_sdc 6_final.sdc
+flow_source final_outputs.tcl

--- a/auto_floorplan_flow_test.py
+++ b/auto_floorplan_flow_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""auto_floorplan_flow.tcl must stay flow.tcl's tail.
+
+The floorplan derivation runs the production flow from floorplan to
+finish in one process, starting from a shared 1_synth.odb. That sequence
+is duplicated from flow.tcl because flow.tcl runs on source and offers no
+seam to enter after synthesis.
+
+Duplication of a sequence that has to stay in step rots silently: a stage
+added to flow.tcl would simply not be measured by the derivation, and the
+derived floorplan would be chosen against a flow that no longer exists.
+This test makes that failure loud.
+"""
+
+import os
+import re
+import unittest
+
+# flow.tcl belongs to ORFS and is read from the pinned @orfs archive, so
+# this compares against the version that actually runs rather than a copy
+# that would have to be kept in step -- which is the very failure the test
+# exists to catch. Both paths come from the build; the fallbacks let the
+# test run directly out of a checkout.
+HERE = os.path.dirname(os.path.abspath(__file__))
+FLOW = os.environ.get("ORFS_FLOW_TCL") or os.path.join(HERE, "flow.tcl")
+DERIVE = os.environ.get("AF_FLOW_TCL") or os.path.join(
+    HERE, "auto_floorplan_flow.tcl"
+)
+
+# The stages flow.tcl runs before the derivation's entry point. Everything
+# after these must appear in both files, in the same order.
+SYNTH_STAGES = ["synth_odb.tcl"]
+
+
+def stages(path):
+    with open(path) as f:
+        return re.findall(r"(?m)^\s*flow_source\s+(\S+)", f.read())
+
+
+def writes(path):
+    with open(path) as f:
+        return re.findall(r"(?m)^\s*flow_write_(?:db|sdc)\s+(\S+)", f.read())
+
+
+class TestDeriveFlowMatchesFlow(unittest.TestCase):
+    def test_stage_sequence_is_flow_tcl_tail(self):
+        flow, derive = stages(FLOW), stages(DERIVE)
+        self.assertEqual(
+            flow[: len(SYNTH_STAGES)],
+            SYNTH_STAGES,
+            "flow.tcl no longer starts with the synthesis stage; the "
+            "derivation's entry point assumption needs revisiting",
+        )
+        self.assertEqual(
+            derive,
+            flow[len(SYNTH_STAGES) :],
+            "auto_floorplan_flow.tcl has drifted from flow.tcl. A stage "
+            "added to one and not the other means the derivation picks a "
+            "floorplan against a flow that is not the production one.",
+        )
+
+    def test_written_artifacts_match(self):
+        flow, derive = writes(FLOW), writes(DERIVE)
+        synth = [w for w in flow if w.startswith("1_synth")]
+        self.assertEqual(
+            derive,
+            [w for w in flow if w not in synth],
+            "the two flows no longer write the same artifacts",
+        )
+
+    def test_derive_does_not_run_synthesis(self):
+        self.assertNotIn(
+            "synth_odb.tcl",
+            stages(DERIVE),
+            "the derivation must start from the shared 1_synth.odb; "
+            "re-running synthesis per candidate measures nothing and is "
+            "the most expensive part of the walk",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/auto_floorplan_flow_test.py
+++ b/auto_floorplan_flow_test.py
@@ -24,9 +24,7 @@ import unittest
 # test run directly out of a checkout.
 HERE = os.path.dirname(os.path.abspath(__file__))
 FLOW = os.environ.get("ORFS_FLOW_TCL") or os.path.join(HERE, "flow.tcl")
-DERIVE = os.environ.get("AF_FLOW_TCL") or os.path.join(
-    HERE, "auto_floorplan_flow.tcl"
-)
+DERIVE = os.environ.get("AF_FLOW_TCL") or os.path.join(HERE, "auto_floorplan_flow.tcl")
 
 # The stages flow.tcl runs before the derivation's entry point. Everything
 # after these must appear in both files, in the same order.

--- a/check_pareto.py
+++ b/check_pareto.py
@@ -288,9 +288,7 @@ def main():
         print("[INFO] every axis within its tie band — no measurable movement")
 
     if args.require_improvement and not improved and not errors:
-        errors.append(
-            "--require-improvement: no axis improved beyond its tie band"
-        )
+        errors.append("--require-improvement: no axis improved beyond its tie band")
 
     for e in errors:
         print(f"[ERROR] {e}")

--- a/check_pareto.py
+++ b/check_pareto.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+
+"""Check whether a run moved the QoR Pareto front in a good direction.
+
+`checkMetadata.py` answers a different question, and answers it well:
+"did anything get worse than a bound we set". Its bounds carry generous
+margin -- 15% on area, 5% of the clock period on worst slack -- so it
+tolerates drift, which is what a regression guard should do.
+
+What it cannot express is a *trade*. A change that shrinks the core 8%
+and gives up 1% of worst slack fails the slack rule and says nothing at
+all about the area rule it just improved. Read literally it reports a
+regression; read honestly it is a point that moved along the front. The
+two are not distinguishable from `rules-base.json` alone, because the
+file records padded thresholds rather than measurements.
+
+So this reads the `golden` values that `genRuleFile.py` now records
+next to those thresholds -- the unpadded numbers actually measured --
+treats them as a point in KPI space, and asks where the new point sits
+relative to it:
+
+  * a **hard constraint** regression (DRC, placement violations, antenna)
+    fails outright, no tie band, no trade. These are not axes you are
+    allowed to spend.
+  * **losing timing closure** -- crossing from meeting the constraint to
+    missing it -- fails outright. That is a change in kind, not a Pareto
+    cost, and no amount of area buys it back.
+  * otherwise the new point fails only if it is **dominated**: every
+    axis worse-or-tied and at least one worse beyond its tie band. A
+    genuine trade -- better on one axis, worse on another -- passes, and
+    the trade is printed.
+
+`--require-improvement` additionally demands at least one axis improve
+beyond its tie band, which is what you want when gating a change that is
+*supposed* to move the front rather than merely not wreck it.
+
+Tie bands come from the `tie` field when present, and otherwise from
+conservative defaults below. A band that came from a real noise
+measurement is worth far more than these defaults; where one exists,
+record it in the rules file so the verdict is measured rather than
+assumed.
+"""
+
+import argparse
+import json
+import sys
+
+# axis -> (metric, direction, default fractional tie band); "down" means
+# smaller is better. The defaults are deliberately not tight: an
+# unmeasured band should not manufacture confident verdicts.
+#
+# The period axis is the ACHIEVED PERIOD (clock - WNS), never WNS itself.
+#
+# WNS is a signed quantity that lives near zero, so a fractional change in
+# it is meaningless: a design at +5.8 ps that moves to +0.9 ps has "lost
+# 85%" of nothing, while one at -274 ps that moves to -280 ps has "lost
+# 2%" of a great deal. Both readings are noise dressed as precision, and
+# a tie band expressed as a fraction of WNS is correspondingly absurd --
+# tight where WNS is small, loose where it is large, for no reason
+# connected to the design.
+#
+# clock - WNS is a stable positive quantity of order the clock period, so
+# a fractional change in it means what it appears to mean, and a tie band
+# expressed as a fraction of it is a fraction of the clock. This is the
+# same convention genRuleFile.py already uses for its timing rules
+# ("period_padding": pad by a percentage of the clock, not of the slack).
+#
+# TNS is deliberately NOT an axis. It is unbounded below, frequently
+# exactly zero, and its scale depends on the endpoint count, so it has
+# the same pathology as WNS and worse. It stays a diagnostic.
+AXES = [
+    ("period", None, "down", 0.005),  # synthesised: clock - WNS
+    ("core_area", "finish__design__core__area", "down", 0.015),
+    ("cell_area", "finish__design__instance__area", "down", 0.015),
+    ("power", "finish__power__total", "down", 0.05),
+]
+
+WNS = "finish__timing__setup__ws"
+
+# Regressions here are never a trade.
+HARD = [
+    "detailedroute__route__drc_errors",
+    "detailedplace__design__violations",
+    "detailedroute__antenna__violating__nets",
+]
+
+# Reported next to the verdict, never gated: these are how a flow buys
+# timing when you are not looking (more repair, more runtime, more wire).
+DIAGNOSTIC = [
+    "finish__timing__setup__tns",
+    "detailedroute__route__wirelength",
+    "cts__design__instance__count__setup_buffer",
+    "cts__design__instance__count__hold_buffer",
+]
+
+# Closure is judged on WNS, and on WNS alone: "does this design meet its
+# constraint" is a discrete fact about the sign, not a magnitude, and it
+# is the one question the achieved period cannot answer.
+CLOSURE = WNS
+
+
+def clock_period(meta):
+    """The first clock's period, as genRuleFile.py reads it."""
+    details = meta.get("constraints__clocks__details")
+    if isinstance(details, list) and details:
+        first = details[0]
+        if isinstance(first, (int, float)):
+            return float(first)
+        if isinstance(first, str):
+            for tok in first.split():
+                try:
+                    return float(tok)
+                except ValueError:
+                    continue
+    return None
+
+
+def num(v):
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return None
+    return float(v)
+
+
+def classify(base, new, direction, tie):
+    """improved / tied / regressed, plus the fractional delta."""
+    if base == 0:
+        delta = 0.0 if new == base else (1.0 if new > base else -1.0)
+    else:
+        delta = (new - base) / abs(base)
+    better = (new > base) if direction == "up" else (new < base)
+    if abs(delta) <= tie:
+        return "tied", delta
+    return ("improved" if better else "regressed"), delta
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--metadata", "-m", required=True)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--baseline",
+        "-b",
+        help="metadata.json measured on the unmodified design. Preferred: "
+        "both arms are then measured on the same toolchain on the same "
+        "day, which is the only comparison that isolates the change.",
+    )
+    src.add_argument(
+        "--rules",
+        "-r",
+        help="rules-base.json, using its 'golden' values as the baseline. "
+        "Only sound if the file was regenerated on the current toolchain: "
+        "checked-in rules lag the flow by however long since the last "
+        "'update rules', and that drift lands in the same diff as the "
+        "change under test. On asap7 the drift has been observed at 9 ps "
+        "of setup slack over six weeks, the same size as the effects "
+        "being measured.",
+    )
+    ap.add_argument(
+        "--require-improvement",
+        action="store_true",
+        help="also fail unless at least one axis improves beyond its tie band",
+    )
+    args = ap.parse_args()
+
+    with open(args.metadata) as f:
+        meta = json.load(f)
+
+    # Both sources are reduced to the same two lookups, so the checks below
+    # do not care which one is in play: base_of() gives the baseline value
+    # for a metric, tie_of() its noise band and where that band came from.
+    if args.baseline:
+        with open(args.baseline) as f:
+            base_meta = json.load(f)
+        source = f"measured baseline {args.baseline}"
+
+        def base_of(field):
+            return num(base_meta.get(field))
+
+        def tie_of(field, default_tie):
+            return default_tie, "default"
+
+    else:
+        with open(args.rules) as f:
+            rules = json.load(f)
+        source = f"golden values in {args.rules}"
+
+        def base_of(field):
+            rule = rules.get(field)
+            if not rule or "golden" not in rule:
+                return None
+            return num(rule["golden"])
+
+        def tie_of(field, default_tie):
+            rule = rules.get(field) or {}
+            if "tie" in rule:
+                return rule["tie"], "measured"
+            return default_tie, "default"
+
+    errors = []
+    notes = []
+
+    # --- hard constraints ------------------------------------------------
+    for field in HARD:
+        b, n = base_of(field), num(meta.get(field))
+        if b is None or n is None:
+            continue
+        if n > b:
+            errors.append(f"{field}: {b:g} -> {n:g} (hard constraint, never a trade)")
+        else:
+            notes.append(f"[ok]   {field:52s} {b:g} -> {n:g}")
+
+    # --- timing closure --------------------------------------------------
+    b, n = base_of(CLOSURE), num(meta.get(CLOSURE))
+    if b is not None and n is not None and b >= 0 > n:
+        errors.append(
+            f"{CLOSURE}: {b:g} -> {n:g} (was meeting the constraint, now "
+            "missing it; that is a change in kind, not a Pareto cost)"
+        )
+
+    # --- Pareto axes -----------------------------------------------------
+    improved, regressed, tied, missing = [], [], [], []
+    period = clock_period(meta)
+    for name, field, direction, default_tie in AXES:
+        if name == "period":
+            # Synthesised from the clock and WNS rather than read directly.
+            gb, gn = base_of(WNS), num(meta.get(WNS))
+            if gb is None or gn is None or period is None:
+                missing.append(name)
+                continue
+            b, n = period - gb, period - gn
+            tie_field = WNS
+            field = f"{WNS} -> achieved period (clock {period:g})"
+        else:
+            b, n = base_of(field), num(meta.get(field))
+            if b is None or n is None:
+                missing.append(name)
+                continue
+            tie_field = field
+        tie, src = tie_of(tie_field, default_tie)
+        verdict, delta = classify(b, n, direction, tie)
+        line = (
+            f"{name:11s} {field:44s} {b:12.6g} -> {n:12.6g} "
+            f"{100 * delta:+7.2f}%  {verdict} (tie {100 * tie:.1f}% {src})"
+        )
+        notes.append("       " + line)
+        {"improved": improved, "regressed": regressed, "tied": tied}[verdict].append(
+            name
+        )
+
+    for field in DIAGNOSTIC:
+        b, n = base_of(field), num(meta.get(field))
+        if b is None or n is None or b == 0:
+            continue
+        notes.append(
+            f"[diag] {field:52s} {b:12.6g} -> {n:12.6g} "
+            f"{100 * (n - b) / abs(b):+7.2f}%"
+        )
+
+    print(f"Pareto check against {source}")
+    print("-" * 78)
+    for line in notes:
+        print(line)
+    print("-" * 78)
+
+    if missing:
+        print(
+            f"[WARN] no baseline value for: {', '.join(missing)} — "
+            "run <design>_update to record them, or pass --baseline"
+        )
+
+    # Dominated: nothing improved, something regressed.
+    dominated = bool(regressed) and not improved
+    if dominated:
+        errors.append(
+            "point is dominated: "
+            f"{', '.join(regressed)} regressed and no axis improved"
+        )
+
+    if improved and regressed:
+        print(
+            f"[INFO] trade: {', '.join(improved)} improved, "
+            f"{', '.join(regressed)} regressed — this is a move along the "
+            "front, not a regression"
+        )
+    elif improved:
+        print(f"[INFO] strict improvement on: {', '.join(improved)}")
+    elif not regressed:
+        print("[INFO] every axis within its tie band — no measurable movement")
+
+    if args.require_improvement and not improved and not errors:
+        errors.append(
+            "--require-improvement: no axis improved beyond its tie band"
+        )
+
+    for e in errors:
+        print(f"[ERROR] {e}")
+
+    if errors:
+        print("Pareto check FAILED")
+        sys.exit(1)
+    print("Pareto check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/check_pareto_test.py
+++ b/check_pareto_test.py
@@ -185,7 +185,6 @@ class TestCheckPareto(unittest.TestCase):
         self.assertIn("no baseline value for", out)
 
 
-
 class TestMeasuredBaseline(unittest.TestCase):
     """--baseline takes the reference from a measured run, not from rules.
 

--- a/check_pareto_test.py
+++ b/check_pareto_test.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+
+"""Tests for check_pareto.py.
+
+The interesting cases are the ones the existing rules check cannot
+express: a genuine trade must pass, a dominated point must fail, and a
+lost timing closure must fail even though it looks like a small delta.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "check_pareto.py")
+
+# A baseline that meets timing with margin, so closure cases are testable.
+CLOCK = 1000.0
+
+BASE = {
+    "constraints__clocks__details": [f"core_clock {CLOCK} ..."],
+    "finish__timing__setup__ws": 10.0,
+    "finish__timing__setup__tns": -100.0,
+    "finish__design__core__area": 1000.0,
+    "finish__design__instance__area": 800.0,
+    "finish__power__total": 0.001,
+    "detailedroute__route__drc_errors": 0,
+    "detailedplace__design__violations": 0,
+    "detailedroute__antenna__violating__nets": 0,
+}
+
+
+def rules_from(base, tie=None):
+    out = {}
+    for k, v in base.items():
+        if not isinstance(v, (int, float)):
+            continue  # clock details are metadata, not a rule
+        entry = {"value": v, "compare": "<=", "golden": v}
+        if tie and k in tie:
+            entry["tie"] = tie[k]
+        out[k] = entry
+    return out
+
+
+def run_baseline(metadata, baseline, extra=()):
+    """The measured-baseline mode: both arms are metadata.json files."""
+    with tempfile.TemporaryDirectory() as d:
+        m, b = os.path.join(d, "m.json"), os.path.join(d, "b.json")
+        with open(m, "w") as f:
+            json.dump(metadata, f)
+        with open(b, "w") as f:
+            json.dump(baseline, f)
+        p = subprocess.run(
+            [sys.executable, SCRIPT, "-m", m, "-b", b, *extra],
+            capture_output=True,
+            text=True,
+        )
+        return p.returncode, p.stdout + p.stderr
+
+
+def run(metadata, rules, extra=()):
+    with tempfile.TemporaryDirectory() as d:
+        m, r = os.path.join(d, "m.json"), os.path.join(d, "r.json")
+        with open(m, "w") as f:
+            json.dump(metadata, f)
+        with open(r, "w") as f:
+            json.dump(rules, f)
+        p = subprocess.run(
+            [sys.executable, SCRIPT, "-m", m, "-r", r, *extra],
+            capture_output=True,
+            text=True,
+        )
+        return p.returncode, p.stdout + p.stderr
+
+
+class TestCheckPareto(unittest.TestCase):
+    def test_identical_passes(self):
+        rc, out = run(dict(BASE), rules_from(BASE))
+        self.assertEqual(rc, 0, out)
+        self.assertIn("no measurable movement", out)
+
+    def test_strict_improvement_passes(self):
+        new = dict(BASE)
+        new["finish__design__core__area"] = 900.0  # -10%
+        rc, out = run(new, rules_from(BASE))
+        self.assertEqual(rc, 0, out)
+        self.assertIn("strict improvement", out)
+
+    def test_genuine_trade_passes(self):
+        # Core area down 10%, achieved period up ~1% (WNS 10 -> 0.5 ps on a
+        # 1000 ps clock): a real move along the front. The existing rules
+        # check would fail on the slack half and say nothing about the area
+        # half. WNS deliberately stays positive so this exercises the trade
+        # path and not the closure check.
+        new = dict(BASE)
+        new["finish__design__core__area"] = 900.0
+        new["finish__timing__setup__ws"] = 0.5
+        rc, out = run(new, rules_from(BASE))
+        self.assertEqual(rc, 0, out)
+        self.assertIn("trade:", out)
+
+    def test_dominated_fails(self):
+        # Everything worse, nothing better -- and still meeting timing, so
+        # this is dominance rather than a closure failure.
+        new = dict(BASE)
+        new["finish__design__core__area"] = 1200.0
+        new["finish__timing__setup__ws"] = 2.0
+        rc, out = run(new, rules_from(BASE))
+        self.assertEqual(rc, 1, out)
+        self.assertIn("dominated", out)
+
+    def test_within_tie_band_passes(self):
+        # 1% area change against a 1.5% default band is not movement.
+        new = dict(BASE)
+        new["finish__design__core__area"] = 990.0
+        rc, out = run(new, rules_from(BASE))
+        self.assertEqual(rc, 0, out)
+        self.assertIn("no measurable movement", out)
+
+    def test_hard_constraint_regression_fails(self):
+        # A DRC error is never a trade, even alongside a big area win.
+        new = dict(BASE)
+        new["finish__design__core__area"] = 500.0
+        new["detailedroute__route__drc_errors"] = 3
+        rc, out = run(new, rules_from(BASE))
+        self.assertEqual(rc, 1, out)
+        self.assertIn("hard constraint", out)
+
+    def test_losing_closure_fails(self):
+        # +10 ps -> -3 ps. Small in percentage terms, and a change in kind.
+        # This is the ibex case from the AUTO_FLOORPLAN sweep.
+        new = dict(BASE)
+        new["finish__timing__setup__ws"] = -3.0
+        new["finish__design__core__area"] = 750.0  # even with a 25% area win
+        rc, out = run(new, rules_from(BASE))
+        self.assertEqual(rc, 1, out)
+        self.assertIn("change in kind", out)
+
+    def test_still_missing_closure_is_not_a_closure_failure(self):
+        # A design that already missed timing has no closure to lose; it
+        # is judged on the axes like anything else.
+        base = dict(BASE)
+        base["finish__timing__setup__ws"] = -50.0
+        new = dict(base)
+        new["finish__timing__setup__ws"] = -55.0
+        new["finish__design__core__area"] = 900.0
+        rc, out = run(new, rules_from(base))
+        self.assertEqual(rc, 0, out)
+        self.assertNotIn("change in kind", out)
+
+    def test_require_improvement_fails_on_no_movement(self):
+        rc, out = run(dict(BASE), rules_from(BASE), extra=("--require-improvement",))
+        self.assertEqual(rc, 1, out)
+        self.assertIn("no axis improved", out)
+
+    def test_measured_tie_band_overrides_default(self):
+        # A 4% area regression passes when the measured band is 5%.
+        new = dict(BASE)
+        new["finish__design__core__area"] = 1040.0
+        rules = rules_from(BASE, tie={"finish__design__core__area": 0.05})
+        rc, out = run(new, rules)
+        self.assertEqual(rc, 0, out)
+        self.assertIn("measured", out)
+
+    def test_tiny_wns_swing_is_not_a_huge_period_change(self):
+        # WNS +5.8 -> +0.9 ps is an 85% "loss" of WNS and 0.5% of the
+        # clock. Judged on WNS it looks catastrophic; judged on achieved
+        # period it is inside the tie band, which is the point.
+        base = dict(BASE)
+        base["finish__timing__setup__ws"] = 5.8
+        new = dict(base)
+        new["finish__timing__setup__ws"] = 0.9
+        rc, out = run(new, rules_from(base))
+        self.assertEqual(rc, 0, out)
+        self.assertIn("no measurable movement", out)
+
+    def test_missing_golden_is_warned_not_fatal(self):
+        rules = rules_from(BASE)
+        del rules["finish__design__core__area"]["golden"]
+        rc, out = run(dict(BASE), rules)
+        self.assertEqual(rc, 0, out)
+        self.assertIn("no baseline value for", out)
+
+
+
+class TestMeasuredBaseline(unittest.TestCase):
+    """--baseline takes the reference from a measured run, not from rules.
+
+    Checked-in rules-base.json lags the toolchain by however long since
+    the last regeneration, so its goldens describe a flow that may no
+    longer exist. On asap7 that drift has been seen at 9 ps of setup
+    slack over six weeks -- the same size as the effects being judged,
+    which is enough to invert a verdict. Both arms measured on the same
+    toolchain is the only comparison that isolates a change.
+    """
+
+    def test_agrees_with_rules_mode_on_identical_baselines(self):
+        new = dict(BASE, finish__design__core__area=900.0)
+        rc_r, out_r = run(new, rules_from(BASE))
+        rc_b, out_b = run_baseline(new, BASE)
+        self.assertEqual(rc_r, rc_b)
+        self.assertIn("improved", out_b)
+        self.assertEqual(rc_b, 0)
+
+    def test_lost_closure_fails(self):
+        # The aes_lvt shape: a much smaller core bought by spending all
+        # the setup margin and crossing zero.
+        new = dict(
+            BASE,
+            finish__timing__setup__ws=-0.5,
+            finish__design__core__area=700.0,
+        )
+        rc, out = run_baseline(new, BASE)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("was meeting the constraint", out)
+
+    def test_a_stale_reference_can_invert_the_verdict(self):
+        # The aes_lvt numbers, scaled to this fixture's 1000 ps clock.
+        # A rules file generated weeks ago recorded ws = 0.0; the design
+        # has since drifted to ws = +9.0 on the current toolchain. The
+        # candidate lands at ws = +0.5, giving up the drift but still
+        # closing, so the closure check -- which only looks at the sign --
+        # stays quiet and the whole verdict rests on the period axis.
+        stale = dict(BASE, finish__timing__setup__ws=0.0)
+        fresh = dict(BASE, finish__timing__setup__ws=9.0)
+        new = dict(BASE, finish__timing__setup__ws=0.5)
+
+        rc_stale, out_stale = run_baseline(new, stale)
+        rc_fresh, out_fresh = run_baseline(new, fresh)
+
+        # Against the stale reference the design looks untouched...
+        self.assertEqual(rc_stale, 0)
+        self.assertIn("tied", out_stale)
+        # ...against the truth it gave up 0.86% of period for nothing.
+        self.assertNotEqual(rc_fresh, 0)
+        self.assertIn("dominated", out_fresh)
+
+    def test_baseline_and_rules_are_mutually_exclusive(self):
+        with tempfile.TemporaryDirectory() as d:
+            m = os.path.join(d, "m.json")
+            with open(m, "w") as f:
+                json.dump(BASE, f)
+            p = subprocess.run(
+                [sys.executable, SCRIPT, "-m", m, "-b", m, "-r", m],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(p.returncode, 0)
+
+    def test_one_of_them_is_required(self):
+        with tempfile.TemporaryDirectory() as d:
+            m = os.path.join(d, "m.json")
+            with open(m, "w") as f:
+                json.dump(BASE, f)
+            p = subprocess.run(
+                [sys.executable, SCRIPT, "-m", m],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(p.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/auto_floorplan.md
+++ b/docs/auto_floorplan.md
@@ -1,5 +1,16 @@
 # Deriving a floorplan
 
+> **A demonstration, not a supported feature.** This is a worked idea:
+> that the floorplan numbers in a `config.mk` are measurable rather than
+> guessable, and roughly what it costs to measure them. It lives here so
+> the idea is concrete and runnable, and the expectation is that anyone
+> who wants it in earnest reimplements it inside their own project,
+> against their own designs, provisioning and definition of "better".
+>
+> So read the ladders, the tie bands and the winner rule as one set of
+> choices that worked on a handful of ORFS designs, not as an interface
+> to build on. Nothing in the normal flow depends on any of it.
+
 A design's `config.mk` carries a handful of numbers that decide its
 floorplan:
 

--- a/docs/auto_floorplan.md
+++ b/docs/auto_floorplan.md
@@ -1,0 +1,221 @@
+# Deriving a floorplan
+
+A design's `config.mk` carries a handful of numbers that decide its
+floorplan:
+
+| Variable | What it is |
+|---|---|
+| `CORE_UTILIZATION` | a guess at the smallest core the netlist closes in |
+| `DIE_AREA` / `CORE_AREA` | the same guess, written as a rectangle |
+| `CORE_ASPECT_RATIO` | folklore, per design |
+| `PLACE_DENSITY` | a local bin-packing cap |
+| `PLACE_DENSITY_LB_ADDON` | headroom above the measured density lower bound |
+
+Each is a human prediction of downstream behaviour standing where a
+measurement should be. The right utilization is "the smallest core in
+which this netlist still closes" — a question about `repair_design`, CTS
+and routing, none of which have happened when the number is read.
+
+These two targets measure them instead:
+
+```bash
+bazelisk build //flow/designs/asap7/gcd:gcd_auto_floorplan_data
+bazelisk run   //flow/designs/asap7/gcd:gcd_auto_floorplan_pin
+```
+
+The first races candidate floorplans and writes the evidence. The second
+writes the winner into `config.mk` as ordinary variables. **Nothing runs
+during a normal build** — the flow reads `config.mk` exactly as it always
+has, and both targets are `manual`, so no wildcard starts a derivation.
+
+## Why it is a job and not a flow mode
+
+An earlier version was a flow variable that raced candidates on every
+build. Two things killed that.
+
+**The cadence is wrong.** What changes in ORFS is the OpenROAD binary,
+and binary churn rarely moves the Pareto front, so a per-build race
+re-derives a number that did not need re-deriving — while adding
+run-to-run variance to a benchmark suite whose whole value is stable
+comparison. A real design's RTL changes during the day and wants a
+nightly re-derivation, which is a job, not a flag.
+
+**A cheap scorer cannot answer the question.** The per-build version
+scored candidates with a fast pre-route proxy: global placement plus a
+sampled-path timing readout. Measured against the finished flow across a
+utilization ladder:
+
+| design | ρ (proxy vs flow) | noise floor |
+|---|---:|---:|
+| gcd | **−1.000** | 1.1% of clock |
+| gcd-ccs | +0.100 | 0.3% of clock |
+
+On gcd the proxy is perfectly inverted: it improves 338 → 335 across the
+ladder while the flow degrades 349.2 → 355.1 ps. Selection driven by
+those numbers picked a core 11.2% *larger* with a worse period on `aes`.
+
+So each candidate here runs the production flow from floorplan to finish
+and reports what it achieved. That is expensive, and it is exactly why
+this is something you run rather than something the flow does.
+
+## What gets raced
+
+Three coordinates, each on a dimensionless ladder. There is no per-design
+constant anywhere in the implementation.
+
+- **Utilization** — fractions of the incumbent, `{0.9 … 1.4}`.
+- **Density** — fractions of the headroom above the measured lower bound
+  (`gpl::get_global_placement_uniform_density`), `{0.00 … 0.20}`. That
+  fraction *is* `PLACE_DENSITY_LB_ADDON`, now measured.
+- **Aspect ratio** — `{0.8, 1.0, 1.25}` at the winning area point. Often
+  a tie, which is a result: the folklore value gets graded rather than
+  assumed.
+
+Coordinate descent, not a grid — utilization, then density, then aspect.
+A full cross product is 90 flows; this is about 20. Interactions between
+the coordinates are therefore not explored, which is a real limitation
+and is recorded in the evidence rather than papered over.
+
+The design's own `config.mk` values enter as a candidate, so a design
+whose folklore was already right keeps it.
+
+## How the winner is chosen
+
+```
+P_eff = T + τ·ln(1 + e^((p−T)/τ))          τ = 2% of the clock
+J     = ln(A) + λ·ln(P_eff)                 λ = 3
+                                            minimise J
+```
+
+`λ` is an **exchange rate**: one percent of achieved period is worth
+three percent of core area. That is a product decision someone has an
+opinion about, not a threshold nobody can defend.
+
+`P_eff` tracks the achieved period when the design is slower than its
+target and flattens to the target when it is faster, so speed nobody
+asked for has no value and area spent buying it is never repaid. That
+removes the regime switch: the same expression minimises area down to the
+target on a design that closes, and trades period against area on one
+that does not.
+
+Both constants are flat: every verdict on an asap7 sweep is unchanged for
+λ ∈ [2, 5] and τ ∈ [1%, 10%], and the smooth form agrees with a hard
+`max(p, T)` on all 15 designs. A policy whose decisions survive a 2.5×
+range in one constant and 10× in the other is a shape, not a fitted
+number.
+
+Two behaviours fall out rather than being coded: a candidate that gives
+up period and returns no area can never lower `J`, and the incumbent is
+just another candidate, so "nothing beat it" needs no special case.
+
+### Guards
+
+- **A floorplan that routes with violations is eliminated**, not scored.
+  No amount of area buys past a DRC.
+- **A flow that fails is an eliminated candidate**, not a crash — a
+  floorplan that cannot be built is a legitimate answer about that
+  floorplan.
+- **Hysteresis in `J`.** The winner must beat the incumbent by more `J`
+  than the measured period noise could account for on its own, or the
+  design keeps what it has. Area is exact — the same coordinates give the
+  same core every time — so only the period term carries noise.
+
+### `delta_tie` is measured, never chosen
+
+The noise floor comes from re-running one candidate under eight different
+placer seeds and taking two standard deviations. Not the range: the range
+of a small sample is biased low and its expectation grows with `n`, so a
+range-based floor would move every threshold purely by changing the seed
+count.
+
+On gcd it comes out at 1.20% of the clock period, independently
+reproducing the ~1.1% measured for gcd by a separate experiment.
+
+## Splitting derive from pin
+
+`_data` is a normal build target with a declared output, so bazel caches
+it. Iterating on the pin never re-derives — a `pin` run against cached
+data takes under a second. And `_pin` **depends on** `_data`, so it can
+never write stale values: bazel's dependency graph is the freshness
+check, and a changed netlist, SDC or toolchain re-derives before the pin
+sees it.
+
+Nothing lands in your source tree except the `config.mk` edit; the
+evidence lives in `bazel-out`.
+
+Derive as many designs in one command as the machine warrants:
+
+```bash
+bazelisk build --keep_going \
+  //flow/designs/asap7/gcd:gcd_auto_floorplan_data \
+  //flow/designs/asap7/ibex:ibex_core_auto_floorplan_data
+```
+
+### Provisioning
+
+The derivation is **one bazel action that forks its own candidates**.
+Bazel provisions roughly one core per action while each candidate runs a
+multi-threaded flow, so expressing candidates as separate targets would
+overprovision by the thread count of every concurrent flow.
+
+Total concurrency is `--jobs × AF_JOBS × AF_THREADS`. Pick a shape:
+
+| goal | `--jobs` | `AF_JOBS` | `AF_THREADS` |
+|---|---|---|---|
+| one design, all cores | 1 | 8 | 4 |
+| many designs at once | 8 | 2 | 2 |
+
+## What the pin writes
+
+Ordinary `config.mk` variables, updated in place, keeping their position,
+alignment and assignment operator. No markers, no generated block, no
+banner — somebody reading a `config.mk` to understand a design should not
+have to care which numbers were typed and which were measured. The
+provenance is printed by the pinning run, for the commit message.
+
+It answers in the form the design asked the question in: a design stating
+`DIE_AREA`/`CORE_AREA` gets a rectangle back, one stating
+`CORE_UTILIZATION` gets a utilization. The rectangle is not recomputed
+from the utilization — each candidate reads back the die and core its own
+`initialize_floorplan` produced, so the two forms cannot disagree.
+
+Exactly one density variable is written. `PLACE_DENSITY_LB_ADDON` and
+`PLACE_DENSITY` are not additive: `place_density_with_lb_addon` returns
+the addon form whenever the addon is set and only falls back to
+`PLACE_DENSITY` otherwise, so writing both would leave a dead variable
+and hand the flow an addon that re-resolves to something other than what
+was measured.
+
+### Bringing up a new design
+
+Wire up only the strictly necessary variables — sources, SDC, platform —
+and let the pin fill in the floorplan:
+
+```bash
+bazelisk run //flow/designs/<platform>/<design>:<name>_auto_floorplan_pin
+```
+
+## When to re-run it
+
+| | cadence |
+|---|---|
+| **ORFS itself** | rarely — when the flow or PDK moves materially, not per OpenROAD bump |
+| **A design under development** | nightly, against the day's RTL |
+
+Ideas for making this better, and the bugs still open, are collected in
+[docs/plans/auto_floorplan_ideas.md](plans/auto_floorplan_ideas.md).
+
+## Limits worth knowing
+
+- **Interactions between the coordinates are not explored.** Coordinate
+  descent finds a good point, not necessarily the best one.
+- **The ladder can saturate or clip.** On gcd the core stops shrinking
+  past utilization 78, so the top rungs are wasted candidates; on ibex
+  the best `J` was at the top rung, meaning the ladder was too narrow and
+  left area unclaimed.
+- **A design that meets timing with a small margin can lose it.** The
+  objective values period against area at a fixed rate; it does not know
+  that crossing zero slack is a change in kind. Check the reported
+  achieved period against your target before accepting a shrink.
+- **`FLOORPLAN_DEF` and `FOOTPRINT` designs are skipped.** A die that
+  comes from a DEF or a pad ring is a constraint, not a choice.

--- a/docs/auto_floorplan.md
+++ b/docs/auto_floorplan.md
@@ -205,6 +205,61 @@ and let the pin fill in the floorplan:
 bazelisk run //flow/designs/<platform>/<design>:<name>_auto_floorplan_pin
 ```
 
+## Pinning a design in another repository
+
+The config path the pin target passes is relative to the repository the
+design lives in, so for an ORFS design it is relative to an ORFS
+checkout -- not to the bazel workspace you ran from, and not to the
+fetched archive, which is read-only. Pass the checkout to edit:
+
+```bash
+bazelisk run @orfs//flow/designs/asap7/gcd:gcd_auto_floorplan_pin ~/ORFS
+```
+
+Without that argument the pin falls back to `BUILD_WORKSPACE_DIRECTORY`,
+which is right only when the design and the workspace are the same
+repository -- a design in this repo, or ORFS built as the root module.
+
+## After pinning: rules-base.json comes from CI, not from here
+
+A pinned floorplan changes the design's QoR, so its `rules-base.json`
+bounds no longer describe it. **Do not regenerate them from a local
+run.**
+
+The bounds are golden values for CI, and a local flow does not reproduce
+what CI measured. Yosys is not idempotent -- the same RTL through the
+same version can yield a different netlist, and ORFS upstream treats
+that pointer-iteration drift as expected rather than as a bug -- and
+tool versions, thread counts and the platform all move the numbers
+besides. Bounds derived locally therefore encode local noise, and the
+next CI run fails against them for reasons that have nothing to do with
+the design.
+
+This is not hypothetical. `//test:orfs_design_tests` carries `mock-alu`
+as a `build_test` rather than a `<design>_test` for exactly this reason:
+its metric comparison missed one of 27 bounds by 0.9%
+(`finish__timing__setup__tns` -18663.9 against -18500) with zero DRC
+errors and every other check passing, purely from an OpenROAD bump
+against bounds tuned at the previous pin.
+
+The supported path is the ORFS-side one, driven by CI:
+
+  * `.github/workflows/github-actions-update-rules.yml` fires on a
+    `set-new-golden` `repository_dispatch` and runs
+    `flow/util/updateRules.py --commitSHA <sha>`, which pulls the
+    metrics **CI itself measured** for that commit from the metrics API
+    and opens a draft PR with the updated rules files.
+  * `flow/util/genRuleFile.py` and `genAllRuleFiles.sh` are what that
+    path uses underneath (`--update`, `--tighten`, `--failing`,
+    `--metrics`). Running them by hand against local metrics is the
+    thing to avoid.
+
+So after pinning a floorplan: land the `config.mk` change, let CI
+measure it, and request the golden update for that commit. Read a local
+metrics diff as a sanity check on direction and magnitude -- did the
+area move the way the derivation predicted -- never as the values to
+commit.
+
 ## When to re-run it
 
 | | cadence |

--- a/docs/auto_floorplan.md
+++ b/docs/auto_floorplan.md
@@ -162,8 +162,18 @@ Total concurrency is `--jobs × AF_JOBS × AF_THREADS`. Pick a shape:
 
 | goal | `--jobs` | `AF_JOBS` | `AF_THREADS` |
 |---|---|---|---|
-| one design, all cores | 1 | 8 | 4 |
+| one small design, all cores | 1 | 8 | 4 |
+| one large design | 1 | 4 | 2 |
 | many designs at once | 8 | 2 | 2 |
+
+**Size `AF_JOBS` by memory, not by cores.** Each candidate holds a whole
+flow in RAM. A `swerv_wrapper` candidate peaks near 18 GB, so `AF_JOBS=8`
+wants about 144 GB while occupying only 16 cores — that ran for four
+hours on a 122 GB machine and was then OOM-killed, losing the run.
+Candidates reach their detailed-route peak at different moments, so the
+ceiling is not hit until several coincide, and a run that looks healthy
+for hours can still die. Budget
+`AF_JOBS <= (RAM - a few GB) / peak-RSS-per-candidate`.
 
 ## What the pin writes
 

--- a/docs/plans/auto_floorplan_ideas.md
+++ b/docs/plans/auto_floorplan_ideas.md
@@ -1,0 +1,336 @@
+# Floorplan derivation: open questions and things to try
+
+Working notes. Everything here is deferred, not done. See
+[docs/auto_floorplan.md](../auto_floorplan.md) for what the derivation
+currently does.
+
+The measurements below were produced in
+[ORFS PR #4487](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4487),
+where this work started before the config.mk BUILD DSL moved here. That
+PR is closed; it remains the record of the runs cited throughout.
+
+Ordered roughly by expected value.
+
+## 0. Blocking defects found by the `aes_lvt` existence proof
+
+Found while trying to turn `aes_lvt` into a single-concern upstream PR
+(2026-09-01). The attempt was stood down; nothing was filed.
+
+Summary, after all four were chased down:
+
+| | | status |
+|---|---|---|
+| **0a** | the incumbent ran at a density the design never states | tooling bug, **fixed and verified** |
+| **0b** | a 9 ps oracle-vs-flow gap on identical coordinates | **not established** -- inside the noise |
+| **0c** | checked-in `rules-base.json` lags the toolchain | not a bug; constrains method |
+| **0d** | the objective accepts a lost timing closure | **policy defect, open** |
+
+0d is the one that produced the bad result. It is not a measurement
+error and it survives perfect information: substituting the flow's own
+numbers for the oracle's, the objective still accepts the losing trade by
+five times the noise band. Fixing 0a and 0b would not have saved it.
+
+**0a and 0b are defects in this campaign's own tooling**, which lives
+only on this branch -- `auto_floorplan.tcl`,
+`auto_floorplan_candidate.tcl`, `auto_floorplan_flow.tcl` and
+`pinAutoFloorplan.py` are not in `origin/master`. Neither is an ORFS bug;
+`place_density_with_lb_addon` (`flow/scripts/util.tcl:184`) behaves
+exactly as this tooling assumed. **0c is not a bug at all** -- it is a
+property of ORFS master that constrains what a PR can prove. **0d must be
+resolved before any derived floorplan is proposed upstream** -- until the
+selector and the acceptance test agree about timing closure, the
+derivation can hand back a design the test will reject.
+
+`aes_lvt`, derived winner `CORE_UTILIZATION 40 -> 56`,
+`PLACE_DENSITY 0.65 -> 0.611`, measured by the production flow on both
+arms:
+
+| | baseline | pinned | |
+|---|---:|---:|---|
+| `finish__timing__setup__ws` | **+9.00** | **-0.46** | lost closure |
+| achieved period (clock - WS) | 351.0 | 360.46 | +2.7% |
+| `finish__design__core__area` | 3480.4 | 2484.2 | -28.6% |
+| `finish__design__instance__area` | 1308.8 | 1300.4 | -0.6% |
+| `detailedroute__route__wirelength` | 51683 | 49648 | -3.9% |
+| `detailedroute__route__drc_errors` | 0 | 0 | |
+
+A 28.6% smaller core bought by giving up all 9 ps of setup margin and
+crossing zero slack.
+
+Before the 0a fix the derivation scored this as a **win on both axes**,
+reporting the winner as both smaller *and* 2.5% faster. With 0a fixed it
+reports the shape correctly -- incumbent 3480 um2 at 351, winner 2484
+um2 at 359, a trade -- and then accepts it anyway, which is 0d.
+
+### 0a. The incumbent was not run at the design's own density -- FIXED
+
+`auto_floorplan.tcl` substituted `addon 0.10` whenever a design expressed
+no incumbent headroom fraction. For a raced candidate the addon *is* the
+coordinate and that is the point; for the **incumbent** it silently
+replaced the design's stated `PLACE_DENSITY`, so the reference point of
+the whole walk was a floorplan the design has never built.
+
+Fixed by `af_incumbent_density` plus an `AF_DENSITY` passthrough: a
+design stating a fixed density now has the utilization ladder held at
+that density, in that form.
+
+Verified on `aes_lvt`. The incumbent candidate now reports achieved
+**351** where the production flow measures **351.0**, and its objective
+value `J = 25.82829` matches the `J` computed independently from
+production `metadata.json` to five decimals. Before the fix it reported
+360.3 -- 9.3 ps pessimistic against a floorplan that did not exist.
+
+### 0b. Oracle-vs-flow gap -- NOT ESTABLISHED
+
+On the winner's own coordinates the candidate harness reads achieved
+351.4 and the production flow delivers 360.46, a 9.1 ps gap on runs that
+should be identical. The first draft of this section called that 4.4
+sigma against a `delta_tie` of 4.15 ps and treated it as a defect. That
+was wrong twice over:
+
+- The **noise floor is itself unstable.** Two runs of the same design,
+  each taking 2 sigma over 8 placer seeds, gave 4.15 ps and 6.87 ps --
+  a 65% swing. Against the larger estimate the gap is 1.3 sigma.
+- Per 0c, this design gained +9 ps from six weeks of ordinary toolchain
+  drift, so 9 ps is simply the scale on which its timing moves.
+
+So the gap cannot presently be distinguished from noise, and `delta_tie`
+over 8 seeds is too imprecise to settle it. That is a measurement
+problem, and it is the same one named in section 7: the binding
+constraint is that two points cannot be told apart, not that the good
+point cannot be found. Resolving it needs a better variance estimate
+(more seeds, or common random numbers across arms), not more search.
+
+### 0c. Checked-in `rules-base.json` files are stale, so a rules diff proves nothing
+
+`rules-base.json` in `origin/master` is not a description of what the
+current toolchain produces. Last regeneration, asap7:
+
+| date | designs |
+|---|---|
+| 2026-07-16 | `aes_lvt`, `gcd`, `gcd-ccs`, `jpeg_lvt`, `swerv_wrapper` |
+| 2026-08-06 | `aes`, `aes-block`, `aes-mbff`, `cva6`, `ethmac`, `mock-alu`, `mock-cpu`, `riscv32i-mock-sram` |
+| 2026-08-12..25 | `uart`, `ibex`, `coralnpu`, `jpeg`, `ethmac_lvt`, `riscv32i` |
+
+For `aes_lvt` (generated 2026-07-16, measured fresh 2026-09-01 on
+`origin/master` + its accompanying `tools/OpenROAD`):
+
+| metric | bound | implied when generated | today | drift |
+|---|---:|---:|---:|---:|
+| `finish__timing__setup__ws` | -18.0 | 0.0 | +9.00 | +9 ps |
+| `detailedroute__route__wirelength` | 60074 | 52238 | 51683 | -1.1% |
+| `finish__design__instance__area` | 1499 | 1303 | 1309 | +0.4% |
+
+The design gained 9 ps of setup margin from toolchain movement alone in
+six and a half weeks. Nothing is wrong with the guard -- it is one-sided
+and a design getting faster is not a regression -- but it means the file
+lags the flow by however long since the last `update rules`.
+
+Two things follow.
+
+**A `config.mk` + `rules-base.json` PR conflates two changes.**
+Regenerating rules on a stale file writes the floorplan change *and* the
+accumulated drift into one diff. On `aes_lvt` the drift on WS is +9 ps
+and the effect being claimed is ~9 ps, so the two are the same size and a
+reviewer cannot separate them. Any such PR must regenerate twice --
+once on unmodified master to publish the drift alone, then again with the
+`config.mk` change -- or the existence proof is unfalsifiable.
+
+**Never back-solve a baseline out of a checked-in bound.** This was done
+once here and produced a baseline of `ws = 0.0` where the real one is
+`+9.00`, which inverted the sign of the verdict on the whole design: it
+made a lost closure look like a 2.5% speedup. Measure both arms.
+
+### 0d. The objective accepts a lost timing closure
+
+**The defect that actually produced the bad `aes_lvt` result.** Unlike 0a
+and 0b it is not a measurement bug at all -- it survives perfect
+information.
+
+With the flow's own numbers substituted for the oracle's, `T = 360`,
+`tau = 2%`, `lambda = 3`:
+
+| | area | period | `P_eff` | `J` |
+|---|---:|---:|---:|---:|
+| incumbent | 3480.4 | 351.00 | 361.81 | 25.82829 |
+| winner, as the oracle saw it | 2484.2 | 351.40 | 361.90 | 25.49185 |
+| winner, as the flow delivers | 2484.2 | 360.46 | 365.22 | 25.51924 |
+
+`dJ = -0.309` against a noise band of 0.057. **The objective still
+accepts, comfortably, knowing the truth.** `lambda = 3` prices 28.6% of
+area as worth roughly 9.5% of period; the trade costs 2.7%. Correcting
+the oracle would not have changed the verdict.
+
+The cause is `P_eff` itself. A soft-plus makes crossing the timing target
+a slightly steeper slope and never a wall, which is exactly the property
+it was chosen for -- it removed the regime switch and made the policy
+differentiable. The cost of that smoothness is that zero slack stops
+being special.
+
+And `checkPareto.py` disagrees: it fails a lost closure outright, as "a
+change in kind, not a Pareto cost". **The selector and the acceptance
+test hold contradictory definitions of closure**, and every derived
+floorplan is chosen by the selector and judged by the test. They must be
+reconciled before any of this is proposed upstream.
+
+Which one gives is a real design question, not an oversight to patch:
+
+- Making closure a hard constraint in the objective restores the regime
+  switch that `P_eff` was introduced to remove, and reintroduces a
+  discontinuity at a point the measurement cannot resolve -- with
+  `delta_tie` at 4-7 ps and the verdict turning on 0.46 ps, the
+  derivation would be gating on noise.
+- Leaving the objective alone means accepting that the derivation
+  optimises a quantity the project does not actually want, and relying
+  on the Pareto test to catch it afterwards -- which works, but wastes a
+  full derivation per rejection.
+- A third option: keep the smooth objective for *ranking* and apply
+  closure as a survival filter, the way DRC already is. A candidate that
+  misses the target is eliminated rather than priced, which needs no
+  discontinuity in `J` because it never reaches `J`.
+
+The third is the shape the guards already use and is the recommendation,
+but it inherits the same resolution problem: eliminating on a 0.46 ps
+miss when the noise floor is 6.87 ps is a coin flip. Whatever is chosen
+has to state what margin counts as missing.
+
+## 1. Replace coordinate descent with a joint design
+
+**The most interesting open item.**
+
+The derivation currently walks utilization, then density, then aspect,
+each conditioned only on the previous winner. That is a fixed
+information path, and it structurally cannot see interactions: aspect is
+only ever evaluated at one area point, so "does aspect ratio matter?"
+is not actually being asked. The best aspect at 40% utilization need not
+be the best at 56%.
+
+Instead, spend the same ~20 evaluations on a **joint design over the
+three coordinates** — a Latin hypercube or similar space-filling sample —
+and let the data say which coordinate explains the variance. Same budget,
+no assumed structure, and it answers the interaction question rather
+than assuming it away.
+
+This is the transferable lesson from *Attention Is All You Need*, with
+the architecture stripped off: RNNs assume recency and CNNs assume
+locality; attention's contribution was to stop hard-coding *which things
+are relevant to which* and let the content decide. Our coordinate order
+is exactly such a hard-coded assumption, and it is one we have never
+tested.
+
+Practical notes:
+
+- The sample must include the incumbent, which stays the reference point
+  (see §2).
+- With n ≈ 20 over 3 dimensions, a fitted response surface is plausible;
+  with the noise floors measured so far (0.3%–10% of clock, design
+  dependent) it may not be, and the honest fallback is ranking only.
+- This changes what the evidence file records — currently phase-tagged,
+  would become a design matrix.
+
+## 2. Multi-fidelity: a cheap estimator with a fitted correction
+
+The pre-route proxy was measured not to rank the utilization axis
+(ρ = −1.000 on gcd, +0.100 on gcd-ccs against the finished flow), which
+is why the derivation runs the full flow per candidate and is expensive.
+
+The residual framing from *ResNet* suggests the missing option. ResNet's
+lesson was not "add skip connections", it was **reparameterise so that
+the identity is free and you learn the difference** — and, in the
+architecture, *add* a shortcut path alongside the full one rather than
+replacing it. Applied here: run the full flow on 3–4 rungs, fit the
+proxy's per-design offset against those, and use the corrected proxy for
+the rest.
+
+The macro-place race's "pruning cascade" is this shape already. What we
+have that it did not is the diagnostic: **ρ between the proxy's deltas
+and the flow's deltas, per design, decides whether that design's proxy is
+correctable at all.** ρ = −1.00 says no for gcd; it is not −1.00
+everywhere, and the measurement is cheap once a full-flow ladder exists.
+
+Caution from what was already tried: the difference-based calibration
+(estimated = flow_anchor + proxy delta) was tested across designs and
+gave ρ = −0.275 with 2/9 sign agreement. The bias is *not* common-mode,
+so a global correction does not work. A per-design correction is a
+different and still-open question.
+
+## 3. Widen the ladder, and stop when it saturates
+
+Both ends of the current `{0.9 … 1.4}` utilization ladder are wrong on
+real designs:
+
+- **Clipping.** Every design starting at utilization 40 landed on exactly
+  56 — the 1.4× ceiling. Those results are a lower bound on the available
+  win, not the optimum.
+- **Saturation.** On gcd the core stops shrinking past utilization 78
+  (the row/site snap quantises it), so the top rungs are wasted
+  evaluations.
+
+An adaptive ladder — keep climbing while area still falls and candidates
+still survive — costs nothing extra on saturating designs and finds the
+real answer on clipping ones.
+
+## 4. Normalisation is where the bugs were
+
+Recorded because it was not obvious in advance. The two worst defects in
+this campaign were normalisation failures, not search failures:
+
+- Judging the period axis on **WNS**, a signed quantity that lives near
+  zero, so fractional changes explode. `clock − WNS` is the stable
+  quantity. This one silently turned a +1.69% period change into
+  "catastrophically lost closure".
+- Expressing the noise floor as a fraction of **score** rather than of
+  the **clock period**, which hid that ethmac's floor was 525% of its
+  clock — i.e. that the measurement could not resolve anything at all.
+
+The general rule worth keeping: put a quantity in units that make it
+comparable across designs *before* comparing it. `delta_tie` as a unit is
+the good version of this.
+
+## 5. Is the scorer over-built?
+
+bazel-orfs#868's E3 found raw gpl HPWL ranks the grt macro-path mean at
+ρ +0.67 against the full-STA proxy's +0.72, CIs overlapping at n = 24 —
+i.e. the analytic no-STA readout was ranking-equivalent for that KPI at
+that operating point.
+
+Our candidates run STA *and* `repair_design` *and* `global_route`. If
+HPWL alone ranks equivalently for our KPI too, the flow oracle could be
+made much cheaper. This is testable against evidence already produced —
+no new flow runs — but note E3's result is for the macro-path mean on
+swerv at 30% utilization, a regime that PR measured to be
+period-saturated, so it does not transfer for free.
+
+## 6. Known bugs and unfinished work
+
+- **`aes-mbff` derives nothing.** Every candidate fails `IFP-0018`
+  "Unable to find site: asap7sc7p5t_pg". The platform adds
+  `ADDITIONAL_SITES += asap7sc7p5t_pg` when `CLUSTER_FLOPS = 1`
+  (`flow/platforms/asap7/config.mk`), with the site defined in the MBFF
+  LEFs; the staged `1_synth.odb` in the derivation does not carry it. The
+  normal aes-mbff flow works, so this is specific to the derivation.
+- **`<name>_pareto_test` predates the derive/pin split** and still
+  describes a per-build feature that no longer exists.
+- **Parallel synthesis is broken** for `riscv32i`,
+  `riscv32i-mock-sram` and `aes-block` after the bazel-orfs bump
+  (`per-module checkpoint missing: partition_*_canonical.rtlil`). Before
+  the floorplan stage, so unrelated to this work, but it costs four
+  designs from every table.
+- **Tier boundaries serialise.** The campaign left ~28 cores idle for
+  hours waiting on `jpeg` alone. Overlap tiers, or size them by measured
+  cost rather than by guessed size class.
+
+## 7. Where the deep-learning analogies stop
+
+Worth writing down so the borrowing stays honest. ResNet and
+transformers are about making *gradient-based* optimisation tractable
+across enormous parameter spaces. This problem is derivative-free
+optimisation over three coordinates with a black-box, noisy oracle at
+~30 minutes per evaluation and a budget of ~20.
+
+The binding constraint is **measurement**, not search: not "we cannot
+find the good point" but "we cannot tell two points apart, and each look
+is expensive". Architecture cleverness does not touch that. Variance
+reduction, common random numbers across arms, cheaper-but-calibrated
+evaluations, and racing/successive-halving under noise do — and that is
+the literature to read, not the deep-learning one.

--- a/ideas/auto-floorplan.md
+++ b/ideas/auto-floorplan.md
@@ -1,0 +1,136 @@
+# Auto floorplan: retiring the last three magic knobs
+
+Why does a user have to tell the flow DIE_AREA/CORE_UTILIZATION,
+ASPECT_RATIO and PLACE_DENSITY? Because each knob is a confession
+that an estimator is missing — a human prediction of downstream
+behavior standing where a measurement should be. The macro-place
+race (`macro-place-race.md`) retires that pattern for macro
+placement; this document is the plan for retiring it from the
+floorplan itself. Companion reading: `rtl-mpl.md` for why
+prediction-shaped knobs fail and measurement-shaped selection works.
+
+## What each knob actually encodes
+
+**PLACE_DENSITY.** Utilization (cell area / core area) is a global
+mean, computable from the inputs — ORFS already computes it
+(`place_density_with_lb_addon`'s lower bound). PLACE_DENSITY is a
+*local cap* on bin packing, and the gap between the two is headroom
+for things that have not happened yet: routing demand where wires
+will concentrate (a netlist property, not an area property), and
+cell growth the flow has not committed — repair_design and
+repair_timing insertions, CTS buffers, hold fixing, ECO margin. The
+swerv A/B showed repair effort varying between arms of identical
+starting area; that growth lands in whitespace the placer reserved
+*before knowing how much would be needed*. So the ADDON margin is a
+human estimate of the fog. It is also the canonical AutoTuner knob —
+the per-design hyperparameter search that the no-magic-knobs rule
+exists to ban.
+
+gpl cannot derive it because the correct value is defined by
+outcomes gpl does not simulate. It has partial mechanisms —
+routability-driven mode inflates cells in congested regions, a
+local, dynamic, *measured* density correction — but the global
+target survives as an input because nothing in the placer models
+repair growth.
+
+**DIE_AREA / CORE_UTILIZATION.** Area cannot be optimized against
+the period goal directly: a bigger core always makes period easier,
+so any blended objective inflates the die. Area is either a
+constraint (a budget handed down) or a frontier axis. The question a
+human answers today by hand-shmooing utilization — "what is the
+smallest core in which this netlist closes timing?" — is an oracle
+query, and the race is the oracle.
+
+**ASPECT_RATIO.** With macros present, the outline decides which
+channel structures are even possible; today's value is folklore per
+design. It is a raced coordinate like any other.
+
+## The scheme
+
+The race machinery never cared what varies between candidates —
+seeds were merely the first coordinate. Extend the candidate space:
+
+1. **Density: measured floor plus a raced ladder.** Keep the
+   computed lower bound (it is derived, not guessed). Race a ladder
+   of steps above it. The scorer already sees the congestion half of
+   the answer (overflow trajectory, RUDY); if E9 shows it is blind
+   to the repair-growth half, the scoring pass gains the estimation
+   ladder's repair rung (RUN_REPAIR_DESIGN) — a fidelity dial that
+   already exists, not new machinery. The winning density also feeds
+   RTL-MP's -target_util, so both consumers of the knob are fixed by
+   one measurement.
+2. **Area: race-as-oracle inside a utilization shmoo.** For a given
+   outline, run the macro-place race; ask whether the winner meets
+   the period target (with delta_tie discipline — a miss inside the
+   noise band is a tie, not a failure); bisect utilization on that
+   answer. Output: the smallest area whose raced winner closes, plus
+   the period-vs-area frontier as a byproduct. This is the veteran's
+   manual methodology, mechanized, with noise bars.
+3. **Aspect ratio: raced per area point.** The outline candidates at
+   each utilization step differ in aspect; the seed race under each
+   outline explores the channel structures that outline permits.
+4. **Stopping and selection inherit the knob-free rules** from the
+   macro-place race unchanged: dimensionless overflow milestones,
+   trajectory-derived movement bounds, dominance elimination,
+   interchangeable ties, delta_tie as the only threshold — measured,
+   never searched.
+
+## Cost structure
+
+Area/aspect candidates forfeit the shared floorplan spine (each
+outline needs its own floorplan, ~30–60s on swerv), but clustering
+is a netlist property and amortizes across *all* outlines — the
+in-process design's biggest win survives. The search is a shallow
+outer loop (a bisection on utilization, a few aspect points) around
+the already-priced inner race (~22 min at k=24 today, dropping with
+the E3/E4 scorer and topology work). A full auto-floorplan of swerv
+class is plausibly an overnight artifact; with the cascade and
+early-stop scorer, an evening one.
+
+## What this displaces
+
+- **AutoTuner on these knobs.** Search guesses and re-runs the flow
+  end to end per trial; the race measures candidates against a
+  ranking-accurate score with a noise floor, reusing shared
+  prefixes. Where a knob's value is decided by data, it stops being
+  a hyperparameter.
+- **The folklore config.mk.** DIE_AREA, ASPECT_RATIO,
+  PLACE_DENSITY_LB_ADDON entries hand-carried from design to design
+  become outputs: the flow's inputs shrink toward netlist +
+  constraints + period target.
+- Nothing about constraints changes: fences, halos, blockages, IO
+  regions remain inputs — human knowledge enters as constraints the
+  race runs inside, never as coordinates (see rtl-mpl.md on manual
+  placement).
+
+## Proof obligations
+
+Phase 2 starts only after the macro-place race's E1–E7 hold (a
+ranking-accurate scorer is the load-bearing assumption; without it
+the oracle answers noise). Then:
+
+- **E9 — density race fidelity** (also listed in
+  macro-place-race.md): does the scorer (± the repair rung) rank a
+  density ladder consistently with grt-after-repair outcomes? Same
+  offline grading pattern as E3, on a density ladder instead of a
+  seed population.
+- **E10 — the area oracle.** On swerv: bisect utilization with the
+  race as oracle against a period target; validate the reported
+  minimum-area point by running its neighbors (one utilization step
+  denser and looser) through the production tail. Success: the
+  frontier point is real within delta_tie; cost of the whole
+  derivation stays overnight-class.
+- **E11 — aspect sensitivity.** At the E10 area point, race a small
+  aspect ladder; success is either a measured preference beyond
+  delta_tie or a demonstrated "aspect is a tie here" — both are
+  results; folklore values get graded, not assumed.
+
+## Status
+
+Idea stage. Depends on: macro-place race E1–E7 (in flight — E1's
+evaluate walk and delta_tie are running as of 2026-08-31), the E3
+scorer-fidelity curve, and the E4 topology recalibration with the
+carried gpl density-scatter patch (0045 / OpenROAD PR #11262).
+Nothing here requires new OpenROAD changes beyond what the race
+already carries; the outer loops are flow-side orchestration over
+existing rungs.

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -43,6 +43,15 @@ ORFS_BAZEL_PLATFORMS = [
 ORFS_PATCHES = [
     Label("//patches:0037-orfs-single-writer-1_synth-sdc.patch"),
     Label("//patches:0039-orfs-slang-plugin-fallback.patch"),
+    # flow.tcl as a label, so the floorplan derivation's drift test can
+    # compare its duplicated stage sequence against the one that runs.
+    #
+    # This patch edits ORFS's own flow/BUILD, so it stops applying once
+    # ORFS deletes that file. _GENERATE_FLOW_BUILD therefore exports
+    # scripts/flow.tcl too, and //test:orfs_flow_build_test requires it.
+    # Both mechanisms are needed: the patch covers an ORFS that still
+    # ships flow/BUILD, the generated file covers one that does not.
+    Label("//patches:0047-orfs-export-flow-tcl.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk
@@ -163,6 +172,7 @@ exports_files(
 
 exports_files(
     [
+        "scripts/flow.tcl",
         "scripts/synth.tcl",
         "scripts/variables.yaml",
     ],

--- a/patches/0047-orfs-export-flow-tcl.patch
+++ b/patches/0047-orfs-export-flow-tcl.patch
@@ -1,0 +1,28 @@
+Expose flow.tcl as an addressable source label.
+
+bazel-orfs's floorplan derivation runs the production flow from floorplan
+to finish in one process, which means auto_floorplan_flow.tcl duplicates
+flow.tcl's stage sequence -- flow.tcl runs on source and offers no seam to
+enter after synthesis. A duplicated sequence that has to stay in step rots
+silently: a stage added to flow.tcl would simply not be measured, and the
+derived floorplan would be chosen against a flow that no longer exists.
+
+auto_floorplan_flow_test.py makes that failure loud by extracting the
+stage order from both files, which needs flow.tcl as a label.
+
+Same argument, and the same shape, as the scripts/synth.tcl export
+immediately above: read the file that actually runs rather than vendor a
+copy that can drift.
+
+diff --git a/flow/BUILD b/flow/BUILD
+--- a/flow/BUILD
++++ b/flow/BUILD
+@@ -24,7 +24,7 @@
+ # instead of vendoring its own (drifting) copy at the bazel-orfs repo
+ # root. See bazel-orfs `private/rules.bzl`.
+ exports_files(
+-    ["scripts/synth.tcl"],
++    ["scripts/synth.tcl", "scripts/flow.tcl"],
+     visibility = ["//visibility:public"],
+ )
+ 

--- a/pin_auto_floorplan.py
+++ b/pin_auto_floorplan.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+
+"""Write the floorplan values AUTO_FLOORPLAN derived into a design's config.mk.
+
+The config.mk DSL is where a design's values live, so that is where these
+land -- as ordinary variables, indistinguishable from hand-written ones.
+Somebody reading a config.mk to understand a design should not have to
+care which numbers were typed and which were measured; the provenance
+belongs in the commit that this run produces, not in the file.
+
+So: no generated block, no markers, no "do not edit" banner. An existing
+assignment is updated in place, keeping its position, spacing and
+assignment operator. A variable the design does not set yet is appended
+next to the ones it does.
+
+That makes bringing up a new design a two-step job: wire up the strictly
+necessary variables in config.mk -- the sources, the SDC, the platform --
+and let this fill in the floorplan.
+
+Usage (via the generated bazel target):
+    bazelisk run //flow/designs/<platform>/<design>:<name>_auto_floorplan_pin
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# The outline, in the two forms a config.mk can state it. Which one gets
+# written is decided by the design: whichever it already uses, and the
+# utilization form for a design that states neither yet.
+RECT_VARS = ["DIE_AREA", "CORE_AREA"]
+UTIL_VARS = ["CORE_UTILIZATION", "CORE_ASPECT_RATIO", "CORE_MARGIN"]
+
+# Density, in the two forms it can be stated -- and exactly ONE of them is
+# written.
+#
+# They are not additive: place_density_with_lb_addon() returns the addon
+# form whenever PLACE_DENSITY_LB_ADDON is set and non-empty, and only
+# falls back to PLACE_DENSITY otherwise. Writing both leaves a dead
+# PLACE_DENSITY in the file and, worse, hands the flow an addon that gets
+# re-resolved against a lower bound computed at run time -- which need not
+# reproduce the absolute density that was actually measured.
+#
+# A design that already states an addon keeps stating one. Anything else,
+# including a design that states neither, gets the absolute density: a pin
+# should reproduce a measurement, not re-derive it.
+ADDON_VAR = "PLACE_DENSITY_LB_ADDON"
+DENSITY_VAR = "PLACE_DENSITY"
+
+# evidence key for each variable
+KEYS = {
+    "DIE_AREA": "die_rect",
+    "CORE_AREA": "core_rect",
+    "CORE_UTILIZATION": "util",
+    "CORE_ASPECT_RATIO": "aspect",
+    "CORE_MARGIN": "margin",
+    "PLACE_DENSITY_LB_ADDON": "addon",
+    "PLACE_DENSITY": "density",
+}
+
+
+def assignment_re(var):
+    """Match `export VAR = value`, `VAR ?= value`, and the spacing variants.
+
+    Captures the text up to and including the operator so it can be put
+    back verbatim -- a pin should change a value, not reformat the file.
+    """
+    return re.compile(
+        r"(?m)^(\s*(?:export\s+)?" + re.escape(var) + r"\s*(?::=|\?=|\+=|=))([^\n]*)$"
+    )
+
+
+def find_assignment(text, var):
+    m = assignment_re(var).search(text)
+    return m if m else None
+
+
+def format_value(val):
+    if isinstance(val, float):
+        # 6 significant digits: enough to reproduce the geometry, short
+        # enough to read. Trailing zeros are noise in a config.mk.
+        return f"{val:.6g}"
+    return str(val)
+
+
+def set_variable(text, var, value):
+    """Update an existing assignment in place, or return None if absent."""
+    m = find_assignment(text, var)
+    if not m:
+        return None
+    # Preserve the original spacing after the operator where there was any.
+    lead = " " if m.group(2).startswith(" ") else " "
+    return text[: m.start(2)] + lead + format_value(value) + text[m.end(2) :]
+
+
+def append_variables(text, pairs, anchor_vars):
+    """Append assignments after the last floorplan variable the design sets.
+
+    Keeps related settings together rather than scattering them at the end
+    of the file, which is what a person would do by hand.
+    """
+    if not pairs:
+        return text
+    end = None
+    for var in anchor_vars:
+        m = find_assignment(text, var)
+        if m and (end is None or m.end() > end):
+            end = m.end()
+    block = "".join(f"export {v} = {format_value(val)}\n" for v, val in pairs)
+    if end is None:
+        sep = "" if text.endswith("\n") else "\n"
+        return text + sep + block
+    return text[: end + 1] + block + text[end + 1 :]
+
+
+def extract_evidence(path):
+    """Pull the evidence JSON out of a floorplan log, or read it directly.
+
+    The floorplan stage echoes its evidence into the stage log between
+    markers, because files written to REPORTS_DIR are not declared build
+    outputs and a sandboxed build discards them. The log is a declared
+    output, so it is the reliable source.
+    """
+    with open(path, errors="replace") as f:
+        text = f.read()
+    if "AUTO_FLOORPLAN-EVIDENCE-BEGIN" in text:
+        blk = text.split("AUTO_FLOORPLAN-EVIDENCE-BEGIN")[-1]
+        blk = blk.split("AUTO_FLOORPLAN-EVIDENCE-END")[0]
+    else:
+        blk = text
+    try:
+        return json.loads(blk)
+    except json.JSONDecodeError as e:
+        sys.exit(f"[ERROR] could not parse AUTO_FLOORPLAN evidence in {path}: {e}")
+
+
+def plan(config_text, winner):
+    """Which variables to write, in which form.
+
+    A design that states an explicit rectangle keeps stating one; anything
+    else gets the utilization form, which is also what a design stating
+    neither yet is given -- it adapts as the netlist grows, where a
+    rectangle would silently change the utilization instead.
+    """
+    uses_rect = all(find_assignment(config_text, v) for v in RECT_VARS)
+    outline = RECT_VARS if uses_rect else UTIL_VARS
+    density = [ADDON_VAR] if find_assignment(config_text, ADDON_VAR) else [DENSITY_VAR]
+    out = []
+    for var in outline + density:
+        val = winner.get(KEYS[var])
+        if val is None or val == -1:
+            continue
+        out.append((var, val))
+    return out, uses_rect
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("evidence", help="floorplan stage log, or evidence JSON")
+    ap.add_argument("config", help="config.mk path, relative to the workspace")
+    args = ap.parse_args()
+
+    root = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    config_path = os.path.join(root, args.config) if root else args.config
+    if not os.path.isfile(config_path):
+        sys.exit(f"[ERROR] no config.mk at {config_path}")
+
+    ev = extract_evidence(args.evidence)
+    winner = ev.get("winner")
+    if not winner:
+        sys.exit(
+            "[ERROR] this run selected no winner (every candidate was "
+            "eliminated, or the ladder did not resolve). There is nothing "
+            "to pin; the design is already using its config.mk values."
+        )
+
+    with open(config_path) as f:
+        before = f.read()
+
+    pairs, uses_rect = plan(before, winner)
+    text = before
+    appended = []
+    for var, val in pairs:
+        updated = set_variable(text, var, val)
+        if updated is None:
+            appended.append((var, val))
+        else:
+            text = updated
+    text = append_variables(
+        text, appended, RECT_VARS + UTIL_VARS + [ADDON_VAR, DENSITY_VAR]
+    )
+
+    if text == before:
+        print(f"[INFO] {args.config} already holds these values")
+        return
+
+    with open(config_path, "w") as f:
+        f.write(text)
+
+    # Provenance goes here, for the commit message -- not into the file.
+    inc = ev.get("incumbent", {})
+    period = ev.get("period", {})
+    dt = ev.get("delta_tie")
+    print(f"[INFO] {args.config}: wrote {', '.join(v for v, _ in pairs)}")
+    print(f"[INFO]   form: {'DIE_AREA/CORE_AREA' if uses_rect else 'CORE_UTILIZATION'}")
+    for var, val in pairs:
+        mark = " (new)" if any(var == v for v, _ in appended) else ""
+        print(f"[INFO]   {var} = {format_value(val)}{mark}")
+    if isinstance(dt, (int, float)):
+        print(f"[INFO]   measured noise floor (delta_tie): {dt:.4g}")
+    tgt, ach = period.get("sdc_target"), period.get("achieved")
+    if isinstance(tgt, (int, float)) and isinstance(ach, (int, float)):
+        print(f"[INFO]   achieved {ach:.4g} against an SDC target of {tgt:.4g}")
+    if inc.get("util") is not None:
+        print(f"[INFO]   utilization was {inc['util']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pin_auto_floorplan.py
+++ b/pin_auto_floorplan.py
@@ -19,6 +19,15 @@ and let this fill in the floorplan.
 
 Usage (via the generated bazel target):
     bazelisk run //flow/designs/<platform>/<design>:<name>_auto_floorplan_pin
+
+For a design in another repository, pass that repository's root:
+    bazelisk run @orfs//flow/designs/asap7/gcd:gcd_auto_floorplan_pin ~/ORFS
+
+The config path the target passes is relative to the repository the
+design lives in, so for an @orfs design it is relative to an ORFS
+checkout -- not to the bazel workspace this ran from, and not to the
+fetched archive, which is read-only. BUILD_WORKSPACE_DIRECTORY is the
+right default only when the design and the workspace are the same repo.
 """
 
 import argparse
@@ -159,13 +168,40 @@ def plan(config_text, winner):
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("evidence", help="floorplan stage log, or evidence JSON")
-    ap.add_argument("config", help="config.mk path, relative to the workspace")
+    ap.add_argument(
+        "config",
+        help="config.mk path, relative to the repository the design is in",
+    )
+    ap.add_argument(
+        "root",
+        nargs="?",
+        help=(
+            "root of the checkout to edit. Required for a design in "
+            "another repository -- e.g. an @orfs design, whose config "
+            "path is relative to an ORFS checkout and whose fetched copy "
+            "is read-only. Defaults to BUILD_WORKSPACE_DIRECTORY, which "
+            "is correct only when the design lives in the workspace this "
+            "was run from."
+        ),
+    )
     args = ap.parse_args()
 
-    root = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    root = args.root or os.environ.get("BUILD_WORKSPACE_DIRECTORY")
     config_path = os.path.join(root, args.config) if root else args.config
     if not os.path.isfile(config_path):
-        sys.exit(f"[ERROR] no config.mk at {config_path}")
+        if args.root:
+            sys.exit(
+                f"[ERROR] no {args.config} under {args.root}.\n"
+                f"        {args.root} does not look like a checkout holding "
+                f"this design -- pass the root of one, e.g. ~/ORFS for an "
+                f"@orfs design."
+            )
+        sys.exit(
+            f"[ERROR] no config.mk at {config_path}.\n"
+            f"        If this design lives in another repository, pass that "
+            f"checkout's root as a third argument, e.g.\n"
+            f"          bazelisk run <target> ~/ORFS"
+        )
 
     ev = extract_evidence(args.evidence)
     winner = ev.get("winner")

--- a/pin_auto_floorplan_test.py
+++ b/pin_auto_floorplan_test.py
@@ -53,6 +53,88 @@ def run(config_text, evidence=None):
             return p.returncode, f.read(), p.stdout + p.stderr
 
 
+class TestRootArgument(unittest.TestCase):
+    """Where the config.mk being edited is looked up.
+
+    The config path a target passes is relative to the repository the
+    design lives in. For an @orfs design that is an ORFS checkout, not
+    the bazel workspace the command ran from, and not the fetched archive
+    -- which is read-only. So:
+
+        bazelisk run @orfs//flow/designs/asap7/gcd:gcd_auto_floorplan_pin ~/ORFS
+    """
+
+    def _run(self, argv, env=None):
+        d = tempfile.mkdtemp()
+        rel = os.path.join("flow", "designs", "asap7", "gcd", "config.mk")
+        cfg = os.path.join(d, rel)
+        os.makedirs(os.path.dirname(cfg))
+        with open(cfg, "w") as f:
+            f.write("export CORE_UTILIZATION = 65\n")
+        ev = os.path.join(d, "ev.json")
+        with open(ev, "w") as f:
+            json.dump(EVIDENCE, f)
+        full_env = dict(os.environ)
+        full_env.pop("BUILD_WORKSPACE_DIRECTORY", None)
+        full_env.update(env or {})
+        p = subprocess.run(
+            [sys.executable, SCRIPT, ev] + [a.format(d=d, rel=rel) for a in argv],
+            capture_output=True,
+            text=True,
+            env=full_env,
+        )
+        with open(cfg) as f:
+            return p.returncode, f.read(), p.stdout + p.stderr, d
+
+    def test_explicit_root_is_used(self):
+        rc, text, out, _ = self._run(["{rel}", "{d}"])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("78", text)
+
+    def test_explicit_root_wins_over_the_environment(self):
+        # A stale BUILD_WORKSPACE_DIRECTORY must not silently redirect
+        # the edit at the wrong checkout.
+        rc, text, out, d = self._run(
+            ["{rel}", "{d}"],
+            env={"BUILD_WORKSPACE_DIRECTORY": "/nonexistent"},
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("78", text)
+
+    def test_falls_back_to_build_workspace_directory(self):
+        d = tempfile.mkdtemp()
+        rel = os.path.join("flow", "designs", "asap7", "gcd", "config.mk")
+        cfg = os.path.join(d, rel)
+        os.makedirs(os.path.dirname(cfg))
+        with open(cfg, "w") as f:
+            f.write("export CORE_UTILIZATION = 65\n")
+        ev = os.path.join(d, "ev.json")
+        with open(ev, "w") as f:
+            json.dump(EVIDENCE, f)
+        env = dict(os.environ, BUILD_WORKSPACE_DIRECTORY=d)
+        p = subprocess.run(
+            [sys.executable, SCRIPT, ev, rel],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        with open(cfg) as f:
+            self.assertIn("78", f.read())
+
+    def test_wrong_root_says_what_to_pass(self):
+        rc, _, out, _ = self._run(["{rel}", "/tmp"])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("does not look like a checkout", out)
+        self.assertIn("~/ORFS", out)
+
+    def test_no_root_and_no_env_says_to_pass_one(self):
+        rc, _, out, _ = self._run(["{rel}"])
+        self.assertNotEqual(rc, 0)
+        self.assertIn("another repository", out)
+        self.assertIn("~/ORFS", out)
+
+
 class TestPin(unittest.TestCase):
     def test_updates_in_place_keeping_position(self):
         cfg = (
@@ -103,7 +185,12 @@ class TestPin(unittest.TestCase):
         cfg = "export DESIGN_NAME = newthing\nexport SDC_FILE = c.sdc\n"
         rc, out, log = run(cfg)
         self.assertEqual(rc, 0, log)
-        for v in ("CORE_UTILIZATION", "CORE_ASPECT_RATIO", "CORE_MARGIN", "PLACE_DENSITY"):
+        for v in (
+            "CORE_UTILIZATION",
+            "CORE_ASPECT_RATIO",
+            "CORE_MARGIN",
+            "PLACE_DENSITY",
+        ):
             self.assertIn(v, out)
         self.assertIn("export DESIGN_NAME = newthing", out)
 

--- a/pin_auto_floorplan_test.py
+++ b/pin_auto_floorplan_test.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+"""Tests for pin_auto_floorplan.py.
+
+The job is editing a config.mk in place without disturbing it, so the
+cases that matter are about what the file looks like afterwards: existing
+assignments keep their position and operator, missing ones land next to
+their relatives, and nothing else in the file moves.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "pin_auto_floorplan.py")
+
+WINNER = {
+    "util": 78.0,
+    "aspect": 1.25,
+    "margin": 2.0,
+    "density": 0.938,
+    "addon": 0.15,
+    "die_rect": "0.0 0.0 16.919 16.919",
+    "core_rect": "1.026 1.08 15.876 15.66",
+}
+
+EVIDENCE = {
+    "winner": WINNER,
+    "incumbent": {"util": 65, "aspect": 1, "addon": -1},
+    "delta_tie": 3.42,
+    "period": {"sdc_target": 310, "achieved": 355.1},
+}
+
+
+def run(config_text, evidence=None):
+    with tempfile.TemporaryDirectory() as d:
+        cfg = os.path.join(d, "config.mk")
+        ev = os.path.join(d, "ev.json")
+        with open(cfg, "w") as f:
+            f.write(config_text)
+        with open(ev, "w") as f:
+            json.dump(evidence or EVIDENCE, f)
+        p = subprocess.run(
+            [sys.executable, SCRIPT, ev, cfg],
+            capture_output=True,
+            text=True,
+        )
+        with open(cfg) as f:
+            return p.returncode, f.read(), p.stdout + p.stderr
+
+
+class TestPin(unittest.TestCase):
+    def test_updates_in_place_keeping_position(self):
+        cfg = (
+            "export DESIGN_NAME = gcd\n"
+            "export CORE_UTILIZATION = 65\n"
+            "export PLACE_DENSITY = 0.35\n"
+            "export SDC_FILE = constraint.sdc\n"
+        )
+        rc, out, log = run(cfg)
+        self.assertEqual(rc, 0, log)
+        lines = out.splitlines()
+        # position preserved: utilization is still the second line
+        self.assertTrue(lines[1].startswith("export CORE_UTILIZATION"))
+        self.assertIn("78", lines[1])
+        # unrelated lines untouched
+        self.assertIn("export DESIGN_NAME = gcd", out)
+        self.assertIn("export SDC_FILE = constraint.sdc", out)
+
+    def test_no_markers_or_banner(self):
+        rc, out, log = run("export CORE_UTILIZATION = 65\n")
+        self.assertEqual(rc, 0, log)
+        for banned in ("BEGIN AUTO_FLOORPLAN", "do not edit", "generated"):
+            self.assertNotIn(banned, out)
+
+    def test_preserves_conditional_operator(self):
+        # A design that deliberately allows the platform to override keeps
+        # doing so; a pin changes the value, not the semantics.
+        rc, out, log = run("export PLACE_DENSITY ?= 0.35\n")
+        self.assertEqual(rc, 0, log)
+        self.assertIn("export PLACE_DENSITY ?= 0.938", out)
+
+    def test_appends_missing_next_to_relatives(self):
+        cfg = "export DESIGN_NAME = gcd\nexport CORE_UTILIZATION = 65\nexport SDC_FILE = x.sdc\n"
+        rc, out, log = run(cfg)
+        self.assertEqual(rc, 0, log)
+        lines = out.splitlines()
+        u = next(i for i, l in enumerate(lines) if "CORE_UTILIZATION" in l)
+        d = next(i for i, l in enumerate(lines) if "PLACE_DENSITY " in l)
+        s = next(i for i, l in enumerate(lines) if "SDC_FILE" in l)
+        # new density lands after the utilization it belongs with, and
+        # before the unrelated tail
+        self.assertGreater(d, u)
+        self.assertGreater(s, d)
+
+    def test_new_design_with_no_floorplan_vars(self):
+        # "wire up the strictly necessary variables and let the pin fill
+        # in the rest"
+        cfg = "export DESIGN_NAME = newthing\nexport SDC_FILE = c.sdc\n"
+        rc, out, log = run(cfg)
+        self.assertEqual(rc, 0, log)
+        for v in ("CORE_UTILIZATION", "CORE_ASPECT_RATIO", "CORE_MARGIN", "PLACE_DENSITY"):
+            self.assertIn(v, out)
+        self.assertIn("export DESIGN_NAME = newthing", out)
+
+    def test_rectangle_design_stays_a_rectangle(self):
+        cfg = (
+            "export DIE_AREA = 0 0 17 17\n"
+            "export CORE_AREA = 1.08 1.08 16 16\n"
+            "export PLACE_DENSITY = 0.70\n"
+        )
+        rc, out, log = run(cfg)
+        self.assertEqual(rc, 0, log)
+        self.assertIn("export DIE_AREA = 0.0 0.0 16.919 16.919", out)
+        self.assertIn("export CORE_AREA = 1.026 1.08 15.876 15.66", out)
+        # and is not silently converted to a utilization
+        self.assertNotIn("CORE_UTILIZATION", out)
+
+    def test_utilization_design_does_not_gain_a_rectangle(self):
+        rc, out, log = run("export CORE_UTILIZATION = 65\n")
+        self.assertEqual(rc, 0, log)
+        self.assertNotIn("DIE_AREA", out)
+
+    def test_writes_only_one_density_form(self):
+        # place_density_with_lb_addon() returns the addon form whenever the
+        # addon is set, so writing both would leave PLACE_DENSITY dead and
+        # let the addon re-resolve to something other than what was
+        # measured.
+        rc, out, log = run("export PLACE_DENSITY = 0.35\n")
+        self.assertEqual(rc, 0, log)
+        self.assertIn("export PLACE_DENSITY = 0.938", out)
+        self.assertNotIn("PLACE_DENSITY_LB_ADDON", out)
+
+    def test_addon_design_keeps_the_addon_form(self):
+        rc, out, log = run("export PLACE_DENSITY_LB_ADDON = 0.20\n")
+        self.assertEqual(rc, 0, log)
+        self.assertIn("export PLACE_DENSITY_LB_ADDON = 0.15", out)
+        self.assertNotIn("export PLACE_DENSITY ", out)
+
+    def test_idempotent(self):
+        cfg = "export CORE_UTILIZATION = 65\nexport PLACE_DENSITY = 0.35\n"
+        rc, once, _ = run(cfg)
+        self.assertEqual(rc, 0)
+        rc2, twice, log = run(once)
+        self.assertEqual(rc2, 0, log)
+        self.assertEqual(once, twice)
+        self.assertIn("already holds these values", log)
+
+    def test_no_winner_is_an_error_not_a_silent_write(self):
+        ev = dict(EVIDENCE)
+        ev["winner"] = None
+        rc, out, log = run("export CORE_UTILIZATION = 65\n", evidence=ev)
+        self.assertEqual(rc, 1, log)
+        self.assertIn("export CORE_UTILIZATION = 65", out)
+
+    def test_provenance_goes_to_stdout_not_the_file(self):
+        rc, out, log = run("export CORE_UTILIZATION = 65\n")
+        self.assertEqual(rc, 0, log)
+        self.assertIn("delta_tie", log)
+        self.assertNotIn("delta_tie", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/private/design_dsl.bzl
+++ b/private/design_dsl.bzl
@@ -19,6 +19,9 @@ generated @orfs_designs//:designs.bzl supplies it, exactly as that file
 already does for orfs_design().
 """
 
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//private:rules.bzl", "orfs_run")
+
 # Per filegroup target: extensions included in the filegroup.
 # config_mk_parser produces these target names from VERILOG_FILES
 # wildcard patterns.
@@ -83,8 +86,106 @@ def export_design_files():
         visibility = ["//visibility:private"],
     )
 
+# Candidates run concurrently inside the single derive action, each with
+# AF_THREADS threads, so one design occupies AF_JOBS * AF_THREADS cores.
+# Empty means "let the driver use its own default" and keeps the value out
+# of the action key.
+AF_JOBS = ""
+
+AF_THREADS = ""
+
+def _auto_floorplan(designs, config):
+    """Generate the floorplan derivation and pinning targets.
+
+    Deriving a floorplan means running the production flow several times
+    over, so it is a job you run rather than something a build does:
+
+        bazelisk build //flow/designs/asap7/gcd:gcd_auto_floorplan_data
+        bazelisk run   //flow/designs/asap7/gcd:gcd_auto_floorplan_pin
+
+    Split in two so the expensive half is paid once. _data races the
+    candidates and writes auto_floorplan.json as a declared output, so
+    bazel caches it: iterating on the pin never re-derives. _pin depends
+    on _data, which is what stops it ever writing stale values -- bazel's
+    dependency graph is the freshness check, so a changed netlist, SDC or
+    toolchain re-derives before the pin sees it. Nothing lands in the
+    source tree except the config.mk edit.
+
+    Both are manual: no wildcard build should start a derivation.
+
+    Args:
+        designs: the per-consumer DESIGNS dict, bound by the generated
+            @orfs_designs//:designs.bzl.
+        config: the design's config.mk, the file the pin edits.
+    """
+
+    # The last two path components are the DESIGNS key ("asap7/gcd"),
+    # whatever depth the consumer's designs_dir sits at.
+    parts = native.package_name().split("/")
+    if len(parts) < 2:
+        return
+    entry = designs.get(parts[-2] + "/" + parts[-1])
+    if not entry:
+        return
+    name = entry["name"]
+
+    orfs_run(
+        name = name + "_auto_floorplan_data",
+        src = ":" + name + "_synth",
+        outs = ["auto_floorplan.json"],
+        arguments = entry["arguments"] | {
+            "AF_EVIDENCE": "$(location auto_floorplan.json)",
+            # The three scripts ship from here while SCRIPTS_DIR points at
+            # ORFS's flow/scripts, so the driver cannot find its siblings
+            # by directory the way it could when all three lived there.
+            "AF_CANDIDATE_TCL": "$(location %s)" % Label("//:auto_floorplan_candidate.tcl"),
+            "AF_FLOW_TCL": "$(location %s)" % Label("//:auto_floorplan_flow.tcl"),
+        } | {
+            # Provisioning. These have to be declared rather than passed
+            # on the command line: orfs_run builds the action with a fixed
+            # environment, so --action_env never reaches the driver. Raise
+            # AF_JOBS for a big design derived on its own -- the phases are
+            # serialised, so a ladder that does not fit in one batch per
+            # phase pays a full candidate's wall time for every extra one.
+            k: v
+            for k, v in [
+                ("AF_JOBS", AF_JOBS),
+                ("AF_THREADS", AF_THREADS),
+            ]
+            if v
+        },
+        data = [
+            Label("//:auto_floorplan_candidate.tcl"),
+            Label("//:auto_floorplan_flow.tcl"),
+        ],
+        script = Label("//:auto_floorplan.tcl"),
+        # The candidates run the flow from floorplan to finish, so every
+        # stage's variables have to reach them.
+        stages = [
+            "floorplan",
+            "place",
+            "cts",
+            "grt",
+            "route",
+            "final",
+        ],
+        tags = ["manual"],
+    )
+    py_binary(
+        name = name + "_auto_floorplan_pin",
+        srcs = [Label("//:pin_auto_floorplan.py")],
+        main = Label("//:pin_auto_floorplan.py"),
+        args = [
+            "$(location :auto_floorplan.json)",
+            native.package_name() + "/" + config,
+        ],
+        data = [":auto_floorplan.json"],
+        tags = ["manual"],
+    )
+
 def design(
         orfs_design,
+        designs,
         config = "config.mk",
         user_arguments = [],
         user_sources = [],
@@ -96,6 +197,8 @@ def design(
         orfs_design: the DESIGNS-bound orfs_design() from the generated
             @orfs_designs//:designs.bzl. Passed in rather than loaded
             because DESIGNS is per-consumer.
+        designs: that same per-consumer DESIGNS dict, read by the
+            floorplan derivation targets.
         config: The config.mk file that drives this design.
         user_arguments: config.mk var names that are project-specific
             (read by the design's own .tcl/.mk, not by ORFS) and should
@@ -122,6 +225,7 @@ def design(
         local_arguments = local_arguments,
         visibility = visibility,
     )
+    _auto_floorplan(designs, config)
 
 def files(group, extra_srcs = None):
     """Named filegroup over conventional extensions.

--- a/private/design_dsl.bzl
+++ b/private/design_dsl.bzl
@@ -130,6 +130,9 @@ def _auto_floorplan(designs, config):
 
     # The last two path components are the DESIGNS key ("asap7/gcd"),
     # whatever depth the consumer's designs_dir sits at.
+    if not designs:
+        return
+
     parts = native.package_name().split("/")
     if len(parts) < 2:
         return
@@ -194,7 +197,7 @@ def _auto_floorplan(designs, config):
 
 def design(
         orfs_design,
-        designs,
+        designs = None,
         config = "config.mk",
         user_arguments = [],
         user_sources = [],
@@ -207,7 +210,10 @@ def design(
             @orfs_designs//:designs.bzl. Passed in rather than loaded
             because DESIGNS is per-consumer.
         designs: that same per-consumer DESIGNS dict, read by the
-            floorplan derivation targets.
+            floorplan derivation targets. Optional: omitting it simply
+            skips those targets, so a caller written against the older
+            two-argument signature keeps working and this addition stays
+            additive.
         config: The config.mk file that drives this design.
         user_arguments: config.mk var names that are project-specific
             (read by the design's own .tcl/.mk, not by ORFS) and should

--- a/private/design_dsl.bzl
+++ b/private/design_dsl.bzl
@@ -90,6 +90,15 @@ def export_design_files():
 # AF_THREADS threads, so one design occupies AF_JOBS * AF_THREADS cores.
 # Empty means "let the driver use its own default" and keeps the value out
 # of the action key.
+#
+# Size AF_JOBS by MEMORY, not by cores. Each candidate holds a full flow in
+# RAM, and on a large design that peaks far higher than the core count
+# suggests: a swerv_wrapper candidate peaks near 18 GB, so AF_JOBS = 8
+# wants ~144 GB while using only 16 cores. That configuration ran four
+# hours on a 122 GB machine and was then OOM-killed, losing the run --
+# candidates reach their detailed-route peak at different times, so the
+# ceiling is not hit until several coincide. Budget
+# AF_JOBS <= (RAM - a few GB) / peak-RSS-per-candidate.
 AF_JOBS = ""
 
 AF_THREADS = ""

--- a/private/designs.bzl
+++ b/private/designs.bzl
@@ -184,7 +184,7 @@ def design(**kwargs):
         **kwargs: Forwarded to design() -- config, user_arguments,
             user_sources, local_arguments.
     """
-    _design(orfs_design, **kwargs)
+    _design(orfs_design, DESIGNS, **kwargs)
 
 files = _files
 ''' % repr(designs)

--- a/test/orfs_design_builds_test.py
+++ b/test/orfs_design_builds_test.py
@@ -301,5 +301,50 @@ class TestGeneratorScript(unittest.TestCase):
             self.assertEqual(first, fp.read())
 
 
+class TestAutoFloorplanScope(unittest.TestCase):
+    """Which design packages get floorplan-derivation targets.
+
+    design() emits <name>_auto_floorplan_data/_pin only for a package
+    whose last two path components form a DESIGNS key -- "asap7/gcd".
+    ORFS's three nested block designs sit a level deeper
+    (asap7/riscv32i-mock-sram/fakeram7_256x32,
+    gf180/uart-blocks/uart_rx,
+    ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl), so their last two
+    components are "riscv32i-mock-sram/fakeram7_256x32", which is not a
+    key, and they get no targets.
+
+    That is intended rather than accidental: a block's floorplan is
+    derived as part of its parent's flow, not on its own. Pinned here so
+    the silence is a decision and not a surprise, and so that widening
+    the lookup later is a deliberate act.
+    """
+
+    NESTED = [
+        "flow/designs/asap7/riscv32i-mock-sram/fakeram7_256x32",
+        "flow/designs/gf180/uart-blocks/uart_rx",
+        "flow/designs/ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl",
+    ]
+
+    def test_a_nested_package_is_not_a_designs_key(self):
+        for pkg in self.NESTED:
+            with self.subTest(pkg=pkg):
+                parts = pkg.split("/")
+                # What design() looks up.
+                key = parts[-2] + "/" + parts[-1]
+                # A real key is <platform>/<design>; these are not.
+                self.assertNotIn(key, ("asap7/gcd", "gf180/uart-blocks"))
+                self.assertEqual(len(pkg.split("/")), 5)
+
+    def test_the_parent_is_a_designs_key(self):
+        # The parent is where the derivation belongs, and it does get
+        # targets.
+        for pkg in self.NESTED:
+            with self.subTest(pkg=pkg):
+                parent = "/".join(pkg.split("/")[:-1])
+                parts = parent.split("/")
+                self.assertEqual(len(parts), 4)
+                self.assertEqual(parts[0] + "/" + parts[1], "flow/designs")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/orfs_flow_build_test.py
+++ b/test/orfs_flow_build_test.py
@@ -32,6 +32,11 @@ _REQUIRED_TARGETS = [
 ]
 
 _REQUIRED_EXPORTS = [
+    # The floorplan derivation compares its duplicated stage sequence
+    # against the one that actually runs, so it needs flow.tcl as a
+    # label. Patch 0047 adds this to the flow/BUILD ORFS still ships;
+    # this list covers the generated one that replaces it.
+    "scripts/flow.tcl",
     "scripts/synth.tcl",
     # bazel-orfs's variables_yaml default. ORFS itself does not export
     # this; it resolves today only because load_json_file is a repository


### PR DESCRIPTION
> **A demonstration, not a core feature.** A worked idea — that the floorplan numbers in a `config.mk` are measurable rather than guessable, and roughly what measuring them costs — kept runnable so the idea is concrete. Anyone who wants it in earnest is expected to reimplement it inside their own project, against their own designs, provisioning and definition of "better". Read the ladders, tie bands and winner rule as one set of choices that worked on a handful of ORFS designs, not as an interface to build on.
>
> What this PR does need to be is **additive and inert**: nothing in the normal flow may depend on it, and both targets are `manual`. That part is measured below.

Rebased onto `main`, verified additive, and the pin now works on a design in another repository.

## The target this enables

```sh
bazelisk run @orfs//flow/designs/asap7/gcd:gcd_auto_floorplan_pin ~/ORFS
```

The config path the target passes is relative to the repository the design lives in, so for an `@orfs` design it is relative to an ORFS checkout — not to the bazel workspace you ran from, and not to the fetched archive, which is read-only. The script resolved it against `BUILD_WORKSPACE_DIRECTORY`, correct only when design and workspace are the same repo, so the command above would have looked under the bazel-orfs workspace and exited. There is now an optional third positional argument for the checkout to edit, which wins over the environment.

## Run for real against a pristine ORFS checkout at the pinned commit

```
derive   315.9 s wall, 14 candidates (6 util + 5 addon + 3 aspect) at AF_JOBS=2, exit 0
pin      exit 0
```

```diff
-export CORE_UTILIZATION         = 65
+export CORE_UTILIZATION         = 78
```

One line, and that is correct rather than partial. The winner — `util 78, aspect 1, margin 0.5, density 0.35, addon 0, drc 0`, achieving 349.7 ps against a 310 ps target — already agrees with `config.mk` on aspect, margin and density, so only utilization differs. Position, spacing and the assignment operator are preserved; no generated block, no markers.

## Additive, measured rather than asserted

```
bazelisk query '@orfs//flow/designs/...:*'    4321 targets, 0 errors
vs main's 4135                                0 lost, +186 added
every one of the 186 is auto-floorplan        62 designs x {auto_floorplan.json, _data, _pin}
bazelisk test //test:all //:all               124/124 pass
```

`design(designs)` is now **optional** (`= None`, with `_auto_floorplan()` returning early). As written it was positionally required, which would break any caller on the older two-argument signature.

## What the rebase surfaced

**Patch `0047` would have broken at the ORFS transition.** It edits ORFS's own `flow/BUILD` to export `scripts/flow.tcl`, so it stops applying the moment ORFS deletes that file — which is exactly what The-OpenROAD-Project/OpenROAD-flow-scripts#4501 does, and the same trap patch `0046` hit. `_GENERATE_FLOW_BUILD` now exports `scripts/flow.tcl` too, and `//test:orfs_flow_build_test` requires it. Both mechanisms are needed: the patch covers an ORFS that still ships `flow/BUILD`, the generated file covers one that does not.

**`MODULE.bazel` conflicted, as expected.** `main` moved ORFS from a `bazel_dep` to an extension-created `http_archive`, so the `archive_override` this branch added `0047` to no longer exists; the patch moved to `ORFS_PATCHES` in `orfs_source.bzl`.

**Three files were not `black`-clean**, so CI's Lint step would have failed as-is — 9 lines of reformatting in `check_pareto.py`, `check_pareto_test.py` and `auto_floorplan_flow_test.py`, none of it mine.

## Scope worth knowing: 62 designs, not all of them

`design()` looks up `DESIGNS[<last two path components>]`, so ORFS's three nested block designs — `asap7/riscv32i-mock-sram/fakeram7_256x32`, `gf180/uart-blocks/uart_rx`, `ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl` — yield a key that does not exist and get no targets, while their **parents** do. That is right: a block's floorplan is derived as part of its parent's flow. Pinned by a test so the silence is a decision rather than a surprise, and so widening the lookup later is deliberate.

## `rules-base.json` comes from CI, not from a local run

New section in `docs/auto_floorplan.md`, because pinning a floorplan changes QoR and the bounds stop describing the design. Regenerating them locally bakes in local noise: yosys is not idempotent, ORFS upstream treats that drift as expected, and tool versions and thread counts move the numbers besides.

The supported path is ORFS's `set-new-golden` `repository_dispatch`, which runs `flow/util/updateRules.py --commitSHA <sha>` against the metrics **CI itself measured** for that commit and opens a draft PR; `genRuleFile.py` / `genAllRuleFiles.sh` are what that path uses underneath. `mock-alu` is the concrete case — one of 27 bounds missed by 0.9% purely from an OpenROAD bump.

So after pinning: land the `config.mk` change, let CI measure it, request the golden update. Read a local metrics diff for direction and magnitude, never as values to commit.

## Not verified

No derivation on a large design. `AF_JOBS` is memory-bound — the branch already records an 18 GB-per-candidate OOM after four hours on `swerv_wrapper` — and provisioning is a judgement call for whoever runs it. The 315.9 s above is `gcd`, the smallest design in the flow.

And CI does not exercise the derivation at all: both targets are `manual`, so `bazelisk test ...` skips them. Green here means "nothing existing broke and the unit tests pass" — which is precisely the additivity claim, and the right thing for a demonstration to be held to. The end-to-end evidence is the local `gcd` run above, not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
