### PR TITLE
fix(estimate): own the reg2reg path group; capstone breadcrumbs

### DIFF
--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -193,6 +193,19 @@ macro-path fields are the channel macro placement controls
 racing and selecting the pin is the macro-placement campaign's
 business (PR #868).
 
+The macro-path fields also answer whether that campaign is worth
+running on a given design at all. The campaign's capstone (24 draws
+through the full flow at swerv's most-live clock step) found the
+achieved period set entirely by generic std-cell paths — Spearman
++0.97 against the general-path mean, worst path a macro path in 0/23
+implementable draws — while the macro-path channel, rankable by a
+fast placement proxy at +0.74, sat 130ps+ below the generic floor
+and never bound. Macro-placement selection moves the clock only when
+macro paths bind, and `macro_paths_worst` against the general-path
+floor in one estimate is that test, per design, before any race is
+paid for. (The 24th draw was infeasible outright — see the PDN-0179
+negative finding below.)
+
 ## Provenance, trust, and breadcrumbs
 
 The lessons above come from exploratory campaigns: one machine, a
@@ -218,7 +231,15 @@ Observed once, pointer attached:
   designs.
 - Determinism held everywhere it was checked: placements and scores
   bit-identical across thread counts, execution shapes and a
-  binary change.
+  binary change (including 24/24 in the capstone re-generation).
+- The capstone (n=23 at swerv's most-live clock step,
+  `score_vs_flow_swerv_c1300.json` on the #868 branch): achieved
+  period unrankable by any macro-placement score (proxy rho −0.08,
+  CI [−0.47, +0.31]) for a structural reason — generic std-cell
+  paths set the clock (+0.97) and macro paths never bind; the
+  macro-path channel itself rankable at +0.74 with 301.7ps of range
+  against a 14.0ps tie band. This is the measurement behind the
+  macro-path fields in the JSON.
 
 Never measured at all, and needed before trusting deltas as
 magnitudes rather than ordering evidence: the PR-vs-merge-base

--- a/estimate.tcl
+++ b/estimate.tcl
@@ -66,11 +66,18 @@ log_cmd global_placement -density $density_lb_addon -overflow 0.6
 estimate_parasitics -placement
 set_propagated_clock [all_clocks]
 
+# The reg2reg path group: defined here rather than inherited, because
+# only some platform SDCs (asap7's, for one) create it and design SDCs
+# generally do not. Registered endpoints are what a floorplan-parameter
+# estimate can speak to; in2out flight time is the SDC's business.
+group_path -name reg2reg -from [all_registers] -to [all_registers]
+
 set wns_path [find_timing_paths -path_group reg2reg -sort_by_slack \
     -group_path_count 1]
 if { [llength $wns_path] == 0 } {
-    error "estimate: no reg2reg timing paths; the platform SDC defines\
-        no reg2reg group for this design"
+    error "estimate: no register-to-register paths; a design whose\
+        registers all live inside macro abstracts (or that has none)\
+        has no reg2reg channel for a floorplan estimate to measure"
 }
 set wns [get_property [lindex $wns_path 0] slack]
 set clk_period [get_property [lindex [get_clocks] 0] period]


### PR DESCRIPTION
Follow-up to #881, two things surfaced by the macro-design smoke that #881 still owed:

**Fix: the estimator defines its own reg2reg path group.** `estimate.tcl` assumed the platform SDC creates the `reg2reg` group. Only some do (asap7's `constraints.sdc`); design SDCs generally don't, and `//test:lb_32x128_top_estimate` failed with *no reg2reg timing paths*. The group is now created in the estimator itself — registered endpoints are what a floorplan-parameter estimate can speak to. A design with no reg2reg paths at all (a pure macro wrapper with no placeable instances, e.g. `//sram:top_fakeram`) still fails, now with a message naming that structure.

Smoked on a real macro design, `//test/estimation_ladder:multiplier_top_asap7_estimate` (16 macros): `rtl_macro_placer` path exercised, 38/200 sampled paths classified as macro paths, and the JSON demonstrates the binding test below in one report — `macro_paths_worst` 673ps against an `est_achievable_raw` floor of 1271ps.

**Docs: the capstone measurement behind the macro-path fields.** The macro-placement campaign's capstone (24 seeds through the full flow at swerv's most-live clock step; data and figure on the #868 branch, `score_vs_flow_swerv_c1300.{json,png}`) found:

- achieved period is set entirely by generic std-cell paths (Spearman +0.97 vs the general-path mean; the worst path is a macro path in 0/23 implementable draws), and is **unrankable** by any macro-placement score (proxy ρ −0.08, CI [−0.47, +0.31]) — not anti-correlated;
- the macro-path channel is rankable (+0.74, CI [+0.42, +0.91]) with 301.7ps of range against a 14.0ps tie band, but never binds on that design;
- 1 of 24 draws was infeasible outright (PDN-0179), converging with the negative-findings entry already in the doc.

So `macro_paths_worst` against the general-path floor in one estimate is the per-design test for whether macro-placement selection can move the clock at all, before any race is paid for. That lesson now lives next to the fields it justifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)