### PR TITLE
fix(synth): honour SYNTH_MINIMUM_KEEP_SIZE in discovery mode, like ORFS's synth.tcl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -338,3 +338,15 @@ orfs_designs(
         "sky130hs",
     ],
 )
+
+# The config.mk DSL fixtures under flow/designs/ (see flow/BUILD): the same
+# repository rule, parsing this repository's own fixture configs, so the
+# DSL path every ORFS design takes can be tested here in seconds. Must
+# stay below the ORFS instance: //test:orfs_platforms_test reads the
+# first orfs_designs() call it finds.
+orfs_designs(
+    name = "bazel_orfs_test_designs",
+    designs_dir = "//flow/designs:BUILD",
+    dev_dependency = True,
+    platforms = ["asap7"],
+)

--- a/TESTING.md
+++ b/TESTING.md
@@ -91,7 +91,11 @@ comm -23 \
 | `yosys` override | (via sweep kwargs) |
 | `stage_arguments` | tag_array (explicit regression test) |
 | `extra_configs` | sram/BUILD (config injection) |
-| `SYNTH_HIERARCHICAL` | L1MetadataArray |
+| `SYNTH_HIERARCHICAL` (serial) | L1MetadataArray |
+| Parallel synth, pinned `SYNTH_KEEP_MODULES` | `//test:kept_modules_synth_test` |
+| Parallel synth, discovered kept list | `//test:discovered_modules_netlist_test`, `flattened_modules_netlist_test` (both sides of `SYNTH_MINIMUM_KEEP_SIZE`) |
+| config.mk DSL (`design()`, `orfs_design.bzl`) | `//test:dsl_hier_discovery_*`, `dsl_hier_pinned_*` -- fixtures under `flow/designs/asap7/`, see `flow/BUILD` |
+| Real ORFS design, discovery mode | `//test:orfs_riscv32i_synth_build_test` |
 | `SYNTH_HDL_FRONTEND=slang` | slang/BUILD |
 | Cross-package refs | subpackage/BUILD |
 | 6 PDKs | smoketest/BUILD |

--- a/flow/BUILD
+++ b/flow/BUILD
@@ -1,0 +1,14 @@
+# Test-fixture plumbing, not a designs tree of bazel-orfs's own.
+#
+# The config.mk DSL (private/orfs_design.bzl) is what every ORFS design
+# goes through, and it is hard-wired to ORFS's layout: a design lives at
+# flow/designs/<platform>/<design>/ and its PDK is //flow:<platform>. To
+# exercise that path in this repository in seconds -- rather than only
+# against real ORFS designs that take minutes -- the fixtures under
+# flow/designs/ mirror the layout, and this package supplies the PDK
+# labels by aliasing ORFS's. See //test:dsl_* and test/BUILD.
+alias(
+    name = "asap7",
+    actual = "@orfs//flow:asap7",
+    visibility = ["//flow/designs:__subpackages__"],
+)

--- a/flow/designs/BUILD
+++ b/flow/designs/BUILD
@@ -1,0 +1,5 @@
+# Root of the config.mk DSL fixtures. MODULE.bazel points a second
+# orfs_designs() instance (bazel_orfs_test_designs) at this file; the
+# repository rule parses every config.mk under <platform>/ here exactly as
+# it parses ORFS's, and the fixtures' BUILD files load design() from it.
+exports_files(["BUILD"])

--- a/flow/designs/asap7/hier_discovery/BUILD
+++ b/flow/designs/asap7/hier_discovery/BUILD
@@ -1,0 +1,8 @@
+load("@bazel_orfs_test_designs//:designs.bzl", "design")
+
+# The same two lines every ORFS design package has, bound to this
+# repository's fixture DESIGNS. Visible to //test, where the tests live.
+design(
+    config = "config.mk",
+    visibility = ["//test:__pkg__"],
+)

--- a/flow/designs/asap7/hier_discovery/config.mk
+++ b/flow/designs/asap7/hier_discovery/config.mk
@@ -1,0 +1,18 @@
+# config.mk DSL fixture: SYNTH_HIERARCHICAL=1 with no SYNTH_KEEP_MODULES.
+#
+# This is the shape of every hierarchical ORFS design without a pinned
+# list (asap7/coralnpu, asap7/riscv32i, sky130hd/microwatt, ...), and the
+# path orfs_design.bzl takes for it: a static SYNTH_NUM_PARTITIONS, the
+# kept modules discovered by synth_keep.tcl at build time, a load-time
+# note that pinning buys per-module caching. Three modules, seconds of
+# yosys. SYNTH_MINIMUM_KEEP_SIZE=0 keeps adder and counter, which are far
+# below asap7's platform default of 1000 estimated gates.
+export PLATFORM                = asap7
+export DESIGN_NAME             = kept_modules_top
+export DESIGN_NICKNAME         = hier_discovery
+
+export VERILOG_FILES           = $(DESIGN_HOME)/asap7/hier_discovery/kept_modules_top.v
+export SDC_FILE                = $(DESIGN_HOME)/asap7/hier_discovery/constraint.sdc
+
+export SYNTH_HIERARCHICAL      = 1
+export SYNTH_MINIMUM_KEEP_SIZE = 0

