### PR TITLE
examples: add the flow to copy, distinct from //test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -29,6 +29,7 @@ timing tables.
 | `//test/smoketest:lb_32x128_sky130hs_build_test` | Full flow, all stages | — | — | sky130hs | yes |
 | `//test/smoketest:lb_32x128_ihp-sg13g2_build_test` | Full flow, all stages | — | — | ihp-sg13g2 | yes |
 | `//test/bump:bump_test` | `bump.sh` MODULE.bazel version update logic | — | — | — | — |
+| `//examples:mac_build_test` | The documented example flow, all stages through `final`. An example first and a test second: see `examples/README.md` | — | — | asap7 | yes |
 | `//:bump_compat_test` | COMPAT markers in `bump_impl.py` stay inside the 30-day window | — | — | — | — |
 
 ## User-facing binaries

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,0 +1,49 @@
+# Examples, not tests.
+#
+# This package shows the idiomatic way to write a bazel-orfs flow: one
+# orfs_flow() per design, RTL and constraints next to it, nothing shared
+# with test fixtures. CI builds it (see the build_test at the bottom) so
+# it can never rot, but it is written to be read first and run second:
+# when clarity and coverage pull in different directions, clarity wins
+# here and the coverage goes in //test.
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//:openroad.bzl", "orfs_flow")
+
+# Skip the slow, sign-off-oriented parts of the flow. Every setting here
+# is an ORFS variable; drop this dict for a real tapeout-grade run.
+FAST_SETTINGS = {
+    "FILL_CELLS": "",
+    "GND_NETS_VOLTAGES": "",
+    "GPL_ROUTABILITY_DRIVEN": "0",
+    "GPL_TIMING_DRIVEN": "0",
+    "PWR_NETS_VOLTAGES": "",
+    "REMOVE_ABC_BUFFERS": "1",
+    "SKIP_CTS_REPAIR_TIMING": "1",
+    "SKIP_INCREMENTAL_REPAIR": "1",
+    "SKIP_REPORT_METRICS": "1",
+    "TAPCELL_TCL": "",
+}
+
+# Creates //examples:mac_synth, _floorplan, _place, _cts, _grt, _route and
+# _final, plus //examples:mac_generate_abstract. Each stage target is a
+# `bazelisk run` entry point with a gui_<stage> argument:
+#
+#   bazelisk run //examples:mac_final gui_final
+orfs_flow(
+    name = "mac",
+    arguments = FAST_SETTINGS | {
+        "CORE_UTILIZATION": "40",
+        "PLACE_DENSITY": "0.65",
+    },
+    sources = {
+        "SDC_FILE": [":constraints.sdc"],
+    },
+    verilog_files = ["mac.v"],
+)
+
+# Keeps the example building in CI. `bazelisk test ...` only builds what a
+# test depends on, so without this the example would be invisible to CI.
+build_test(
+    name = "mac_build_test",
+    targets = [":mac_final"],
+)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,50 @@
+# Examples
+
+The idiomatic way to write a bazel-orfs flow, kept deliberately small.
+
+```bash
+bazelisk run //examples:mac_final gui_final
+```
+
+`mac` is a multiply-accumulate unit: a 24-bit accumulator that adds the
+product of two 8-bit inputs on every enabled clock. It is small enough to
+run the whole ORFS flow on asap7 in a couple of minutes and has a real
+timing path, the multiplier feeding the adder, for the GUI to show.
+
+| File | What it is |
+|---|---|
+| [BUILD](BUILD) | One `orfs_flow()`; the file to copy into your own project |
+| [mac.v](mac.v) | The RTL |
+| [constraints.sdc](constraints.sdc) | Clock and I/O timing constraints |
+
+## Things to try
+
+Change `PLACE_DENSITY` in `BUILD` and rerun. Only placement and the stages
+after it rebuild; synthesis and floorplan come from cache.
+
+Change the clock period in `constraints.sdc` and rerun. Synthesis and
+everything after it rebuild, because the SDC is a synthesis input.
+
+Open the Tcl shell instead of the GUI and ask for the worst path:
+
+```bash
+bazelisk run //examples:mac_final open_final
+report_checks -path_delay max
+```
+
+Re-run one substep outside Bazel, edit the flow Tcl, run it again:
+
+```bash
+bazelisk run //:deps -- //examples:mac_place do-3_4_place_resized
+```
+
+See [docs/local-flow.md](../docs/local-flow.md) for that workflow and
+[docs/customize.md](../docs/customize.md) for macros, abstracts and
+parameter sweeps.
+
+## Examples versus tests
+
+This directory is written to be read; `//test` is written to break when a
+rule changes. CI builds the example through `mac_build_test` so it cannot
+rot, but when clarity and coverage pull in different directions, clarity
+wins here and the coverage goes in `//test`.

--- a/examples/constraints.sdc
+++ b/examples/constraints.sdc
@@ -1,0 +1,7 @@
+# 1 GHz clock on the single clock port. asap7 units are picoseconds.
+create_clock -period 1000 -name clk [get_ports clk]
+
+# Give the inputs and outputs a plausible external budget so the
+# in-to-reg and reg-to-out paths are constrained too.
+set_input_delay  200 -clock clk [all_inputs -no_clocks]
+set_output_delay 200 -clock clk [all_outputs]

--- a/examples/mac.v
+++ b/examples/mac.v
@@ -1,0 +1,23 @@
+// Multiply-accumulate: acc <= acc + a * b on every enabled clock.
+//
+// Small enough to run the whole ORFS flow on asap7 in a couple of minutes,
+// large enough to have a real timing path (the multiplier feeding the
+// adder) for the GUI to show.
+module mac (
+    input             clk,
+    input             rst,
+    input             en,
+    input      [7:0]  a,
+    input      [7:0]  b,
+    output reg [23:0] acc
+);
+
+  always @(posedge clk) begin
+    if (rst) begin
+      acc <= 24'd0;
+    end else if (en) begin
+      acc <= acc + a * b;
+    end
+  end
+
+endmodule


### PR DESCRIPTION
## Summary

A new `examples/` package: the idiomatic bazel-orfs flow to copy, kept deliberately small and distinct from `//test`.

- `mac.v`, a 20-line multiply-accumulate with a real timing path (multiplier feeding the adder) for the GUI to show.
- `constraints.sdc`, a clock and I/O budgets.
- `BUILD`, one `orfs_flow()` with `FAST_SETTINGS` through `final` on asap7, plus a `build_test` so CI builds it and it cannot rot.
- `README.md` with things to try: change `PLACE_DENSITY` and watch only placement rebuild, open the Tcl shell and run `report_checks`, re-run one substep with `//:deps`.

The distinction is stated in `examples/BUILD`, the package README and `TESTING.md`: `examples/` is written to be read, `test/` is written to break when a rule changes. Examples may double as tests; tests are not examples. When clarity and coverage pull in different directions, clarity wins here and the coverage goes in `//test`.

The README rewrite that points at this package is a separate PR stacked on this one.

## Verified

```
bazelisk build //examples:mac_final                        # exit 0, full flow
bazelisk run   //examples:mac_final open_final             # report_checks: a[4] -> multiplier -> adder -> acc[17], slack met
bazelisk test  //examples:mac_build_test                   # PASSED
bazelisk run   //:fix_lint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
