### PR TITLE
test: drive the config.mk DSL with in-repo fixtures, and riscv32i as the real design

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -338,3 +338,15 @@ orfs_designs(
         "sky130hs",
     ],
 )
+
+# The config.mk DSL fixtures under flow/designs/ (see flow/BUILD): the same
+# repository rule, parsing this repository's own fixture configs, so the
+# DSL path every ORFS design takes can be tested here in seconds. Must
+# stay below the ORFS instance: //test:orfs_platforms_test reads the
+# first orfs_designs() call it finds.
+orfs_designs(
+    name = "bazel_orfs_test_designs",
+    designs_dir = "//flow/designs:BUILD",
+    dev_dependency = True,
+    platforms = ["asap7"],
+)

--- a/TESTING.md
+++ b/TESTING.md
@@ -91,7 +91,11 @@ comm -23 \
 | `yosys` override | (via sweep kwargs) |
 | `stage_arguments` | tag_array (explicit regression test) |
 | `extra_configs` | sram/BUILD (config injection) |
-| `SYNTH_HIERARCHICAL` | L1MetadataArray |
+| `SYNTH_HIERARCHICAL` (serial) | L1MetadataArray |
+| Parallel synth, pinned `SYNTH_KEEP_MODULES` | `//test:kept_modules_synth_test` |
+| Parallel synth, discovered kept list | `//test:discovered_modules_netlist_test`, `flattened_modules_netlist_test` (both sides of `SYNTH_MINIMUM_KEEP_SIZE`) |
+| config.mk DSL (`design()`, `orfs_design.bzl`) | `//test:dsl_hier_discovery_*`, `dsl_hier_pinned_*` -- fixtures under `flow/designs/asap7/`, see `flow/BUILD` |
+| Real ORFS design, discovery mode | `//test:orfs_riscv32i_synth_build_test` |
 | `SYNTH_HDL_FRONTEND=slang` | slang/BUILD |
 | Cross-package refs | subpackage/BUILD |
 | 6 PDKs | smoketest/BUILD |

--- a/flow/BUILD
+++ b/flow/BUILD
@@ -1,0 +1,14 @@
+# Test-fixture plumbing, not a designs tree of bazel-orfs's own.
+#
+# The config.mk DSL (private/orfs_design.bzl) is what every ORFS design
+# goes through, and it is hard-wired to ORFS's layout: a design lives at
+# flow/designs/<platform>/<design>/ and its PDK is //flow:<platform>. To
+# exercise that path in this repository in seconds -- rather than only
+# against real ORFS designs that take minutes -- the fixtures under
+# flow/designs/ mirror the layout, and this package supplies the PDK
+# labels by aliasing ORFS's. See //test:dsl_* and test/BUILD.
+alias(
+    name = "asap7",
+    actual = "@orfs//flow:asap7",
+    visibility = ["//flow/designs:__subpackages__"],
+)

--- a/flow/designs/BUILD
+++ b/flow/designs/BUILD
@@ -1,0 +1,5 @@
+# Root of the config.mk DSL fixtures. MODULE.bazel points a second
+# orfs_designs() instance (bazel_orfs_test_designs) at this file; the
+# repository rule parses every config.mk under <platform>/ here exactly as
+# it parses ORFS's, and the fixtures' BUILD files load design() from it.
+exports_files(["BUILD"])

--- a/flow/designs/asap7/hier_discovery/BUILD
+++ b/flow/designs/asap7/hier_discovery/BUILD
@@ -1,0 +1,8 @@
+load("@bazel_orfs_test_designs//:designs.bzl", "design")
+
+# The same two lines every ORFS design package has, bound to this
+# repository's fixture DESIGNS. Visible to //test, where the tests live.
+design(
+    config = "config.mk",
+    visibility = ["//test:__pkg__"],
+)

--- a/flow/designs/asap7/hier_discovery/config.mk
+++ b/flow/designs/asap7/hier_discovery/config.mk
@@ -1,0 +1,18 @@
+# config.mk DSL fixture: SYNTH_HIERARCHICAL=1 with no SYNTH_KEEP_MODULES.
+#
+# This is the shape of every hierarchical ORFS design without a pinned
+# list (asap7/coralnpu, asap7/riscv32i, sky130hd/microwatt, ...), and the
+# path orfs_design.bzl takes for it: a static SYNTH_NUM_PARTITIONS, the
+# kept modules discovered by synth_keep.tcl at build time, a load-time
+# note that pinning buys per-module caching. Three modules, seconds of
+# yosys. SYNTH_MINIMUM_KEEP_SIZE=0 keeps adder and counter, which are far
+# below asap7's platform default of 1000 estimated gates.
+export PLATFORM                = asap7
+export DESIGN_NAME             = kept_modules_top
+export DESIGN_NICKNAME         = hier_discovery
+
+export VERILOG_FILES           = $(DESIGN_HOME)/asap7/hier_discovery/kept_modules_top.v
+export SDC_FILE                = $(DESIGN_HOME)/asap7/hier_discovery/constraint.sdc
+
+export SYNTH_HIERARCHICAL      = 1
+export SYNTH_MINIMUM_KEEP_SIZE = 0

