### PR TITLE
test(estimation_ladder): carry the macro-selector apparatus, not its data

### DIFF
--- a/test/estimation_ladder/README.md
+++ b/test/estimation_ladder/README.md
@@ -885,3 +885,31 @@ bazel run //test/estimation_ladder:calibration_models
 bazel run //test/estimation_ladder:update-readme
 ```
 
+## The macro-placement selector apparatus
+
+`macro_select.tcl`, `macro_score.tcl`, `seed_distribution.py`,
+`score_vs_flow.py`, `extract_from_src.tcl` and `sdc/swerv_c*.sdc` are the
+rig from the macro-placement selection study: RTL-MP driven as a
+distribution generator, a report-only global placement used to rank the
+candidates it produces, and the accuracy analysis over the result.
+
+The findings are in `../../docs/estimate.md` ("Negative findings of
+importance") and `../../ideas/e12-clustered-scorer.md`. Two of the
+OpenROAD-side conclusions are filed upstream as
+The-OpenROAD-Project/OpenROAD#11315 (`rtl_macro_placer` has no
+`-random_seed`, so its anneal cannot be used as a candidate generator)
+and #11316 (`gpl` fillers and nets ignore `placement_cluster`).
+
+**The measured populations are deliberately not carried here.** They run
+to some 84,000 lines of JSON -- the per-candidate scores, the stage
+variance sweeps and the clock shmoo -- and they live on the
+`macro-selector` branch and its pull request, both immutable. Anyone who
+doubts a published number has to regenerate the population anyway: these
+scripts are what regenerate it, and a seeded rerun is the check, not a
+diff against an archive. That last point is not incidental. An archived
+score/truth pair turned out to be unusable for grading a later rerun at
+all, because the bazel-orfs pin changes the synthesis netlist and
+therefore the candidates -- see the negative findings.
+
+The bazel targets that drove these scripts are on that branch too, since
+several of them take an archived population as an input.

--- a/test/estimation_ladder/extract_from_src.tcl
+++ b/test/estimation_ladder/extract_from_src.tcl
@@ -1,0 +1,13 @@
+# extract.tcl for an orfs_run whose src may live in another package
+# (e.g. a design in the pinned ORFS repo): load.tcl's load_design reads
+# from this run's RESULTS_DIR, so stage the src's ODB/SDC there first.
+set odb $::env(ODB_FILE)
+set sdc [file rootname $odb].sdc
+set results_odb [file join $::env(RESULTS_DIR) [file tail $odb]]
+set results_sdc [file join $::env(RESULTS_DIR) [file tail $sdc]]
+if { [file normalize $odb] ne [file normalize $results_odb] } {
+    file mkdir $::env(RESULTS_DIR)
+    file copy -force $odb $results_odb
+    file copy -force $sdc $results_sdc
+}
+source $::env(EXTRACT_TCL)

--- a/test/estimation_ladder/macro_score.tcl
+++ b/test/estimation_ladder/macro_score.tcl
@@ -269,6 +269,22 @@ proc ms_leaf { tag stratum displacement } {
     puts "macro_score: leaf $tag done (tail ${::ms_tail_s}s)"
 }
 
+# A cfg's MS_SEED runs the candidate's generation with rtl_macro_placer
+# -random_seed (carried OpenROAD patch): the seed-population arm of the
+# audit, where the placer is a distribution generator and each
+# candidate is reproducible by its seed alone. Appends to the exact
+# argument list ORFS's macro_place_util.tcl constructs (RTLMP_ARGS
+# would replace it, dropping halos and target_util).
+proc ms_wrap_placer_seed { seed } {
+    if { [info commands ms_real_rtl_macro_placer] eq "" } {
+        rename rtl_macro_placer ms_real_rtl_macro_placer
+        proc rtl_macro_placer { args } {
+            ms_real_rtl_macro_placer {*}$args -random_seed $::ms_seed
+        }
+    }
+    set ::ms_seed $seed
+}
+
 set FLOORPLAN_ONLY {floorplan.tcl}
 set MACRO_STEP {macro_place.tcl}
 set EVAL_TAIL {tapcell.tcl pdn.tcl global_place_skip_io.tcl io_placement.tcl
@@ -292,7 +308,11 @@ if { $::ms_mode eq "generate" } {
         file copy -force [file rootname $::env(ODB_FILE)].sdc \
             [file join $::env(RESULTS_DIR) 1_synth.sdc]
         dict for {k v} [dict get $configs $tag] {
-            if {$k ne "TAG"} { set ::env($k) $v }
+            if {$k eq "MS_SEED"} {
+                ms_wrap_placer_seed $v
+            } elseif {$k ne "TAG"} {
+                set ::env($k) $v
+            }
         }
         set_debug_level MPL hierarchical_macro_placement 1
         puts "MS_TABLE_BEGIN $tag"

--- a/test/estimation_ladder/macro_select.tcl
+++ b/test/estimation_ladder/macro_select.tcl
@@ -1,0 +1,331 @@
+# Measured selection over a seed-generated population of macro
+# placements: the selector the macro_score audit argued for
+# (ideas/rtl-mpl.md).
+#
+# RTL-MP's annealing cost picks the better of two placements at roughly
+# coin-flip probability, so instead of trusting the objective this walk
+# generates k candidates with rtl_macro_placer -random_seed (carried
+# OpenROAD patch), scores each with a fast non-timing-driven global
+# placement -- a measurement taken on the far side of the fog that
+# implicitly prices density and congestion -- and materializes the
+# winner's placement as macro.tcl for the production flow variant to
+# consume through MACRO_PLACEMENT_TCL.
+#
+# The walk runs off the synthesis output (orfs_run src = <design>_synth)
+# and shares one production floorplan spine; candidates diverge only at
+# macro_place, so the //fork copy-on-write snapshot pays for the whole
+# shared prefix.  Two execution shapes, selected by MS_SERIAL_THREADS:
+#
+#   0 (default)  fork -jobs $MS_JOBS: candidates run in parallel,
+#                single-threaded each (fork quiesces set_thread_count;
+#                a child must not raise it).
+#   N > 0        no fork: candidates run sequentially in the parent
+#                with set_thread_count N.  Exists for the parallelism
+#                calibration experiment: global placement saturates on
+#                internal parallelism well below the core count, and
+#                the winning shape is decided by measurement, not
+#                folklore (see README, "Parallelism calibration").
+#
+# Each candidate leaf writes <tag>.json (score components, runtimes,
+# peak RSS) and <tag>.place.tcl (the production 2_2_floorplan_macro.tcl
+# ORFS already dumps) into the evidence directory; the parent joins,
+# selects by MS_SELECT_KPI and copies the winner to the declared
+# macro.tcl output.
+#
+# Faithfulness rests on the carried OpenROAD patches: -random_seed makes
+# a candidate reproducible, snap-inside-core makes its place.tcl
+# round-trip through place_macro, and the all-fixed standard-cell
+# seeding makes the consumer variant's injection equivalent to the
+# generation run.  Selection therefore ships coordinates, not a recipe.
+
+source $::env(ORFS_FORK_TCL)
+source $::env(EXTRACT_LIB_TCL)
+
+proc ms_env { name default } {
+    if { [info exists ::env($name)] && $::env($name) ne "" } {
+        return $::env($name)
+    }
+    return $default
+}
+
+# Evidence directory: MS_OUT_DIR (driver-owned, orfs_run_executable) or
+# RUN_OUTPUT_DIR (tree artifact, orfs_run out_dir).
+set ::ms_out [ms_env MS_OUT_DIR [ms_env RUN_OUTPUT_DIR ""]]
+if { $::ms_out eq "" } {
+    error "macro_select: set MS_OUT_DIR or declare out_dir"
+}
+set ::ms_work [ms_env MS_WORK [file join $::env(WORK_HOME) macro_select_work]]
+# Defaults calibrated on the campaign machine class (24C/48T, 64GB
+# Threadripper; README "Parallelism calibration"): fork -jobs 12 is the
+# throughput knee at 65 candidates/hour -- jobs 24 buys 1% for double
+# the per-child latency, and the serial multi-threaded shape is 3x
+# slower because global placement saturates on internal parallelism.
+# 24 candidates therefore cost ~22 minutes.
+set ::ms_k [ms_env MS_K 24]
+set ::ms_jobs [ms_env MS_JOBS 12]
+set ::ms_serial_threads [ms_env MS_SERIAL_THREADS 0]
+# Default selection KPI: the macro-path aggregate. The E1 campaign
+# measured period at grt as macro-placement-insensitive at this
+# utilization (every candidate inside delta_tie) while the macro-path
+# mean spans ~300ps and is ranked by this proxy at rho +0.72; at tight
+# utilization macro paths become the period, so the KPI is
+# regime-robust (see ideas/rtl-mpl.md and score_vs_flow_swerv.json).
+set ::ms_kpi [ms_env MS_SELECT_KPI macro_mean]
+set ::ms_macro_tcl [ms_env MS_MACRO_TCL [file join $::env(WORK_HOME) macro.tcl]]
+set ::ms_fork_opts [list -timeout [ms_env MS_CHILD_TIMEOUT 14400]]
+file mkdir $::ms_out
+
+set ::env(KEEP_VARS) 1
+set ::env(SKIP_REPORT_METRICS) 1
+
+proc ms_redirect { tag } {
+    set base [file join $::ms_work $tag]
+    foreach {var sub} {RESULTS_DIR results REPORTS_DIR reports
+                       LOG_DIR logs OBJECTS_DIR objects} {
+        set dir [file join $base $sub]
+        file mkdir $dir
+        set ::env($var) $dir
+    }
+    return $base
+}
+
+set ::ms_tail_s 0.0
+proc ms_step { script } {
+    set t0 [clock clicks -milliseconds]
+    uplevel #0 [list source [file join $::env(SCRIPTS_DIR) $script]]
+    set s [expr {([clock clicks -milliseconds] - $t0) / 1000.0}]
+    set ::ms_tail_s [expr {$::ms_tail_s + $s}]
+    puts "macro_select: $script done in ${s}s"
+    return $s
+}
+
+proc ms_vmhwm_kb { } {
+    if { [catch {
+        set fp [open /proc/self/status r]
+        set status [read $fp]
+        close $fp
+        regexp {VmHWM:\s+(\d+) kB} $status -> kb
+    }] } {
+        return 0
+    }
+    return $kb
+}
+
+# Append -random_seed to the exact argument list ORFS's
+# macro_place_util.tcl constructs.  RTLMP_ARGS would REPLACE that list,
+# dropping halos and target_util; wrapping the command keeps ORFS's
+# arguments and adds only the seed.
+proc ms_wrap_placer_seed { seed } {
+    if { [info commands ms_real_rtl_macro_placer] eq "" } {
+        rename rtl_macro_placer ms_real_rtl_macro_placer
+        proc rtl_macro_placer { args } {
+            ms_real_rtl_macro_placer {*}$args -random_seed $::ms_seed
+        }
+    }
+    set ::ms_seed $seed
+}
+
+# The fast non-timing-driven scoring rung (the estimation ladder's gate
+# rung): pins once, one global placement with timing/routability off,
+# placement parasitics, the shared sampling instrument.
+proc ms_score_candidate { } {
+    set t0 [clock clicks -milliseconds]
+    if { ![info exists ::ms_pins_placed] } {
+        if { [info exists ::env(IO_CONSTRAINTS)] && $::env(IO_CONSTRAINTS) ne "" } {
+            uplevel #0 [list source $::env(IO_CONSTRAINTS)]
+        }
+        place_pins -hor_layers $::env(IO_PLACER_H) \
+            -ver_layers $::env(IO_PLACER_V)
+        set ::ms_pins_placed 1
+    }
+    set gp_args "-density [place_density_with_lb_addon]"
+    set cell_pad [ms_env CELL_PAD_IN_SITES_GLOBAL_PLACEMENT 0]
+    append gp_args " -pad_left $cell_pad -pad_right $cell_pad"
+    append gp_args " -force_center_initial_place"
+    eval global_placement $gp_args
+    set gpl_s [expr {([clock clicks -milliseconds] - $t0) / 1000.0}]
+
+    set t0 [clock clicks -milliseconds]
+    estimate_parasitics -placement
+    set_propagated_clock [all_clocks]
+    set sample [extract_sample_paths]
+    set sta_s [expr {([clock clicks -milliseconds] - $t0) / 1000.0}]
+
+    set wq25_sum 0.0
+    set wq25_n 0
+    set macro_sum 0.0
+    set macro_n 0
+    foreach pt [dict get $sample paths] {
+        set period [lindex $pt 2]
+        if { [lindex $pt 3] } {
+            set macro_sum [expr {$macro_sum + $period}]
+            incr macro_n
+        } else {
+            set wq25_sum [expr {$wq25_sum + $period}]
+            incr wq25_n
+        }
+    }
+    set wq25 [expr {$wq25_n ? $wq25_sum / $wq25_n : 0.0}]
+    set macro_mean [expr {$macro_n ? $macro_sum / $macro_n : 0.0}]
+
+    return [dict create \
+        clock_period [dict get $sample clock_period] \
+        wns [dict get $sample wns] \
+        period [expr {[dict get $sample clock_period] - [dict get $sample wns]}] \
+        wq25 $wq25 \
+        macro_mean $macro_mean \
+        gpl_s $gpl_s \
+        sta_s $sta_s \
+        sample $sample]
+}
+
+proc ms_leaf { tag seed score place_s } {
+    set fp [open [file join $::ms_out ${tag}.json] w]
+    puts $fp "{"
+    puts $fp "\"tag\": \"$tag\","
+    puts $fp "\"seed\": $seed,"
+    puts $fp "\"time_unit\": \"[sta::unit_scale_abbreviation time][sta::unit_suffix time]\","
+    puts $fp "\"clock_period\": [dict get $score clock_period],"
+    puts $fp "\"wns\": [dict get $score wns],"
+    puts $fp "\"period\": [dict get $score period],"
+    puts $fp "\"wq25\": [dict get $score wq25],"
+    puts $fp "\"macro_mean\": [dict get $score macro_mean],"
+    puts $fp "\"macro_place_s\": $place_s,"
+    puts $fp "\"gpl_s\": [dict get $score gpl_s],"
+    puts $fp "\"sta_s\": [dict get $score sta_s],"
+    puts $fp "\"vmhwm_kb\": [ms_vmhwm_kb],"
+    puts $fp "\"paths\": [extract_paths_json [dict get $score sample paths]]"
+    puts $fp "}"
+    close $fp
+    puts "macro_select: leaf $tag done (macro_place ${place_s}s,\
+        gpl [dict get $score gpl_s]s)"
+}
+
+# One candidate: seeded production macro placement, then the scoring
+# rung.  Runs inside a fork child (parallel shape) or inline in the
+# parent (serial calibration shape).
+proc ms_candidate { seed } {
+    set tag cand_s$seed
+    ms_redirect $tag
+    ms_wrap_placer_seed $seed
+    set t0 [clock clicks -milliseconds]
+    ms_step macro_place.tcl
+    set place_s [expr {([clock clicks -milliseconds] - $t0) / 1000.0}]
+    file copy -force \
+        [file join $::env(RESULTS_DIR) 2_2_floorplan_macro.tcl] \
+        [file join $::ms_out $tag.place.tcl]
+    set score [ms_score_candidate]
+    ms_leaf $tag $seed $score $place_s
+}
+
+# In-parent reset between serial candidates: macros back to unfixed and
+# unplaced, standard cells and pins unplaced, macro soft blockages gone.
+# Fork children never need this -- each inherits the pristine
+# post-floorplan snapshot.
+proc ms_reset_placement { } {
+    set blk [ord::get_db_block]
+    foreach inst [$blk getInsts] {
+        set master [$inst getMaster]
+        if { [$master isBlock] } {
+            $inst setPlacementStatus NONE
+            $inst setOrient R0
+            $inst setLocation 0 0
+        } elseif { [$inst isPlaced] } {
+            $inst setPlacementStatus NONE
+        }
+    }
+    foreach blockage [$blk getBlockages] {
+        odb::dbBlockage_destroy $blockage
+    }
+    foreach bterm [$blk getBTerms] {
+        foreach bpin [$bterm getBPins] {
+            odb::dbBPin_destroy $bpin
+        }
+    }
+    unset -nocomplain ::ms_pins_placed
+    unset_propagated_clock [all_clocks]
+}
+
+# ---------------------------------------------------------------------
+# The walk.
+
+set seeds {}
+for {set i 0} {$i < $::ms_k} {incr i} { lappend seeds $i }
+puts "macro_select: [llength $seeds] candidates, kpi $::ms_kpi,\
+    [expr {$::ms_serial_threads > 0 ?
+        "serial with $::ms_serial_threads threads" :
+        "fork -jobs $::ms_jobs"}]"
+
+ms_redirect spine
+file copy -force $::env(ODB_FILE) \
+    [file join $::env(RESULTS_DIR) 1_synth.odb]
+file copy -force [file rootname $::env(ODB_FILE)].sdc \
+    [file join $::env(RESULTS_DIR) 1_synth.sdc]
+set t0 [clock clicks -milliseconds]
+ms_step floorplan.tcl
+set ::ms_prefix_s [expr {([clock clicks -milliseconds] - $t0) / 1000.0}]
+
+set failed {}
+if { $::ms_serial_threads > 0 } {
+    set_thread_count $::ms_serial_threads
+    foreach seed $seeds {
+        if { [catch { ms_candidate $seed } err] } {
+            puts stderr "macro_select: candidate s$seed failed: $err"
+            lappend failed s$seed
+        }
+        ms_reset_placement
+    }
+} else {
+    set statuses [fork -jobs $::ms_jobs {*}$::ms_fork_opts seed $seeds {
+        ms_candidate $seed
+    }]
+    dict for {seed code} $statuses {
+        if {$code != 0} {
+            puts stderr "macro_select: candidate s$seed failed with\
+                status $code; its outputs are missing"
+            lappend failed s$seed
+        }
+    }
+}
+
+# ---------------------------------------------------------------------
+# Join and select.
+
+proc ms_read_json_number { path key } {
+    set fp [open $path r]
+    set content [read $fp]
+    close $fp
+    if { ![regexp "\"$key\":\\s*(\[-0-9.eE\]+)" $content -> value] } {
+        error "macro_select: no $key in $path"
+    }
+    return $value
+}
+
+set best_tag ""
+set best_score Inf
+set scored 0
+foreach seed $seeds {
+    set tag cand_s$seed
+    set json [file join $::ms_out $tag.json]
+    if { ![file exists $json] } { continue }
+    set score [ms_read_json_number $json $::ms_kpi]
+    incr scored
+    puts "macro_select: $tag $::ms_kpi = $score"
+    if { $score < $best_score } {
+        set best_score $score
+        set best_tag $tag
+    }
+}
+if { $best_tag eq "" } {
+    error "macro_select: no candidate produced a score"
+}
+
+file copy -force [file join $::ms_out $best_tag.place.tcl] $::ms_macro_tcl
+set fp [open [file join $::ms_out winner.json] w]
+puts $fp "{\"winner\": \"$best_tag\", \"kpi\": \"$::ms_kpi\",\
+ \"score\": $best_score, \"scored\": $scored,\
+ \"candidates\": [llength $seeds], \"prefix_s\": $::ms_prefix_s}"
+close $fp
+puts "macro_select: winner $best_tag ($::ms_kpi = $best_score,\
+    $scored/[llength $seeds] scored)"
+exit 0

--- a/test/estimation_ladder/score_vs_flow.py
+++ b/test/estimation_ladder/score_vs_flow.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""The money figure: does a score predict what the flow delivers?
+
+Two rows of scatter panels over the SAME candidates on the SAME design
+(asap7 swerv_wrapper, the campaign's recognizable ORFS design), one
+column per flow KPI measured at grt:
+
+  row 1  x = RTL-MP's own objective at the candidate (raw penalty
+         components recombined under one fixed normalization)
+  row 2  x = the fast non-timing-driven global-placement proxy score
+
+Only the x changes between rows, so "the objective cannot see what the
+post-fog proxy sees" is visible as the same cloud of points organizing
+itself -- or failing to.  Each panel is annotated with Spearman's rho
+(rank correlation: candidate selection is a ranking problem) and a
+bootstrap 95% CI; with ~24 candidates a point estimate alone would
+overclaim.  Timing panels shade the +/- delta_tie band from the
+design's own stage_variance walk: differences inside the band are
+ties, and a score should not be rewarded for predicting noise.
+
+Inputs (all produced by the campaign):
+  --evaluate-dir   macro_score evaluate-mode leaves (<tag>.json): the
+                   ground truth per candidate at grt
+  --proxy-dir      macro_select evidence dir (<tag>.json): the proxy
+                   score per candidate
+  --objective-json {tag: score} from the generate-mode debug tables,
+                   recombined by macro_score.py's fixed normalization
+  --delta-tie-json stage_variance_<design>.json (optional until the
+                   walk completes; panels then omit the tie band)
+  --out            output PNG
+"""
+
+import argparse
+import glob
+import json
+import math
+import os
+import random
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# Reference palette (dataviz skill): candidates in blue, the proxy's
+# winner in orange, ink/greys for text and the tie band.
+BLUE = "#2a78d6"
+ORANGE = "#eb6834"
+INK = "#1a1f26"
+INK_SECONDARY = "#5a6472"
+BAND = "#d7dbe0"
+GRID = "#e8eaed"
+
+KPI_COLUMNS = [
+    ("achieved", "achieved period (ps)", True),
+    ("wq25", "general paths mean (ps)", True),
+    ("macro_mean", "macro paths mean (ps)", True),
+    ("stdcell_um2", "stdcell area (um2)", False),
+]
+
+
+def kpis_from_evaluate_leaf(leaf):
+    """The KPI menu from a macro_score evaluate leaf."""
+    paths = leaf["paths"]
+    gen = [p["min_period"] for p in paths if not p["macro_path"]]
+    mac = [p["min_period"] for p in paths if p["macro_path"]]
+    return {
+        "achieved": leaf["clock_period"] - leaf["wns"],
+        "wq25": sum(gen) / len(gen) if gen else float("nan"),
+        "macro_mean": sum(mac) / len(mac) if mac else float("nan"),
+        "stdcell_um2": leaf["area"]["stdcell_um2"],
+    }
+
+
+def rankdata(values):
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        mean_rank = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = mean_rank
+        i = j + 1
+    return ranks
+
+
+def spearman(x, y):
+    rx, ry = rankdata(x), rankdata(y)
+    n = len(rx)
+    mx = sum(rx) / n
+    my = sum(ry) / n
+    num = sum((a - mx) * (b - my) for a, b in zip(rx, ry))
+    dx = math.sqrt(sum((a - mx) ** 2 for a in rx))
+    dy = math.sqrt(sum((b - my) ** 2 for b in ry))
+    if dx == 0 or dy == 0:
+        return float("nan")
+    return num / (dx * dy)
+
+
+def spearman_ci(x, y, n_boot=4000, seed=0):
+    rng = random.Random(seed)
+    n = len(x)
+    rhos = []
+    for _ in range(n_boot):
+        idx = [rng.randrange(n) for _ in range(n)]
+        rho = spearman([x[i] for i in idx], [y[i] for i in idx])
+        if not math.isnan(rho):
+            rhos.append(rho)
+    rhos.sort()
+    lo = rhos[int(0.025 * len(rhos))]
+    hi = rhos[int(0.975 * len(rhos)) - 1]
+    return lo, hi
+
+
+def load_tag_jsons(directory):
+    out = {}
+    for path in sorted(glob.glob(os.path.join(directory, "*.json"))):
+        tag = os.path.splitext(os.path.basename(path))[0]
+        if tag in ("winner",):
+            continue
+        with open(path) as f:
+            out[tag] = json.load(f)
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evaluate-dir", required=True)
+    parser.add_argument("--proxy-dir", required=True)
+    parser.add_argument("--objective-json", required=True)
+    parser.add_argument("--delta-tie-json")
+    parser.add_argument("--design", default="swerv_wrapper (asap7)")
+    parser.add_argument("--out", default="score_vs_flow.png")
+    args = parser.parse_args()
+
+    evaluate = load_tag_jsons(args.evaluate_dir)
+    proxy = load_tag_jsons(args.proxy_dir)
+    with open(args.objective_json) as f:
+        objective = json.load(f)
+
+    delta_tie = {}
+    if args.delta_tie_json and os.path.exists(args.delta_tie_json):
+        with open(args.delta_tie_json) as f:
+            delta_tie = json.load(f).get("delta_tie", {})
+
+    tags = sorted(set(evaluate) & set(proxy) & set(objective))
+    if len(tags) < 3:
+        raise SystemExit(
+            f"score_vs_flow: only {len(tags)} candidates present in all three "
+            "inputs; need the evaluate walk, the proxy scores and the "
+            "objective scores over the same population"
+        )
+
+    flow = {t: kpis_from_evaluate_leaf(evaluate[t]) for t in tags}
+    rows = [
+        ("RTL-MP objective (fixed normalization)", {t: objective[t] for t in tags}),
+        ("fast-GPL proxy score (ps)", {t: proxy[t]["wq25"] for t in tags}),
+    ]
+    # The proxy's own pick, and the default draw, called out by name.
+    winner = min(tags, key=lambda t: proxy[t]["wq25"])
+    default = "cand_s0" if "cand_s0" in tags else None
+
+    fig, axes = plt.subplots(
+        2, len(KPI_COLUMNS), figsize=(3.4 * len(KPI_COLUMNS), 6.4), sharex="row"
+    )
+    fig.suptitle(
+        f"Does the score predict the flow at grt? {args.design}, "
+        f"{len(tags)} seed candidates",
+        color=INK,
+        fontsize=13,
+    )
+
+    for row, (xlabel, scores) in enumerate(rows):
+        xs_all = [scores[t] for t in tags]
+        for col, (kpi, kpi_label, is_timing) in enumerate(KPI_COLUMNS):
+            ax = axes[row][col]
+            ys_all = [flow[t][kpi] for t in tags]
+
+            ax.grid(True, color=GRID, linewidth=0.8, zorder=0)
+            ax.set_axisbelow(True)
+            for spine in ("top", "right"):
+                ax.spines[spine].set_visible(False)
+            for spine in ("left", "bottom"):
+                ax.spines[spine].set_color(INK_SECONDARY)
+            ax.tick_params(colors=INK_SECONDARY, labelsize=8)
+
+            if is_timing and delta_tie.get("achieved"):
+                mid = sum(ys_all) / len(ys_all)
+                tie = delta_tie["achieved"]
+                ax.axhspan(mid - tie, mid + tie, color=BAND, alpha=0.5, zorder=0, lw=0)
+
+            ax.scatter(
+                xs_all,
+                ys_all,
+                s=42,
+                color=BLUE,
+                edgecolors="white",
+                linewidths=0.8,
+                zorder=3,
+            )
+            for special, label in ((winner, "winner"), (default, "seed 0")):
+                if special is None:
+                    continue
+                x, y = scores[special], flow[special][kpi]
+                ax.scatter(
+                    [x],
+                    [y],
+                    s=58,
+                    color=ORANGE if special == winner else BLUE,
+                    edgecolors=INK,
+                    linewidths=1.0,
+                    zorder=4,
+                )
+                ax.annotate(
+                    label,
+                    (x, y),
+                    textcoords="offset points",
+                    xytext=(6, 6),
+                    fontsize=7.5,
+                    color=INK_SECONDARY,
+                )
+
+            rho = spearman(xs_all, ys_all)
+            lo, hi = spearman_ci(xs_all, ys_all)
+            ax.text(
+                0.03,
+                0.97,
+                f"ρ = {rho:+.2f}  [{lo:+.2f}, {hi:+.2f}]",
+                transform=ax.transAxes,
+                va="top",
+                fontsize=9,
+                color=INK,
+            )
+
+            if row == 0:
+                ax.set_title(kpi_label, fontsize=10, color=INK)
+            if row == len(rows) - 1:
+                ax.set_xlabel(xlabel, fontsize=9, color=INK)
+            if col == 0:
+                ax.set_ylabel(
+                    "flow at grt" if row == 0 else "flow at grt",
+                    fontsize=9,
+                    color=INK,
+                )
+
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    fig.savefig(args.out, dpi=160)
+    print(f"score_vs_flow: wrote {args.out} ({len(tags)} candidates)")
+    for row_label, scores in rows:
+        line = [row_label]
+        for kpi, _, _ in KPI_COLUMNS:
+            xs = [scores[t] for t in tags]
+            ys = [flow[t][kpi] for t in tags]
+            line.append(f"{kpi}: {spearman(xs, ys):+.2f}")
+        print("  " + "  ".join(line))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/estimation_ladder/sdc/swerv_c1100.sdc
+++ b/test/estimation_ladder/sdc/swerv_c1100.sdc
@@ -1,0 +1,14 @@
+current_design swerv_wrapper
+
+set clk_name core_clock
+set clk_port_name clk
+set clk_period 1100
+
+# Match the old set_input/output_delay = 0.2 * clk_period budget, as
+# optimization targets only (no set_input/output_delay — see rationale in
+# $PLATFORM_DIR/constraints.sdc).
+set in2reg_max [expr { $clk_period * 0.8 }]
+set reg2out_max [expr { $clk_period * 0.8 }]
+set in2out_max [expr { $clk_period * 0.6 }]
+
+source $::env(PLATFORM_DIR)/constraints.sdc

--- a/test/estimation_ladder/sdc/swerv_c1200.sdc
+++ b/test/estimation_ladder/sdc/swerv_c1200.sdc
@@ -1,0 +1,14 @@
+current_design swerv_wrapper
+
+set clk_name core_clock
+set clk_port_name clk
+set clk_period 1200
+
+# Match the old set_input/output_delay = 0.2 * clk_period budget, as
+# optimization targets only (no set_input/output_delay — see rationale in
+# $PLATFORM_DIR/constraints.sdc).
+set in2reg_max [expr { $clk_period * 0.8 }]
+set reg2out_max [expr { $clk_period * 0.8 }]
+set in2out_max [expr { $clk_period * 0.6 }]
+
+source $::env(PLATFORM_DIR)/constraints.sdc

--- a/test/estimation_ladder/sdc/swerv_c1300.sdc
+++ b/test/estimation_ladder/sdc/swerv_c1300.sdc
@@ -1,0 +1,14 @@
+current_design swerv_wrapper
+
+set clk_name core_clock
+set clk_port_name clk
+set clk_period 1300
+
+# Match the old set_input/output_delay = 0.2 * clk_period budget, as
+# optimization targets only (no set_input/output_delay — see rationale in
+# $PLATFORM_DIR/constraints.sdc).
+set in2reg_max [expr { $clk_period * 0.8 }]
+set reg2out_max [expr { $clk_period * 0.8 }]
+set in2out_max [expr { $clk_period * 0.6 }]
+
+source $::env(PLATFORM_DIR)/constraints.sdc

--- a/test/estimation_ladder/sdc/swerv_c1400.sdc
+++ b/test/estimation_ladder/sdc/swerv_c1400.sdc
@@ -1,0 +1,14 @@
+current_design swerv_wrapper
+
+set clk_name core_clock
+set clk_port_name clk
+set clk_period 1400
+
+# Match the old set_input/output_delay = 0.2 * clk_period budget, as
+# optimization targets only (no set_input/output_delay — see rationale in
+# $PLATFORM_DIR/constraints.sdc).
+set in2reg_max [expr { $clk_period * 0.8 }]
+set reg2out_max [expr { $clk_period * 0.8 }]
+set in2out_max [expr { $clk_period * 0.6 }]
+
+source $::env(PLATFORM_DIR)/constraints.sdc

--- a/test/estimation_ladder/seed_distribution.py
+++ b/test/estimation_ladder/seed_distribution.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""The distribution the selector draws from.
+
+One dot per rtl_macro_placer -random_seed candidate, sorted by the
+fast-GPL proxy score: the spread is the whole reason measured selection
+exists.  The proxy's winner and the default draw (seed 0 -- what the
+flow ships when nobody selects) are called out by name.  Reads a
+macro_select evidence directory (<tag>.json per candidate).
+"""
+
+import argparse
+import glob
+import json
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+BLUE = "#2a78d6"
+ORANGE = "#eb6834"
+INK = "#1a1f26"
+INK_SECONDARY = "#5a6472"
+GRID = "#e8eaed"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--proxy-dir", required=True)
+    parser.add_argument("--kpi", default="wq25")
+    parser.add_argument("--design", default="swerv_wrapper (asap7)")
+    parser.add_argument("--out", default="seed_distribution_swerv.png")
+    args = parser.parse_args()
+
+    candidates = {}
+    for path in sorted(glob.glob(os.path.join(args.proxy_dir, "cand_*.json"))):
+        with open(path) as f:
+            leaf = json.load(f)
+        candidates[leaf["seed"]] = leaf[args.kpi]
+    if len(candidates) < 2:
+        raise SystemExit(f"seed_distribution: {len(candidates)} candidates found")
+
+    ordered = sorted(candidates.items(), key=lambda kv: kv[1])
+    winner_seed = ordered[0][0]
+
+    fig, ax = plt.subplots(figsize=(7.2, 4.2))
+    ax.grid(True, axis="y", color=GRID, linewidth=0.8)
+    ax.set_axisbelow(True)
+    for spine in ("top", "right"):
+        ax.spines[spine].set_visible(False)
+    for spine in ("left", "bottom"):
+        ax.spines[spine].set_color(INK_SECONDARY)
+    ax.tick_params(colors=INK_SECONDARY, labelsize=8)
+
+    xs = list(range(len(ordered)))
+    ys = [v for _, v in ordered]
+    colors = [ORANGE if seed == winner_seed else BLUE for seed, _ in ordered]
+    ax.scatter(xs, ys, s=52, c=colors, edgecolors="white", linewidths=0.8, zorder=3)
+
+    for x, (seed, value) in zip(xs, ordered):
+        if seed == winner_seed:
+            ax.annotate(
+                f"seed {seed} (winner)",
+                (x, value),
+                textcoords="offset points",
+                xytext=(8, -2),
+                fontsize=8.5,
+                color=INK,
+            )
+        elif seed == 0:
+            ax.annotate(
+                "seed 0 (the default draw)",
+                (x, value),
+                textcoords="offset points",
+                xytext=(-8, 4),
+                ha="right",
+                fontsize=8.5,
+                color=INK,
+            )
+
+    spread = (ordered[-1][1] - ordered[0][1]) / ordered[-1][1] * 100.0
+    ax.set_title(
+        f"{args.design}: {len(ordered)} seed candidates span "
+        f"{spread:.0f}% on the scoring proxy",
+        fontsize=11,
+        color=INK,
+    )
+    ax.set_xlabel(
+        "candidates in proxy-score order (monotone by construction: "
+        "this shows spread, not ranking quality)",
+        fontsize=9,
+        color=INK,
+    )
+    ax.set_ylabel("fast-GPL proxy score, sampled-path mean (ps)", fontsize=9, color=INK)
+    ax.set_xticks([])
+
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=160)
+    print(f"seed_distribution: wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The reusable half of #868, so that PR can be closed. **9 files, no bazel targets, no measurement data.**

| file | what |
|---|---|
| `macro_select.tcl` | wrap the placer, seed it, pick a winner |
| `macro_score.tcl` | the report-only scorer |
| `extract_from_src.tcl` | pull KPIs out of a built variant |
| `score_vs_flow.py` | Spearman + bootstrap CI, stdlib only |
| `seed_distribution.py` | the candidate spread |
| `sdc/swerv_c{1100,1200,1300,1400}.sdc` | the four clock-shmoo points |

## What is deliberately left behind

Some **84,000 lines** of measurement JSON — per-candidate scores, stage-variance sweeps, the clock shmoo. It stays on the `macro-selector` branch and #868, both immutable.

Size is the lesser reason. Anyone who doubts a published number has to regenerate the population anyway, and these scripts are what regenerate it: **a seeded rerun is the check, not a diff against an archive.**

That is load-bearing rather than a platitude. The campaign established that an archived score/truth pair *cannot* grade a later rerun — the bazel-orfs pin changes the synthesis netlist and therefore the candidates, and re-measured truth against archived truth came out at **rho −0.26 [−0.65, +0.24]** on the macro-path KPI. Carrying the archive forward would invite precisely the comparison that does not work. It is written up under "Negative findings of importance" in `docs/estimate.md`, and the README section added here points at it.

## No bazel targets, on purpose

Several of #868's targets take an archived population as an *input* — `stage_variance_swerv` reads `stage_variance_swerv_wrapper.json` (19,809 lines) as its `delta_tie`. A target that cannot run is worse than no target, so they stay on the branch with the data they need. These files are here to be read and adapted by the next experiment, which is where their value is.

## Already landed elsewhere

- Findings: `docs/estimate.md` and `ideas/e12-clustered-scorer.md` (#881)
- `rtl_macro_placer` has no `-random_seed`: The-OpenROAD-Project/OpenROAD#11315
- `gpl` fillers/nets ignore `placement_cluster`: The-OpenROAD-Project/OpenROAD#11316
- gpl thread-invariant density scatter: already upstream as OpenROAD PR #11262

## Verified

`bazelisk build --nobuild //test/estimation_ladder/...` clean, both Python scripts parse, `//:fix_lint` clean. Nothing here is wired into a build, so there is no behaviour change to verify beyond that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)