### PR TITLE
ci: drop the "Submodule: lec build" step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,6 @@ jobs:
       - name: Run tests
         run: bazelisk test ... --build_tests_only --test_output=errors --profile=test.profile
 
-      # --- Submodules ---
-      - name: "Submodule: lec build"
-        working-directory: lec
-        run: >-
-          bazelisk build ... --keep_going --profile=lec.profile
-
       # --- Save caches (main branch only) ---
       - name: Save Repository cache
         if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Single concern: removes six lines from `.github/workflows/ci.yml`.

```yaml
      # --- Submodules ---
      - name: "Submodule: lec build"
        working-directory: lec
        run: >-
          bazelisk build ... --keep_going --profile=lec.profile
```

`lec/` is exercised in private downstream PRs, which are its only use case. Building it here tests nothing this repository depends on, and it is not cheap: `lec/` is its own bazel workspace with its own `MODULE.bazel` and `.bazelversion`, so it shares no analysis or action cache with the main build and pays a full separate module-graph resolution on every run.

## Scope

**Only the CI step.** `lec/` itself — `BUILD`, `lec.bzl`, `lec.yaml.tpl`, `MODULE.bazel`, `README.md` — is untouched and still builds on demand with `cd lec && bazelisk build ...`, which is how the downstream consumers drive it anyway.

## Checked

- The step was the **only** mention of `lec` in `.github/workflows/` (the one remaining match is the word "below" in a comment)
- `lec.profile` was consumed only by that step
- `ci.yml` still parses, and the remaining 13 steps are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)