### PR TITLE
fix(flow): tag the estimate oracle manual

### DIFF
--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -134,6 +134,12 @@ def _orfs_estimate_report(name, src, arguments = {}, sources = {}, variant = Non
         run_kwargs["openroad"] = openroad
     if visibility != None:
         run_kwargs["visibility"] = visibility
+
+    # The oracle is a diagnostic, not part of anyone's build: a wildcard
+    # pattern that swept it up would run place_pins on whatever die the
+    # flow's variables imply, which fails outright for a mocked macro whose
+    # stub die cannot hold the module's ports.
+    run_kwargs["tags"] = ["manual"]
     orfs_run(
         name = name,
         src = src,


### PR DESCRIPTION
## What

Tags the generated `*_estimate` targets `manual`.

## Why

The estimate target is emitted for every flow, so a wildcard build (`bazel test //...`) picks it up and runs `place_pins` on whatever die the flow's variables imply. For a mocked macro — a stub standing in for a memory, with a die sized for the stub — the module's ports do not fit:

```
[ERROR PPL-0024] Number of IO pins (226) exceeds maximum number of available positions (170).
```

The failure is not wrong exactly — those pins really do not fit that die — but it is not interesting either: nobody asked for an estimate of a stub, and the wildcard did the asking.

The oracle is a diagnostic rather than part of anyone's build, which is what `manual` is for. Asking for it by name still works.

## Measured downstream

Wildcard set for one package went from 442 targets to 308, turning a red CI run green, with `bazel build <the estimate target>` still succeeding.