--- a/flow/designs/asap7/hier_discovery/constraint.sdc
+++ b/flow/designs/asap7/hier_discovery/constraint.sdc
@@ -1,0 +1,5 @@
+set clk_name clock
+set clk_port_name clock
+set clk_period 2000
+
+source $env(PLATFORM_DIR)/constraints.sdc

--- a/flow/designs/asap7/hier_discovery/kept_modules_top.v
+++ b/flow/designs/asap7/hier_discovery/kept_modules_top.v
@@ -1,0 +1,42 @@
+// Minimal multi-module design for testing SYNTH_KEEP_MODULES.
+// Three modules: two sub-modules (adder, counter) and a top.
+module adder(
+  input  [7:0] a,
+  input  [7:0] b,
+  output [8:0] sum
+);
+  assign sum = a + b;
+endmodule
+
+module counter(
+  input        clk,
+  input        reset,
+  output [7:0] count
+);
+  reg [7:0] cnt;
+  always @(posedge clk or posedge reset)
+    if (reset)
+      cnt <= 8'd0;
+    else
+      cnt <= cnt + 8'd1;
+  assign count = cnt;
+endmodule
+
+module kept_modules_top(
+  input        clk,
+  input        reset,
+  input  [7:0] data_in,
+  output [8:0] result
+);
+  wire [7:0] count;
+  counter u_counter(
+    .clk(clk),
+    .reset(reset),
+    .count(count)
+  );
+  adder u_adder(
+    .a(count),
+    .b(data_in),
+    .sum(result)
+  );
+endmodule

--- a/flow/designs/asap7/hier_pinned/BUILD
+++ b/flow/designs/asap7/hier_pinned/BUILD
@@ -1,0 +1,8 @@
+load("@bazel_orfs_test_designs//:designs.bzl", "design")
+
+# The same two lines every ORFS design package has, bound to this
+# repository's fixture DESIGNS. Visible to //test, where the tests live.
+design(
+    config = "config.mk",
+    visibility = ["//test:__pkg__"],
+)

--- a/flow/designs/asap7/hier_pinned/config.mk
+++ b/flow/designs/asap7/hier_pinned/config.mk
@@ -1,0 +1,14 @@
+# config.mk DSL fixture: SYNTH_HIERARCHICAL=1 with SYNTH_KEEP_MODULES
+# pinned, the shape of asap7/swerv_wrapper. orfs_design.bzl sets
+# SYNTH_NUM_PARTITIONS to the list length and rules.bzl declares one
+# re-canonicalization action per named module. Three modules, seconds of
+# yosys.
+export PLATFORM                = asap7
+export DESIGN_NAME             = kept_modules_top
+export DESIGN_NICKNAME         = hier_pinned
+
+export VERILOG_FILES           = $(DESIGN_HOME)/asap7/hier_pinned/kept_modules_top.v
+export SDC_FILE                = $(DESIGN_HOME)/asap7/hier_pinned/constraint.sdc
+
+export SYNTH_HIERARCHICAL      = 1
+export SYNTH_KEEP_MODULES      = adder counter

--- a/flow/designs/asap7/hier_pinned/constraint.sdc
+++ b/flow/designs/asap7/hier_pinned/constraint.sdc
@@ -1,0 +1,5 @@
+set clk_name clock
+set clk_port_name clock
+set clk_period 2000
+
+source $env(PLATFORM_DIR)/constraints.sdc

--- a/flow/designs/asap7/hier_pinned/kept_modules_top.v
+++ b/flow/designs/asap7/hier_pinned/kept_modules_top.v
@@ -1,0 +1,42 @@
+// Minimal multi-module design for testing SYNTH_KEEP_MODULES.
+// Three modules: two sub-modules (adder, counter) and a top.
+module adder(
+  input  [7:0] a,
+  input  [7:0] b,
+  output [8:0] sum
+);
+  assign sum = a + b;
+endmodule
+
+module counter(
+  input        clk,
+  input        reset,
+  output [7:0] count
+);
+  reg [7:0] cnt;
+  always @(posedge clk or posedge reset)
+    if (reset)
+      cnt <= 8'd0;
+    else
+      cnt <= cnt + 8'd1;
+  assign count = cnt;
+endmodule
+
+module kept_modules_top(
+  input        clk,
+  input        reset,
+  input  [7:0] data_in,
+  output [8:0] result
+);
+  wire [7:0] count;
+  counter u_counter(
+    .clk(clk),
+    .reset(reset),
+    .count(count)
+  );
+  adder u_adder(
+    .a(count),
+    .b(data_in),
+    .sum(result)
+  );
+endmodule