--- a/flow/designs/asap7/hier_discovery/constraint.sdc
+++ b/flow/designs/asap7/hier_discovery/constraint.sdc
@@ -1,0 +1,5 @@
+set clk_name clock
+set clk_port_name clock
+set clk_period 2000
+
+source $env(PLATFORM_DIR)/constraints.sdc

--- a/flow/designs/asap7/hier_discovery/kept_modules_top.v
+++ b/flow/designs/asap7/hier_discovery/kept_modules_top.v
@@ -1,0 +1,42 @@
+// Minimal multi-module design for testing SYNTH_KEEP_MODULES.
+// Three modules: two sub-modules (adder, counter) and a top.
+module adder(
+  input  [7:0] a,
+  input  [7:0] b,
+  output [8:0] sum
+);
+  assign sum = a + b;
+endmodule
+
+module counter(
+  input        clk,
+  input        reset,
+  output [7:0] count
+);
+  reg [7:0] cnt;
+  always @(posedge clk or posedge reset)
+    if (reset)
+      cnt <= 8'd0;
+    else
+      cnt <= cnt + 8'd1;
+  assign count = cnt;
+endmodule
+
+module kept_modules_top(
+  input        clk,
+  input        reset,
+  input  [7:0] data_in,
+  output [8:0] result
+);
+  wire [7:0] count;
+  counter u_counter(
+    .clk(clk),
+    .reset(reset),
+    .count(count)
+  );
+  adder u_adder(
+    .a(count),
+    .b(data_in),
+    .sum(result)
+  );
+endmodule

--- a/flow/designs/asap7/hier_pinned/BUILD
+++ b/flow/designs/asap7/hier_pinned/BUILD
@@ -1,0 +1,8 @@
+load("@bazel_orfs_test_designs//:designs.bzl", "design")
+
+# The same two lines every ORFS design package has, bound to this
+# repository's fixture DESIGNS. Visible to //test, where the tests live.
+design(
+    config = "config.mk",
+    visibility = ["//test:__pkg__"],
+)

--- a/flow/designs/asap7/hier_pinned/config.mk
+++ b/flow/designs/asap7/hier_pinned/config.mk
@@ -1,0 +1,14 @@
+# config.mk DSL fixture: SYNTH_HIERARCHICAL=1 with SYNTH_KEEP_MODULES
+# pinned, the shape of asap7/swerv_wrapper. orfs_design.bzl sets
+# SYNTH_NUM_PARTITIONS to the list length and rules.bzl declares one
+# re-canonicalization action per named module. Three modules, seconds of
+# yosys.
+export PLATFORM                = asap7
+export DESIGN_NAME             = kept_modules_top
+export DESIGN_NICKNAME         = hier_pinned
+
+export VERILOG_FILES           = $(DESIGN_HOME)/asap7/hier_pinned/kept_modules_top.v
+export SDC_FILE                = $(DESIGN_HOME)/asap7/hier_pinned/constraint.sdc
+
+export SYNTH_HIERARCHICAL      = 1
+export SYNTH_KEEP_MODULES      = adder counter

--- a/flow/designs/asap7/hier_pinned/constraint.sdc
+++ b/flow/designs/asap7/hier_pinned/constraint.sdc
@@ -1,0 +1,5 @@
+set clk_name clock
+set clk_port_name clock
+set clk_period 2000
+
+source $env(PLATFORM_DIR)/constraints.sdc

--- a/flow/designs/asap7/hier_pinned/kept_modules_top.v
+++ b/flow/designs/asap7/hier_pinned/kept_modules_top.v
@@ -1,0 +1,42 @@
+// Minimal multi-module design for testing SYNTH_KEEP_MODULES.
+// Three modules: two sub-modules (adder, counter) and a top.
+module adder(
+  input  [7:0] a,
+  input  [7:0] b,
+  output [8:0] sum
+);
+  assign sum = a + b;
+endmodule
+
+module counter(
+  input        clk,
+  input        reset,
+  output [7:0] count
+);
+  reg [7:0] cnt;
+  always @(posedge clk or posedge reset)
+    if (reset)
+      cnt <= 8'd0;
+    else
+      cnt <= cnt + 8'd1;
+  assign count = cnt;
+endmodule
+
+module kept_modules_top(
+  input        clk,
+  input        reset,
+  input  [7:0] data_in,
+  output [8:0] result
+);
+  wire [7:0] count;
+  counter u_counter(
+    .clk(clk),
+    .reset(reset),
+    .count(count)
+  );
+  adder u_adder(
+    .a(count),
+    .b(data_in),
+    .sum(result)
+  );
+endmodule

