### PR TITLE
fix(bump): keep a submodule digest stable across a parent bump

### DIFF
--- a/bump_impl.py
+++ b/bump_impl.py
@@ -1107,7 +1107,11 @@ def _parse_mirror_urls(block, commit):
 
 
 def _resolve_openroad_archives(
-    openroad_commit, fetch_integrity_fn, fetch_sha256_hex_fn, fetch_submodule_sha_fn
+    openroad_commit,
+    fetch_integrity_fn,
+    fetch_sha256_hex_fn,
+    fetch_submodule_sha_fn,
+    known_digests=None,
 ):
     """Hash the parent archive and every submodule archive, concurrently.
 
@@ -1116,11 +1120,24 @@ def _resolve_openroad_archives(
     lookup and tarball hash stay sequential with respect to each other
     (the sha names the tarball), but the submodules run alongside one
     another and alongside the parent.
+
+    ``known_digests`` maps submodule path -> (sha, sha256_hex) as already
+    recorded in the block being regenerated.  A submodule whose sha the new
+    parent commit leaves unchanged keeps its recorded digest: re-hashing it
+    would download a tarball to arrive at the digest we already hold, and
+    GitHub's archives are not byte-stable, so the value can come back
+    *different* for identical content.  A digest that moves without its sha
+    moving invalidates any mirror keyed by digest, and stops a mismatch from
+    meaning what it should.
     """
     parent_url = github_archive_url(OPENROAD_REPO, openroad_commit)
+    known_digests = known_digests or {}
 
     def resolve_submodule(path, github_repo):
         sub_sha = fetch_submodule_sha_fn(OPENROAD_REPO, openroad_commit, path)
+        known = known_digests.get(path)
+        if known and known[0] == sub_sha:
+            return (path, github_repo, sub_sha, known[1])
         sub_url = f"https://github.com/{github_repo}/archive/{sub_sha}.tar.gz"
         return (path, github_repo, sub_sha, fetch_sha256_hex_fn(sub_url))
 
@@ -1282,6 +1299,7 @@ def update_openroad_archive_override(
             fetch_integrity_fn,
             fetch_sha256_hex_fn,
             fetch_submodule_sha_fn,
+            _parse_submodule_digests(old_block),
         )
 
     # Mirrors a consumer added are configuration, not hand-edits to undo:

--- a/bump_impl_test.py
+++ b/bump_impl_test.py
@@ -223,6 +223,59 @@ class TestMirrorPreservation(unittest.TestCase):
         self.assertEqual(digests["third-party/abc"], (OLD_SHA, OLD_HEX))
 
 
+REHASH_HEX = "e" * 64
+
+SUBMODULE_PATHS = [path for path, _ in bump_impl.OPENROAD_SUBMODULES]
+
+
+class TestSubmoduleDigestStability(unittest.TestCase):
+    """A submodule's digest may not move unless its sha moves.
+
+    GitHub's archives are not byte-stable, so re-hashing an unchanged
+    submodule can hand back a different digest for identical content.  That
+    breaks a consumer mirror keyed by digest outright, and it costs the
+    digest its meaning: a mismatch should say the content changed.
+    """
+
+    def _regenerate(self, content, sha256_fn, sub_sha=OLD_SHA):
+        return bump_impl.update_openroad_archive_override(
+            content=content,
+            openroad_commit="67890",
+            fetch_integrity_fn=lambda u: "sha256-bar",
+            fetch_sha256_hex_fn=sha256_fn,
+            fetch_submodule_sha_fn=lambda r, c, p: sub_sha,
+            workspace_dir=None,
+        )
+
+    def test_unchanged_submodule_sha_keeps_its_digest(self):
+        content = _block([_submodule_cmd(path) for path in SUBMODULE_PATHS])
+        out = self._regenerate(content, lambda u: REHASH_HEX)
+        self.assertIn(OLD_HEX, out)
+        self.assertNotIn(REHASH_HEX, out)
+
+    def test_unchanged_submodule_is_not_re_downloaded(self):
+        """The parent commit moving is not a reason to re-fetch every tarball."""
+        content = _block([_submodule_cmd(path) for path in SUBMODULE_PATHS])
+        urls = []
+
+        def spy(url):
+            urls.append(url)
+            return REHASH_HEX
+
+        self._regenerate(content, spy)
+        self.assertEqual(urls, [], "re-hashed a submodule whose sha did not move")
+
+    def test_changed_submodule_sha_is_still_rehashed(self):
+        """Reuse is keyed on the sha, so a moved submodule must not be cached."""
+        out = self._regenerate(
+            _block([_submodule_cmd("third-party/abc")]),
+            lambda u: NEW_HEX,
+            sub_sha=NEW_SHA,
+        )
+        self.assertIn(NEW_HEX, out)
+        self.assertNotIn(OLD_HEX, out)
+
+
 class TestUpdateOrfsSourceTag(unittest.TestCase):
     """ORFS as an extension-created http_archive.
 


### PR DESCRIPTION
Digest reuse was gated on the **parent** commit being unchanged, so any openroad
bump re-resolved every submodule from scratch — including submodules the new
parent commit leaves at the same sha.

GitHub's archives are not byte-stable, so re-hashing identical content can hand
back a different digest. Two things break when it does:

- A consumer whose mirror object is **named by digest** gets a URL that cannot
  exist, and the fetch fails outright.
- More quietly, a digest that moves without its sha moving stops being evidence
  of anything — a mismatch should mean the content changed.

Observed in the wild: across an openroad parent bump, `third-party/abc` stayed at
`d527cfab…` while its recorded digest moved.

Keyed on the submodule's own sha instead. `fetch_submodule_sha` is a cheap API
call that already runs before the tarball download, so the check costs nothing
and skips a multi-MB download per unchanged submodule as a side effect.

Three tests. The two behavioural ones fail without the change (verified by
reverting it); `test_changed_submodule_sha_is_still_rehashed` passes either way
and guards the opposite error — over-caching a submodule that genuinely moved.
