### PR TITLE
docs(eta): make the recovery reference survive a rebase

### DIFF
--- a/ideas/eta.md
+++ b/ideas/eta.md
@@ -8,13 +8,18 @@ The apparatus was committed alongside this document and then retired, so
 the numbers can still be disputed by anyone willing to restore it:
 
 ```sh
-git show 02cbd2b --stat          # what was built
-git checkout 02cbd2b -- ideas/eta
+# Find it by message rather than by hash: the hash changes whenever the
+# branch is rebased, including on merge, so a hash written *inside* the
+# commit it names is wrong by the time anyone reads it.
+SHA=$(git log --all --format=%H --grep="measure whether ORFS grinds")
+git show "$SHA" --stat            # what was built
+git checkout "$SHA" -- ideas/eta  # restore it
 ```
 
-That commit carries the parsers, the three forecasters, the backtest
-harness, the TimesFM binary with its pinned lock, and `corpus.jsonl` --
-the 81 series every number below is computed from.
+At the time of writing that resolves to `573dbf5`. The commit carries the
+parsers, the three forecasters, the backtest harness, the TimesFM binary
+with its pinned lock, and `corpus.jsonl` -- the 81 series every number
+below is computed from.
 
 ## The question
 


### PR DESCRIPTION
`ideas/eta.md`, merged in #901, tells the reader to restore the retired
study machinery with:

```sh
git checkout 02cbd2b -- ideas/eta
```

**That hash is unreachable from `main`.** #901 was rebase-merged and the commit
became `573dbf5`, so the instruction fails for anyone who clones the repo.

The mistake is structural, not a typo: a commit cannot contain its own
post-merge hash, so a hash written inside the document it describes is wrong as
soon as the branch is rebased — which is how this repo merges. Recording it was
always going to break.

Fix: look the commit up by message, which survives any rebase, and keep the
hash alongside as a convenience rather than as the mechanism.

```sh
SHA=$(git log --all --format=%H --grep="measure whether ORFS grinds")
git show "$SHA" --stat
git checkout "$SHA" -- ideas/eta
```

Verified: resolves to `573dbf5` and restores all 81 series of `corpus.jsonl`.

This is a one-line-wide promise — the entire reason the apparatus was retired in
a separate commit was that the evidence stays recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)