### PR TITLE
fix(yosys): pin YOSYS_MAX_THREADS=1 so synthesis is reproducible

### DIFF
--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -96,6 +96,13 @@ def yosys_environment(ctx):
         "ABC": ctx.executable._abc.path,
         "FLOW_HOME": ctx.file._makefile_yosys.dirname,
         "YOSYS_EXE": ctx.executable.yosys.path,
+        # yosys' abc pass runs its ABC invocations on a thread pool and the
+        # resulting netlist depends on their completion order, so synthesis
+        # is not reproducible with more than one thread:
+        # https://github.com/YosysHQ/yosys/issues/6170
+        # Modules are already synthesised as separate Bazel actions, so the
+        # in-process threads add no parallelism here.
+        "YOSYS_MAX_THREADS": "1",
     } | orfs_environment(ctx)
 
     # Tell yosys where to find out-of-tree plugins (e.g. yosys-slang)


### PR DESCRIPTION
## What

Sets `YOSYS_MAX_THREADS=1` in the yosys action environment.

## Why

yosys' `abc` pass runs its ABC invocations on a thread pool, and the resulting netlist depends on the order in which they complete. The same design, on the same machine, with the same binaries, lands on a different netlist nearly every run.

Measured on a testcase whose memories expand to per-word, per-bit write enables — 258 clock/enable domains, so 258 ABC invocations across the pool:

| | result |
|---|---|
| default (threaded), 8 runs | **6 distinct netlists** |
| `YOSYS_MAX_THREADS=1`, repeated runs | bit-identical every time |

The netlists differ in cell counts, not just naming, so this is a different mapping rather than a renaming. Reported upstream as https://github.com/YosysHQ/yosys/issues/6170, with a single-file reproducer.

Ruled out along the way: ASLR (`setarch -R` does not help), CPU contention, the random `/tmp/yosys-abc-XXXXXX` paths, and ABC process reuse (`abc -exe <copy>` takes the non-reuse branch and still diverges).

## Why pinning it here costs nothing

Modules are already synthesised as separate Bazel actions, so parallelism comes from the action graph; the in-process thread pool adds none on top of that. Measured cost on one partition of a large design was within run-to-run noise.

Reproducible actions are what make the remote cache trustworthy — a synthesis action that returns a different netlist each run undermines caching and makes any A/B comparison across a re-synthesis unreliable.