### PR TITLE
ci: analyse every @orfs design flow target, not just load its package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,26 @@ jobs:
       - name: Load @orfs design packages
         run: bazelisk query '@orfs//flow/designs/...:*' > /dev/null
 
+      # Loading a package does not resolve the labels its rules reference.
+      # asap7/coralnpu loaded fine while its synth target pointed at
+      # //flow/designs/src/coralnpu, a directory ORFS had added with no
+      # BUILD; only analysis sees that edge. So analyse the flow targets
+      # themselves -- every design's _route, which pulls in synth through
+      # grt -- with --nobuild. Filtering to _route keeps out the bespoke
+      # ORFS targets (gcd_single_flow_*) that reference @openroad, which
+      # is why the step above is a query. ~1 minute for every platform.
+      #
+      # nangate45/mempool_group is excluded: its shipped
+      # src/mempool_group/rtl/BUILD is a bespoke filegroup with no
+      # exports_files, so the per-file labels config_mk_parser emits for
+      # it fail visibility. Pre-existing and unrelated to the generator;
+      # drop the exclusion when that BUILD is fixed.
+      - name: Analyse @orfs design flow targets
+        run: >
+          bazelisk build --nobuild --keep_going
+          $(bazelisk query 'filter("_route$", kind(rule, @orfs//flow/designs/...))
+          except @orfs//flow/designs/nangate45/mempool_group:all')
+
       # --- Unit tests ---
       - name: Run tests
         run: bazelisk test ... --build_tests_only --test_output=errors --profile=test.profile


### PR DESCRIPTION
CI loads every @orfs design package with `bazelisk query '@orfs//flow/designs/...:*'`. That catches DSL skew, but loading a package does not resolve the labels its rules reference: asap7/coralnpu loaded fine while its synth target pointed at `//flow/designs/src/coralnpu`, a directory ORFS had added with no BUILD. Only analysis sees that edge, and nothing analysed @orfs designs from this workspace.

**Change.** A second step analyses every design's `_route` target with `--nobuild --keep_going`. Filtering to `_route` keeps out the bespoke ORFS targets (`gcd_single_flow_*`) that reference `@openroad`, which is the reason the existing step is a query rather than `build --nobuild`. 61 targets across every platform, about a minute.

**Depends on #910.** Without it the step fails on coralnpu, which is the point: at the current pin this step is red on `main`, and it would have gone red the day the pin moved onto an ORFS containing coralnpu.

**Pre-existing, excluded.** `nangate45/mempool_group` fails analysis for an unrelated reason: its shipped `src/mempool_group/rtl/BUILD` is a bespoke `filegroup` with no `exports_files`, so the per-file labels `config_mk_parser` emits for it are not visible. The step excludes that package explicitly with a comment saying why; the fix belongs in that BUILD, and the exclusion goes when it lands.

**Verified** in a clean worktree: the command over all platforms fails on exactly coralnpu at `main`, and passes (exit 0, every target analysed) with #910 cherry-picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
