### PR TITLE
deps: bump ORFS to 8c0616910, OpenROAD to 39a75ec608d1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,7 +53,7 @@ bazel_dep(name = "orfs")
 # blocked (e.g. inside the maintainers organization).
 archive_override(
     module_name = "orfs",
-    integrity = "sha256-hAos8HgYSs5NZlc3wWPKCT7dbZB23Poyqo4cqha6YwA=",
+    integrity = "sha256-AbmwPa1L9X9hC0WF/eJuyi17uuViGNIxyDbb88/QJlI=",
     # Generate the BUILD file for any design directory that has a
     # config.mk and no BUILD, so ORFS need not carry ~56 identical
     # `design(config = "config.mk")` files whose only reader is bazel -- a
@@ -132,14 +132,14 @@ done
         # a repeat.
         "//patches:0046-orfs-design-dsl-reexport.patch",
     ],
-    strip_prefix = "OpenROAD-flow-scripts-427bd762b7b7448f8bb6bc4e14207aa3963fca30",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/427bd762b7b7448f8bb6bc4e14207aa3963fca30.tar.gz"],
+    strip_prefix = "OpenROAD-flow-scripts-8c0616910615e843780ba527526f2b83a564ba70",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/archive/8c0616910615e843780ba527526f2b83a564ba70.tar.gz"],
 )
 
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-Jv0jwVu6+XuTJycvfoVpcf5C2MWH29Hs+eOxjHASwFQ=",
+    integrity = "sha256-OMm/0RskoU/QGyWOnkkPjbZziplDJDAHLwF575P0AgY=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -147,14 +147,14 @@ archive_override(
     # aren't covered by archive_override's integrity.  Regenerated
     # by bump.py on every commit bump; do not edit by hand.
     patch_cmds = [
-        "curl -sSfL --retry 5 --retry-connrefused --retry-delay 5 -o .openroad-submodule-src-sta-509913b1398b36eda23caa1f1f380167465dceee.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/509913b1398b36eda23caa1f1f380167465dceee.tar.gz && echo '680920e76cdb2f9add4de04db4b24500ef7faa0405c9802f815e7286c106a2ec  .openroad-submodule-src-sta-509913b1398b36eda23caa1f1f380167465dceee.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-509913b1398b36eda23caa1f1f380167465dceee.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-509913b1398b36eda23caa1f1f380167465dceee.tar.gz",
+        "curl -sSfL --retry 5 --retry-connrefused --retry-delay 5 -o .openroad-submodule-src-sta-65bd9df5f7846015313734d08a5a6367df79453c.tar.gz https://github.com/The-OpenROAD-Project/OpenSTA/archive/65bd9df5f7846015313734d08a5a6367df79453c.tar.gz && echo 'c2c47d7540d49c458bca977e9145eb129f97e33212deb2c27803a92ddaf6fae0  .openroad-submodule-src-sta-65bd9df5f7846015313734d08a5a6367df79453c.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-src-sta-65bd9df5f7846015313734d08a5a6367df79453c.tar.gz --strip-components=1 -C src/sta && rm .openroad-submodule-src-sta-65bd9df5f7846015313734d08a5a6367df79453c.tar.gz",
         "curl -sSfL --retry 5 --retry-connrefused --retry-delay 5 -o .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz https://github.com/The-OpenROAD-Project/abc/archive/d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz && echo '0cbf538e60d0303d0e00360d8973aaad7dae198954bed6e34cc31c9a13b3f802  .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz --strip-components=1 -C third-party/abc && rm .openroad-submodule-third-party-abc-d527cfab4ad731b767ea0a2be2021d920d3afece.tar.gz",
         "curl -sSfL --retry 5 --retry-connrefused --retry-delay 5 -o .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz https://github.com/povik/yosys-slang/archive/82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz && echo 'ea31b4a205ebb1fe5ec3789bcd66f21f4975e73c0901622af667f843b833ff10  .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz' | sha256sum -c - && tar xzf .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz --strip-components=1 -C third-party/slang-elab && rm .openroad-submodule-third-party-slang-elab-82effc8d9541be69e1ed3ec44759a4449f5d9247.tar.gz",
         "find . -name BUILD -exec sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|g' {} +",
         "sed -i 's|defines = \\[|copts = [\"-include\", \"fmt/format.h\"],\\n    defines = [|' src/syn/src/elab/BUILD third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-21512b0ab68cc3bc7e11a772e1ec32f6f90e0eec",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/21512b0ab68cc3bc7e11a772e1ec32f6f90e0eec.tar.gz"],
+    strip_prefix = "OpenROAD-39a75ec608d107a62b6d44fb8fb7c52a67071a9a",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/39a75ec608d107a62b6d44fb8fb7c52a67071a9a.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.

--- a/bump_reference_date.txt
+++ b/bump_reference_date.txt
@@ -1,4 +1,4 @@
 # Commit date of the ORFS pin in MODULE.bazel, written by //:bump.
 # The anchor //:bump_compat_test measures COMPAT markers against, so
 # that the cleanup policy runs on commit dates and not on the clock.
-2026-08-25
+2026-09-02


### PR DESCRIPTION
Written by `bazelisk run //:bump`, not by hand.

| module | from | to | |
|---|---|---|---|
| orfs | `427bd762b7b7` | `8c0616910615` | 55 commits |
| openroad | `21512b0ab68c` | `39a75ec608d1` | ORFS `tools/OpenROAD` |
| src/sta | `509913b1398b` | `65bd9df5f784` | vendored submodule |

qt-bazel and yosys were already at the commits ORFS pins, so the resolved delta is ORFS plus the OpenROAD stack that moves with it.

## Why this bump is worth a note

It's the first bump since the `@orfs` design packages became first-class here (#887), so it's the first real exercise of the load guard that came with the DSL move — 55 commits of ORFS churn the guard has never seen. **It passes with no fixes needed:**

```
bazelisk query '@orfs//flow/designs/...:*'    4135 targets, 0 errors
bazelisk test (unit + generator + compat)     21/21 pass
bazelisk build --nobuild --keep_going //...   1567 targets, 0 errors
```

4,135 is up from 3,889 because 55 commits of ORFS brought new designs — not because anything existing was reinterpreted.

This is the evidence behind the bet in [docs/plans/orfs-as-file-store.md](docs/plans/orfs-as-file-store.md) §5: ORFS's file layout is stable enough that bump-and-fix is cheap. The measured cost of this bump was zero fixes.

## The only output is deliberate

Every line the query emits is a DEBUG diagnostic from a warn-not-fail path we chose on purpose:

- 16 designs setting `SYNTH_HIERARCHICAL=1` with no `SYNTH_KEEP_MODULES` (CoreMiniAxi, mempool_group, ariane, riscv_top, black_parrot, microwatt, uart, bsg_chip, the bp_* family, RocketTile, aes_cipher_top)
- `swerv_wrapper`'s unresolved `$(CLKGATE_MAP_FILE)`

Both pre-existing, and both warnings rather than `fail()` specifically so one unbuildable design cannot stop every other design from loading — the regression #885 fixed after I introduced it in #882.

`bump_reference_date.txt` moves `2026-08-25` → `2026-09-02`, the commit date of the new ORFS pin and the anchor `//:bump_compat_test` measures COMPAT markers against.

## Not claimed

No design was *built* at the new pin — per the testing policy in §5, broad design coverage isn't the deal. `gcd_test` in CI covers "does the flow still run"; this PR's claim is the narrower and more important one: bazel can still see every design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)