--- a/synth.tcl
+++ b/synth.tcl
@@ -106,7 +106,33 @@ if { [env_var_exists_and_non_empty SYNTH_CHECKPOINT] && [env_var_exists_and_non_
   # defer flattening until we have decided what hierarchy to keep
   synth -run :fine
 
-  keep_hierarchy
+  # Which modules to keep as hierarchy boundaries. The flow itself runs
+  # ORFS's synth.tcl (@orfs//flow:scripts/synth.tcl); this copy is the
+  # one the unit tests drive, kept in step with it. Mirrors ORFS's
+  # synth.tcl: SYNTH_MINIMUM_KEEP_SIZE is the threshold in estimated
+  # gates below which a module is flattened into its parent (asap7's
+  # platform default is 1000; riscv32i sets 10000, coralnpu 40000).
+  # e46fca0 dropped this on the theory that yosys's default keeps "all
+  # substantial modules"; it does not -- with no threshold keep_hierarchy
+  # marks every module, so riscv32i kept its 30-gate shifter (whose
+  # `input signed` ports OpenSTA then rejects) and coralnpu kept 131
+  # modules where ORFS keeps a handful. Diverging from ORFS here changes
+  # the netlist every hierarchical ORFS design gets under bazel.
+  #
+  # convert_liberty_areas is a proc from ORFS's synth_preamble.tcl that
+  # feeds liberty cell areas into the estimate; guarded so the block
+  # also runs where the preamble is not sourced (the unit tests drive
+  # these scripts on bare yosys), falling back to yosys's gate counts.
+  if { [env_var_exists_and_non_empty SYNTH_MINIMUM_KEEP_SIZE] } {
+    set ungroup_threshold $::env(SYNTH_MINIMUM_KEEP_SIZE)
+    puts "Keep modules above estimated size of $ungroup_threshold gate equivalents"
+    if { [info commands convert_liberty_areas] ne "" } {
+      convert_liberty_areas
+    }
+    keep_hierarchy -min_cost $ungroup_threshold
+  } else {
+    keep_hierarchy
+  }
 
   # Re-run coarse-level script, this time do pass -flatten
   synth -flatten -run coarse:fine {*}$synth_full_args

--- a/synth_keep.tcl
+++ b/synth_keep.tcl
@@ -27,7 +27,31 @@ if { [env_var_exists_and_non_empty SYNTH_KEEP_MODULES] } {
 # Coarse synthesis without flattening to get module sizes
 synth -run :fine
 
-keep_hierarchy
+# Which modules to keep as hierarchy boundaries. Mirrors ORFS's
+# synth.tcl: SYNTH_MINIMUM_KEEP_SIZE is the threshold in estimated
+# gates below which a module is flattened into its parent (asap7's
+# platform default is 1000; riscv32i sets 10000, coralnpu 40000).
+# e46fca0 dropped this on the theory that yosys's default keeps "all
+# substantial modules"; it does not -- with no threshold keep_hierarchy
+# marks every module, so riscv32i kept its 30-gate shifter (whose
+# `input signed` ports OpenSTA then rejects) and coralnpu kept 131
+# modules where ORFS keeps a handful. Diverging from ORFS here changes
+# the netlist every hierarchical ORFS design gets under bazel.
+#
+# convert_liberty_areas is a proc from ORFS's synth_preamble.tcl that
+# feeds liberty cell areas into the estimate; guarded so the block
+# also runs where the preamble is not sourced (the unit tests drive
+# these scripts on bare yosys), falling back to yosys's gate counts.
+if { [env_var_exists_and_non_empty SYNTH_MINIMUM_KEEP_SIZE] } {
+  set ungroup_threshold $::env(SYNTH_MINIMUM_KEEP_SIZE)
+  puts "Keep modules above estimated size of $ungroup_threshold gate equivalents"
+  if { [info commands convert_liberty_areas] ne "" } {
+    convert_liberty_areas
+  }
+  keep_hierarchy -min_cost $ungroup_threshold
+} else {
+  keep_hierarchy
+}
 
 # Save RTLIL checkpoint after keep_hierarchy decisions.
 # The kept module list (kept_modules.json) is extracted separately

--- a/test/BUILD
+++ b/test/BUILD
@@ -857,6 +857,55 @@ sh_test(
     data = [":flattened_modules_synth_netlist"],
 )
 
+# The config.mk DSL end to end, in seconds. kept_modules_synth and
+# discovered_modules_synth above drive orfs_synth directly; nothing
+# drove private/orfs_design.bzl -- the SYNTH_NUM_PARTITIONS defaulting,
+# the SYNTH_KEEP_MODULES parsing, the discovery-mode note -- although it
+# is the path every ORFS design takes. Discovery mode was broken for
+# three months (f3c5254 .. #911) without a test noticing. These two
+# fixtures under flow/designs/asap7/ (see flow/BUILD) are the same
+# three-module design through design(), one branch each.
+[
+    (
+        build_test(
+            name = "dsl_%s_synth_test" % fixture,
+            targets = ["//flow/designs/asap7/%s:kept_modules_top_synth" % fixture],
+        ),
+        filegroup(
+            name = "dsl_%s_netlist" % fixture,
+            srcs = ["//flow/designs/asap7/%s:kept_modules_top_synth" % fixture],
+            output_group = "1_2_yosys.v",
+        ),
+        sh_test(
+            name = "dsl_%s_netlist_test" % fixture,
+            size = "small",
+            srcs = ["synth_discovery_netlist_test.sh"],
+            args = [
+                "$(location :dsl_%s_netlist)" % fixture,
+                "adder",
+                "counter",
+                "kept_modules_top",
+            ],
+            data = [":dsl_%s_netlist" % fixture],
+        ),
+    )
+    for fixture in [
+        "hier_discovery",
+        "hier_pinned",
+    ]
+]
+
+# One real ORFS design in discovery mode, minutes: 24 modules, and at its
+# SYNTH_MINIMUM_KEEP_SIZE of 10000 exactly one (dmem) stays a boundary.
+# It is what caught both the top-module-in-the-kept-list bug (#911) and
+# the ignored threshold (#913): the 30-gate shifter, kept when it should
+# not have been, has `input signed` ports OpenSTA rejects. A build_test
+# for the same reason mock-alu is one: the flow running is the question.
+build_test(
+    name = "orfs_riscv32i_synth_build_test",
+    targets = ["@orfs//flow/designs/asap7/riscv32i:riscv_top_synth"],
+)
+
 # Lock the SDC/clock-period split on the serial synth path (Mul_synth):
 # the expensive actions read only the extracted clock_period.txt; the raw
 # SDC feeds only the cheap extraction and sdc-copy actions, so a

--- a/test/BUILD
+++ b/test/BUILD
@@ -779,6 +779,9 @@ orfs_synth(
     arguments = {
         "SDC_FILE": "$(location :constraints-top.sdc)",
         "SYNTH_HIERARCHICAL": "1",
+        # Keep every module regardless of size: adder and counter are a
+        # few dozen gates, far under asap7's platform default of 1000.
+        "SYNTH_MINIMUM_KEEP_SIZE": "0",
         "SYNTH_NUM_PARTITIONS": "2",
     },
     data = [":constraints-top.sdc"],
@@ -813,6 +816,45 @@ sh_test(
         "kept_modules_top",
     ],
     data = [":discovered_modules_synth_netlist"],
+)
+
+# The threshold's other side: with SYNTH_MINIMUM_KEEP_SIZE above every
+# module's estimated size, discovery keeps nothing, every partition is
+# empty and the top partition synthesizes the whole flattened design.
+# This is the ORFS behaviour e46fca0 lost -- asap7/riscv32i's 30-gate
+# shifter stayed a boundary and its `input signed` ports broke
+# do-1_synth -- pinned here so the threshold is known to be honoured.
+orfs_synth(
+    name = "flattened_modules_synth",
+    arguments = {
+        "SDC_FILE": "$(location :constraints-top.sdc)",
+        "SYNTH_HIERARCHICAL": "1",
+        "SYNTH_MINIMUM_KEEP_SIZE": "100000",
+        "SYNTH_NUM_PARTITIONS": "2",
+    },
+    data = [":constraints-top.sdc"],
+    module_top = "kept_modules_top",
+    variant = "flattened",
+    verilog_files = ["rtl/kept_modules_top.v"],
+)
+
+filegroup(
+    name = "flattened_modules_synth_netlist",
+    srcs = [":flattened_modules_synth"],
+    output_group = "1_2_yosys.v",
+)
+
+sh_test(
+    name = "flattened_modules_netlist_test",
+    size = "small",
+    srcs = ["synth_discovery_netlist_test.sh"],
+    args = [
+        "$(location :flattened_modules_synth_netlist)",
+        "kept_modules_top",
+        "!adder",
+        "!counter",
+    ],
+    data = [":flattened_modules_synth_netlist"],
 )
 
 # Lock the SDC/clock-period split on the serial synth path (Mul_synth):

--- a/test/synth_discovery_netlist_test.sh
+++ b/test/synth_discovery_netlist_test.sh
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
 # Does discovery-mode parallel synthesis keep the discovered hierarchy?
 #
-# Arguments: the merged 1_2_yosys.v, then the module names that must
-# appear as their own `module` declarations. Partition synthesis emits one
-# netlist per kept module and the merge concatenates them, so a flattened
-# result -- or one where a partition produced nothing -- fails here even
-# though yosys exited zero.
+# Arguments: the merged 1_2_yosys.v, then module names. A bare name must
+# appear as its own `module` declaration; a name prefixed with `!` must
+# not. Partition synthesis emits one netlist per kept module and the
+# merge concatenates them, so a flattened result -- or one where a
+# partition produced nothing -- fails here even though yosys exited zero;
+# and a module that SYNTH_MINIMUM_KEEP_SIZE should have flattened but
+# that survives as a boundary fails the `!` form.
 set -euo pipefail
 netlist=$1
 shift
 status=0
-for module in "$@"; do
-  if ! grep -Eq "^module ${module}(\(|\s|$)" "$netlist"; then
+for spec in "$@"; do
+  module=${spec#!}
+  if grep -Eq "^module ${module}(\(|\s|$)" "$netlist"; then
+    if [ "$spec" != "$module" ]; then
+      echo "FAIL: 'module ${module}' present in $netlist but should be flattened" >&2
+      status=1
+    fi
+  elif [ "$spec" = "$module" ]; then
     echo "FAIL: no 'module ${module}' in $netlist" >&2
     status=1
   fi


### PR DESCRIPTION
Discovery-mode parallel synthesis ignores `SYNTH_MINIMUM_KEEP_SIZE`. e46fca0 removed it from `synth_keep.tcl` on the theory that yosys's default `keep_hierarchy` keeps all substantial modules. It does not: with no threshold it marks every module. ORFS's `synth.tcl`, which the serial path runs, still applies the threshold, so a hierarchical ORFS design without a pinned list gets a different set of kept modules under parallel synthesis than under `make` or the serial path.

Measured on two designs:
- **asap7/riscv32i** (`SYNTH_MINIMUM_KEEP_SIZE=10000`): bazel kept 15 of 23 submodules, including the 30-gate `shifter`, whose `input signed` ports OpenSTA's Verilog reader rejects in `do-1_synth` (`STA-0171 syntax error`). The design could not build. With the threshold honoured it keeps one module (`dmem`) and synth completes.
- **asap7/coralnpu** (`SYNTH_MINIMUM_KEEP_SIZE=40000`): bazel kept 131 modules where ORFS keeps a handful; `repair_design` then inserted one buffer on a 200k-cell design and detailed routing plateaued at ~3400 violations for 10 hours. Not debugged further (the design is ORFS's), but the divergence is not free.

**Change.** Restore the block e46fca0 removed in `synth_keep.tcl`, mirroring ORFS's `synth.tcl`: `convert_liberty_areas` (a proc from ORFS's `synth_preamble.tcl`, guarded so the script also runs on bare yosys in unit tests), then `keep_hierarchy -min_cost $SYNTH_MINIMUM_KEEP_SIZE` when set, plain `keep_hierarchy` otherwise. The in-repo `synth.tcl`, which only the unit tests drive (the flow runs `@orfs//flow:scripts/synth.tcl`), gets the same block so it stays in step.

The `SYNTH_MINIMUM_KEEP_SIZE=0` default for hierarchical designs that e46fca0 also removed from `orfs_design.bzl` is **not** restored: the platform default (asap7: 1000) reaches the make environment the way it does in ORFS.

**Tests.** `discovered_modules_synth` now sets `SYNTH_MINIMUM_KEEP_SIZE=0` explicitly, since its adder and counter are far below asap7's default. New `flattened_modules_synth` sets 100000 and its netlist test asserts `adder` and `counter` are gone and only the top remains, so the threshold is known to be honoured on both sides. The netlist checker grew a `!module` form for that. `kept_modules_synth_test`, `synth_keep_modules_check_test`, and the serial-path `L1MetadataArray` synth targets in `//test` and `//subpackage` still build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
