### PR TITLE
feat(orfs): let the root module carry its own ORFS patches

### DIFF
--- a/extension.bzl
+++ b/extension.bzl
@@ -43,6 +43,19 @@ _source_tag = tag_class(
                   "not reliably serve a commit that exists only on a " +
                   "fork, even one that is an open PR's head.",
         ),
+        "patches": attr.label_list(
+            doc = "Site-specific ORFS patches, applied with -p1 after " +
+                  "this repository's own. bazel-orfs patches ORFS here " +
+                  "rather than as a bazel_dep so that patching works " +
+                  "whoever is root; that reasoning says nothing about " +
+                  "a consumer's own ORFS changes, which have nowhere " +
+                  "else to go once ORFS is no longer overridable from " +
+                  "the root module.",
+        ),
+        "patch_cmds": attr.string_list(
+            doc = "Site-specific patch commands, run after this " +
+                  "repository's own.",
+        ),
     },
 )
 
@@ -144,7 +157,13 @@ def _orfs_repositories_impl(module_ctx):
 
     http_archive(
         name = "orfs",
-        **orfs_archive_args(source.commit, source.integrity, source.urls)
+        **orfs_archive_args(
+            source.commit,
+            source.integrity,
+            source.urls,
+            source.patches,
+            source.patch_cmds,
+        )
     )
 
     # GNU Make built from source

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -366,7 +366,7 @@ ORFS_PATCH_CMDS = [
     _GENERATE_FLOW_BUILD,
 ]
 
-def orfs_archive_args(commit, integrity, urls = []):
+def orfs_archive_args(commit, integrity, urls = [], patches = [], patch_cmds = []):
     """http_archive arguments for an ORFS commit.
 
     Args:
@@ -374,6 +374,9 @@ def orfs_archive_args(commit, integrity, urls = []):
       integrity: Subresource Integrity string for the tarball.
       urls: optional override for where the tarball comes from. Empty
         means the canonical ORFS GitHub archive for `commit`.
+      patches: extra patches applied after this repository's own, for a
+        consumer carrying site-specific ORFS changes. -p1, as ours are.
+      patch_cmds: extra patch commands, run after this repository's own.
 
     Returns:
       A dict of http_archive keyword arguments.
@@ -381,8 +384,8 @@ def orfs_archive_args(commit, integrity, urls = []):
     return {
         "integrity": integrity,
         "patch_args": ["-p1"],
-        "patch_cmds": ORFS_PATCH_CMDS,
-        "patches": ORFS_PATCHES,
+        "patch_cmds": ORFS_PATCH_CMDS + patch_cmds,
+        "patches": ORFS_PATCHES + patches,
         "strip_prefix": ORFS_STRIP_PREFIX_TEMPLATE.format(commit),
         "urls": urls if urls else [ORFS_URL_TEMPLATE.format(commit)],
     }


### PR DESCRIPTION
## What

`orfs.source()` gains `patches` and `patch_cmds`, appended after this repository's own `ORFS_PATCHES` / `ORFS_PATCH_CMDS`.

## Why

ORFS is fetched and patched inside the extension rather than declared as a `bazel_dep`, so that patching works whoever is root — `orfs_source.bzl` explains that well. That settles where *this* repository's patches live. It says nothing about a consumer's own ORFS changes, which since the move have had nowhere to go: `patches` on an override is honoured only from the root module, and the root module no longer overrides ORFS.

A downstream project carrying site-specific ORFS patches currently has three options, all bad: fork ORFS and point `urls` at it (a fork branch to rebase every bump, and `/archive/<sha>` does not reliably serve fork-only commits), upstream site-specific changes that do not belong upstream, or stop bumping.

## Layering

Two layers, in order: this repository's patches first, the root module's second. That ordering is the useful one — a consumer patches the tree bazel-orfs has already fixed — and it makes duplicates fail loudly rather than silently diverge.

## Exercised

On a downstream project carrying 22 ORFS patches: all apply in order after the two carried here. One of them duplicated `0039-orfs-slang-plugin-fallback` and was dropped rather than rebased — the expected outcome, since a duplicate cannot apply once the copy ahead of it has moved the context.