--- a/test/BUILD
+++ b/test/BUILD
@@ -857,6 +857,55 @@ sh_test(
     data = [":flattened_modules_synth_netlist"],
 )
 
+# The config.mk DSL end to end, in seconds. kept_modules_synth and
+# discovered_modules_synth above drive orfs_synth directly; nothing
+# drove private/orfs_design.bzl -- the SYNTH_NUM_PARTITIONS defaulting,
+# the SYNTH_KEEP_MODULES parsing, the discovery-mode note -- although it
+# is the path every ORFS design takes. Discovery mode was broken for
+# three months (f3c5254 .. #911) without a test noticing. These two
+# fixtures under flow/designs/asap7/ (see flow/BUILD) are the same
+# three-module design through design(), one branch each.
+[
+    (
+        build_test(
+            name = "dsl_%s_synth_test" % fixture,
+            targets = ["//flow/designs/asap7/%s:kept_modules_top_synth" % fixture],
+        ),
+        filegroup(
+            name = "dsl_%s_netlist" % fixture,
+            srcs = ["//flow/designs/asap7/%s:kept_modules_top_synth" % fixture],
+            output_group = "1_2_yosys.v",
+        ),
+        sh_test(
+            name = "dsl_%s_netlist_test" % fixture,
+            size = "small",
+            srcs = ["synth_discovery_netlist_test.sh"],
+            args = [
+                "$(location :dsl_%s_netlist)" % fixture,
+                "adder",
+                "counter",
+                "kept_modules_top",
+            ],
+            data = [":dsl_%s_netlist" % fixture],
+        ),
+    )
+    for fixture in [
+        "hier_discovery",
+        "hier_pinned",
+    ]
+]
+
+# One real ORFS design in discovery mode, minutes: 24 modules, and at its
+# SYNTH_MINIMUM_KEEP_SIZE of 10000 exactly one (dmem) stays a boundary.
+# It is what caught both the top-module-in-the-kept-list bug (#911) and
+# the ignored threshold (#913): the 30-gate shifter, kept when it should
+# not have been, has `input signed` ports OpenSTA rejects. A build_test
+# for the same reason mock-alu is one: the flow running is the question.
+build_test(
+    name = "orfs_riscv32i_synth_build_test",
+    targets = ["@orfs//flow/designs/asap7/riscv32i:riscv_top_synth"],
+)
+
 # Lock the SDC/clock-period split on the serial synth path (Mul_synth):
 # the expensive actions read only the extracted clock_period.txt; the raw
 # SDC feeds only the cheap extraction and sdc-copy actions, so a


### PR DESCRIPTION
The config.mk DSL (`design()` → `private/orfs_design.bzl`) is the path every ORFS design takes, and nothing in this repository drove it: `kept_modules_synth` and `discovered_modules_synth` call `orfs_synth` directly, so the `SYNTH_NUM_PARTITIONS` defaulting, the kept-list parsing and the discovery-mode note in `orfs_design.bzl` had no test. Discovery mode was broken for three months (f3c5254 to #911) without a test noticing.

**Fixtures.** `design()` is hard-wired to ORFS's layout, `flow/designs/<platform>/<design>/` and a `//flow:<platform>` PDK, so the fixtures mirror it:
- `flow/BUILD` aliases `//flow:asap7` to `@orfs//flow:asap7` and says why it exists.
- `flow/designs/asap7/hier_discovery`: `SYNTH_HIERARCHICAL=1`, no kept list, `SYNTH_MINIMUM_KEEP_SIZE=0`. The coralnpu/riscv32i/microwatt shape.
- `flow/designs/asap7/hier_pinned`: `SYNTH_KEEP_MODULES = adder counter`. The swerv_wrapper shape.
- A second `orfs_designs()` instance in MODULE.bazel (`bazel_orfs_test_designs`, dev dependency, asap7 only) parses them with the same repository rule ORFS's designs go through. It sits below the ORFS instance because `orfs_platforms_test` reads the first call.

Each fixture gets a `build_test` on its `_synth` target and a netlist check that `adder`, `counter` and the top survive as modules. Three-module design, seconds of yosys; the load-time note from `orfs_design.bzl` fires for `hier_discovery`, which is the point.

**Real design.** `//test:orfs_riscv32i_synth_build_test`, next to mock-alu: 24 modules, one kept at its threshold. It is the design that caught both the top-in-kept-list bug (#911) and the ignored threshold (#913).

**Depends on #913** (stacked on its branch): without the threshold the riscv32i build test fails on the `input signed` ports of the kept `shifter`.

Verified: the four DSL tests, the riscv32i build test, `orfs_platforms_test`, and the 52 small/medium unit tests under `//test` and `//` pass; `//flow/...` loads (67 targets). TESTING.md's coverage table gains the rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
