### PR TITLE
Timestamp ORFS log lines behind --@bazel-orfs//:log_timestamps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//private:settings.bzl", "orfs_bool_flag")
 
 exports_files([
     # Read by //test:orfs_design_builds_test, which extracts the
@@ -28,6 +29,7 @@ exports_files([
     "deploy.tpl",
     "estimate.tcl",
     "html_timing_report.tcl",
+    "log_timestamps.py",
     "make.tpl",
     "mock_area.tcl",
     "open_blend.sh",
@@ -48,6 +50,20 @@ exports_files([
     "synth_keep.tcl",
     "synth_partition.sh",
 ])
+
+# Prefix every ORFS log line with elapsed seconds:
+#
+#   bazelisk build --@bazel-orfs//:log_timestamps //your:target_place
+#
+# Additive and off by default. Stamping changes the log bytes, so a
+# stamped run does not share cache entries with an unstamped one and
+# turning it on costs a rebuild of the stages you ask for. See
+# docs/debugging.md.
+orfs_bool_flag(
+    name = "log_timestamps",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
 
 sh_binary(
     name = "klayout",

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -43,6 +43,46 @@ RTL canonicalization uses the plugin (2). `Can't load module './slang': …
 cannot open slang.so` means the plugin isn't wired (yosys fell back to its
 `share/plugins` dir); set `yosys_plugins`.
 
+## Reading stage logs
+
+### Timestamp log lines with `--@bazel-orfs//:log_timestamps`
+An ORFS log tells you what a stage did, not when. `Took N seconds:`
+(`util.tcl`) and the closing `Elapsed time:` line are both written after the
+fact, so a log that took four hours does not say which part of it took the
+four hours.
+
+    bazelisk build --@bazel-orfs//:log_timestamps //your:target_place
+
+prefixes every logged line with elapsed wall seconds since the command
+started:
+
+    [    0.000] [INFO ODB-0227] LEF file: ..., created 13 layers
+    [  184.421]      1300 |   0.0912 | 1.234560e+06 |  -0.31% | 4.12e+04 |
+    [  391.887]      1310 |   0.0904 | 1.233210e+06 |  -0.11% | 4.28e+04 |
+
+which is enough to see where the time actually went — a slow global-place
+iteration, a `repair_timing` pass that stopped converging, a single
+long-running command between two cheap ones.
+
+Mechanically it replaces ORFS's `RUN_CMD` (`flow/scripts/variables.mk`, the
+one variable every logged tool invocation goes through) with
+`log_timestamps.py`, which delegates the actual work back to ORFS's
+`run_command.py` and only adds the stamp and the log write. No ORFS patch is
+involved, and every logged tool is stamped, not just OpenROAD.
+
+Scope is the build actions — `bazelisk build` and `bazelisk test`. A tree
+deployed by `//:deps` runs ORFS's own `RUN_CMD` and logs unstamped.
+
+Two things to know:
+
+* **It costs a rebuild.** Stamping changes the log bytes, so a stamped stage
+  does not share cache entries with an unstamped one. This is a debugging
+  flag, off by default; leaving it off is the normal state.
+* **Stamps are read times, not emission times.** The clock is read as each
+  line comes out of the child's pipe. OpenROAD's logger flushes as it goes,
+  so the two coincide; a tool that block-buffers instead shows up as a burst
+  of near-identical stamps — which is worth knowing in its own right.
+
 ## Builds & the from-source toolchain
 
 ### "up-to-date, 0 processes" is a cache hit, not a compile

--- a/log_timestamps.py
+++ b/log_timestamps.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Prefix every ORFS log line with elapsed seconds.
+
+A drop-in for ORFS's `RUN_CMD` (`flow/scripts/run_command.py`), injected
+by the stage rules when `--@bazel-orfs//:log_timestamps` is on. ORFS
+funnels every logged tool invocation through that one variable, so
+overriding it stamps every stage log without patching ORFS.
+
+    [    0.000] [INFO GPL-0002] DBU: 1000
+    [  184.421]       1300 |   0.0912 | 1.234560e+06 |  -0.31% | ...
+
+The prefix is elapsed wall seconds since the command started, so a log
+answers "where did the four hours go" by inspection -- which iteration
+of which grind, and how fast the iterations were coming. That is the
+question an ORFS log otherwise cannot answer at all: `Took N seconds`
+(util.tcl) and the closing `Elapsed time:` line arrive only once the
+command is over.
+
+Timing is measured when a line is read out of the child's pipe, so it
+is emission time only to the extent the child flushes as it goes.
+OpenROAD's logger does; anything that block-buffers will show as a
+burst of identical stamps, which is itself worth knowing.
+
+The heavy lifting -- process management, rusage accounting, the closing
+`Elapsed time:` line ORFS's own tooling parses -- stays in ORFS's
+run_command.py, which this delegates to. Only the stamping and the log
+write happen here.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+
+def stamp(prefix_seconds):
+    return "[{:9.3f}] ".format(prefix_seconds)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Run a command with timestamped log output.",
+    )
+    parser.add_argument("--log", help="Log file path")
+    parser.add_argument("--append", action="store_true", help="Append to the log")
+    parser.add_argument("--tee", action="store_true", help="Also write to stdout")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    cmd = args.command
+    if cmd and cmd[0] == "--":
+        cmd = cmd[1:]
+    if not cmd:
+        parser.error("No command specified")
+
+    flow_home = os.environ.get("FLOW_HOME")
+    if not flow_home:
+        sys.stderr.write("log_timestamps.py: FLOW_HOME is not set\n")
+        return 1
+    run_command = os.path.join(flow_home, "scripts", "run_command.py")
+
+    # --tee, never --log: run_command.py streams everything to its stdout
+    # and this process owns the log file. Its closing timing line goes to
+    # stderr, so merge stderr in to keep it in the log.
+    child = [sys.executable, run_command, "--tee", "--"] + cmd
+
+    log_file = None
+    if args.log:
+        os.makedirs(os.path.dirname(os.path.abspath(args.log)), exist_ok=True)
+        log_file = open(args.log, "a" if args.append else "w")
+
+    start = time.monotonic()
+    proc = subprocess.Popen(
+        child,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        for raw in iter(proc.stdout.readline, b""):
+            line = stamp(time.monotonic() - start) + raw.decode(errors="replace")
+            if args.tee:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+            if log_file:
+                log_file.write(line)
+                log_file.flush()
+        proc.wait()
+    except BaseException:
+        proc.kill()
+        proc.wait()
+        raise
+    finally:
+        if log_file:
+            log_file.close()
+
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -52,6 +52,10 @@ ORFS_PATCHES = [
     # Both mechanisms are needed: the patch covers an ORFS that still
     # ships flow/BUILD, the generated file covers one that does not.
     Label("//patches:0047-orfs-export-flow-tcl.patch"),
+    # flow.sh spells out run_command.py by hand instead of going through
+    # RUN_CMD, so an override reaches every logged target except the
+    # stage logs. --@bazel-orfs//:log_timestamps overrides RUN_CMD.
+    Label("//patches:0048-orfs-flow-sh-honor-run-cmd.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/patches/0048-orfs-flow-sh-honor-run-cmd.patch
+++ b/patches/0048-orfs-flow-sh-honor-run-cmd.patch
@@ -1,0 +1,41 @@
+Let flow.sh honor RUN_CMD, like the rest of the flow does.
+
+variables.mk defines RUN_CMD as the way a logged tool invocation is run,
+and every logged target in flow/Makefile goes through it -- yosys
+metrics, generate_abstract, the merge/drc/cdl/lvs steps, `run`. The one
+exception is flow.sh, which every *stage* goes through, and which spells
+out `$PYTHON_EXE $SCRIPTS_DIR/run_command.py` by hand.
+
+The effect is that RUN_CMD governs the peripheral logs and not one of
+the logs anyone actually reads. Overriding it -- to timestamp lines, to
+tee somewhere else, to wrap the tool -- silently misses floorplan,
+place, cts, grt and route.
+
+Defaulting to the current command keeps the behavior identical when
+RUN_CMD is unset, so this is a no-op for a normal `make` and makes the
+variable mean what its name says everywhere.
+
+diff --git a/flow/scripts/flow.sh b/flow/scripts/flow.sh
+--- a/flow/scripts/flow.sh
++++ b/flow/scripts/flow.sh
+@@ -3,6 +3,11 @@ set -euo pipefail
+ 
+ mkdir -p "$RESULTS_DIR" "$LOG_DIR" "$REPORTS_DIR" "$OBJECTS_DIR"
+ 
++# The rest of the flow runs logged commands through RUN_CMD; do the same
++# here so an override reaches the stage logs too. Unset -- a plain `make`
++# -- keeps exactly the command this script used to spell out inline.
++RUN_CMD="${RUN_CMD:-$PYTHON_EXE $SCRIPTS_DIR/run_command.py}"
++
+ echo "Running $2.tcl, stage $1"
+ 
+ (
+@@ -11,7 +16,7 @@ echo "Running $2.tcl, stage $1"
+   eval "$OPENROAD_EXE $OPENROAD_ARGS -exit \"$SCRIPTS_DIR/noop.tcl\"" \
+     >"$LOG_DIR/$1.tmp.log" 2>&1
+ 
+-  $PYTHON_EXE "$SCRIPTS_DIR/run_command.py" --log "$(realpath "$LOG_DIR/$1.tmp.log")" --append --tee -- \
++  $RUN_CMD --log "$(realpath "$LOG_DIR/$1.tmp.log")" --append --tee -- \
+     $OPENROAD_CMD -no_splash "$SCRIPTS_DIR/$2.tcl" -metrics "$LOG_DIR/$1.json"
+ )
+ 

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -95,6 +95,15 @@ def orfs_attrs():
             allow_single_file = True,
             default = Label("@bazel-orfs//:package_stage.py"),
         ),
+        "_log_timestamps": attr.label(
+            doc = "Whether to prefix log lines with elapsed seconds.",
+            default = Label("@bazel-orfs//:log_timestamps"),
+        ),
+        "_log_timestamps_script": attr.label(
+            doc = "RUN_CMD replacement that stamps log lines.",
+            allow_single_file = True,
+            default = Label("@bazel-orfs//:log_timestamps.py"),
+        ),
     }
 
 def flow_attrs():

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -8,6 +8,7 @@ load(
     "PdkInfo",
     "TopInfo",
 )
+load("//private:settings.bzl", "OrfsFlagInfo")
 load("//private:stages.bzl", "dropped_variables")
 load("//private:utils.bzl", "file_path", "flatten")
 
@@ -138,10 +139,38 @@ def _runfiles(attrs):
         ),
     )
 
+def log_timestamps_enabled(ctx):
+    """Whether --@bazel-orfs//:log_timestamps asked for stamped logs."""
+    flag = getattr(ctx.attr, "_log_timestamps", None)
+    return bool(flag) and flag[OrfsFlagInfo].value
+
+def log_timestamps_make_arg(ctx):
+    """A make command-line RUN_CMD override, or "" when the flag is off.
+
+    ORFS routes every logged tool invocation through RUN_CMD
+    (flow/scripts/variables.mk), so replacing it stamps every stage log
+    without patching ORFS. It has to be a make *command-line*
+    assignment: variables.mk sets RUN_CMD with `=`, which beats both the
+    environment and the `?=` lines of the generated argument include.
+    """
+    if not log_timestamps_enabled(ctx):
+        return ""
+    return "RUN_CMD='{python} {script}' ".format(
+        python = ctx.executable._python.path,
+        script = ctx.file._log_timestamps_script.path,
+    )
+
+def log_timestamps_inputs(ctx):
+    """The stamper script, when it is going to be invoked."""
+    if not log_timestamps_enabled(ctx):
+        return []
+    return [ctx.file._log_timestamps_script]
+
 def flow_inputs(ctx):
     if ctx.attr.lint:
         return flow_inputs_lite(ctx)
     return depset(
+        log_timestamps_inputs(ctx),
         transitive = [
             _runfiles(
                 [
@@ -164,6 +193,7 @@ def flow_inputs_lite(ctx):
     makefile, and user tools.
     """
     return depset(
+        log_timestamps_inputs(ctx),
         transitive = [
             _runfiles(
                 [

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -37,6 +37,7 @@ load(
     "hack_away_prefix",
     "input_commands",
     "log_dir_arguments",
+    "log_timestamps_make_arg",
     "merge_and_filter_arguments",
     "merge_arguments",
     "module_top",
@@ -188,9 +189,12 @@ def _expand_deploy_template(ctx, exe, config, make, genfiles, name = "", renames
 
 def _make_cmd(ctx):
     """Returns the make command prefix, with --silent in lint mode."""
-    if getattr(ctx.attr, "lint", False):
-        return ctx.executable._make.path + " --silent $@"
-    return ctx.executable._make.path + " $@"
+    silent = "--silent " if getattr(ctx.attr, "lint", False) else ""
+    return "{make} {silent}{stamp}$@".format(
+        make = ctx.executable._make.path,
+        silent = silent,
+        stamp = log_timestamps_make_arg(ctx),
+    )
 
 def _create_make_script(ctx, name, extra_substitutions = {}):
     """Creates the make wrapper script via template expansion.

--- a/private/settings.bzl
+++ b/private/settings.bzl
@@ -1,0 +1,21 @@
+"""Build settings owned by bazel-orfs.
+
+Bazel's own `config.bool` build setting, rather than bazel_skylib's
+`bool_flag`: skylib is a `dev_dependency` in MODULE.bazel, so reaching
+for it here would force it on every consumer for the sake of eight
+lines.
+"""
+
+OrfsFlagInfo = provider(
+    doc = "Value of a bazel-orfs command-line flag.",
+    fields = {"value": "The flag's value."},
+)
+
+def _orfs_bool_flag_impl(ctx):
+    return OrfsFlagInfo(value = ctx.build_setting_value)
+
+orfs_bool_flag = rule(
+    doc = "A boolean flag settable on the command line with --@bazel-orfs//:<name>.",
+    implementation = _orfs_bool_flag_impl,
+    build_setting = config.bool(flag = True),
+)


### PR DESCRIPTION
An ORFS log says what a stage did, not when. `Took N seconds:` and the closing
`Elapsed time:` line are both written after the fact, so a log that took four
hours does not say which part of it took the four hours — which iteration of
which grind, and how fast they were coming.

```
bazelisk build --@bazel-orfs//:log_timestamps //your:target_place
```

```
[    1.901]       290 |   0.1726 |  5.247910e+02 |   -2.77% | 2.91e-05 |
[    1.902]       300 |   0.1443 |  5.225640e+02 |   -0.42% | 4.29e-05 |
[    1.903]       310 |   0.1124 |  5.273030e+02 |   +0.91% | 6.32e-05 |
```

Two commits, least-churn-first.

### 1. `fix(orfs): let flow.sh honor RUN_CMD`

`variables.mk` defines `RUN_CMD` as the way a logged tool invocation is run, and
every logged target in `flow/Makefile` goes through it — yosys metrics,
`generate_abstract`, merge/drc/cdl/lvs, `run`. The one exception is `flow.sh`,
which every *stage* goes through, and which spells out
`$PYTHON_EXE $SCRIPTS_DIR/run_command.py` by hand.

So `RUN_CMD` governs the peripheral logs and not one of the logs anyone reads.
Overriding it silently misses floorplan, place, cts, grt and route.

The patch defaults `RUN_CMD` to the command `flow.sh` already spelled out, so an
unset `RUN_CMD` keeps behavior byte-identical and a plain `make` is unaffected.
Upstreamable as-is, and worth upstreaming: the variable does not currently mean
what its name says.

### 2. `feat(debug): timestamp ORFS log lines behind a flag`

The stage rules override `RUN_CMD` with `log_timestamps.py`, which delegates the
work back to ORFS's `run_command.py` — process management, rusage, the closing
timing line its own tooling parses — and adds only the stamp and the log write.
It has to be a make command-line assignment: `variables.mk` sets `RUN_CMD` with
`=`, which beats both the environment and the generated `?=` include.

The build setting is Bazel's own `config.bool` rather than skylib's `bool_flag`;
skylib is a `dev_dependency` and eight lines does not justify forcing it on
every consumer.

### Scope and caveats, all documented in `docs/debugging.md`

* **Additive, off by default.** Stamping changes the log bytes, so a stamped
  stage shares no cache entry with an unstamped one and turning it on costs a
  rebuild of the stages asked for. That is why it is a flag, not the default.
* **Build actions only.** A `//:deps` tree keeps ORFS's own `RUN_CMD`.
* **Stamps are pipe-read times.** A block-buffering tool would show as a burst
  of near-identical stamps. OpenROAD's logger flushes as it goes — on a gcd
  place the stamps advance at millisecond resolution.
* The first few lines of each stage log stay unstamped: they come from
  `flow.sh`'s separate `noop.tcl` banner invocation, which is outside `RUN_CMD`.

### Testing

No new tests — this is an additive debug flag whose off state is a no-op.
Verified by hand instead:

* `//test:lb_32x128_floorplan` with the flag on — stage logs stamped.
* `@orfs//flow/designs/asap7/gcd:gcd_place` with the flag on — real OpenROAD
  progress tables stamped, stamps advancing at ms resolution.
* The same target with the flag **off** — zero stamped lines, confirming the
  ORFS patch is a genuine no-op.
* `//:guard_tool_test`, `//test:openroad_wrapper_test`,
  `//test:orfs_design_builds_test`, `//test:orfs_flow_build_test`,
  `//test:orfs_platforms_test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)