### PR TITLE
fix(orfs): patch src/mempool_group/rtl to files() so its sources export individually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,17 +119,10 @@ jobs:
       # grt -- with --nobuild. Filtering to _route keeps out the bespoke
       # ORFS targets (gcd_single_flow_*) that reference @openroad, which
       # is why the step above is a query. ~1 minute for every platform.
-      #
-      # nangate45/mempool_group is excluded: its shipped
-      # src/mempool_group/rtl/BUILD is a bespoke filegroup with no
-      # exports_files, so the per-file labels config_mk_parser emits for
-      # it fail visibility. Pre-existing and unrelated to the generator;
-      # drop the exclusion when that BUILD is fixed.
       - name: Analyse @orfs design flow targets
         run: >
           bazelisk build --nobuild --keep_going
-          $(bazelisk query 'filter("_route$", kind(rule, @orfs//flow/designs/...))
-          except @orfs//flow/designs/nangate45/mempool_group:all')
+          $(bazelisk query 'filter("_route$", kind(rule, @orfs//flow/designs/...))')
 
       # --- Unit tests ---
       - name: Run tests

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -56,6 +56,11 @@ ORFS_PATCHES = [
     # RUN_CMD, so an override reaches every logged target except the
     # stage logs. --@bazel-orfs//:log_timestamps overrides RUN_CMD.
     Label("//patches:0048-orfs-flow-sh-honor-run-cmd.patch"),
+    # src/mempool_group/rtl's shipped BUILD is a bare filegroup, so the
+    # per-file labels config_mk_parser emits for nangate45/mempool_group
+    # are not visible. Not upstreamed yet -- carried here until it has
+    # proven itself; retire at the bump onto an ORFS that carries it.
+    Label("//patches:0049-orfs-mempool-rtl-files-include.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/patches/0049-orfs-mempool-rtl-files-include.patch
+++ b/patches/0049-orfs-mempool-rtl-files-include.patch
@@ -1,0 +1,42 @@
+Use files() for src/mempool_group/rtl so its sources export individually.
+
+nangate45/mempool_group's VERILOG_FILES names the files under
+src/mempool_group/rtl one by one. config_mk_parser turns each into a
+per-file label, and ORFS's bare filegroup over a glob makes those files
+private to the package, so the design fails analysis with a visibility
+error on every one of them. files("include", extra_srcs = ...) is the
+same filegroup -- same glob, same five sibling-package headers -- plus
+the per-file exports.
+
+Not upstreamed. Carried here until the fix has proven itself and the
+maintainer decides the timing is right for an ORFS pull request; retire
+the patch at the first //:bump onto an ORFS that carries the change, and
+re-record orfs_design_builds.bzl then.
+
+diff --git a/flow/designs/src/mempool_group/rtl/BUILD b/flow/designs/src/mempool_group/rtl/BUILD
+index c9161cd38..d43f51f4c 100644
+--- a/flow/designs/src/mempool_group/rtl/BUILD
++++ b/flow/designs/src/mempool_group/rtl/BUILD
+@@ -1,11 +1,18 @@
+-filegroup(
+-    name = "include",
+-    srcs = glob(["*.v", "*.sv", "*.svh"], allow_empty = True) + [
++load("//flow/designs:design.bzl", "files")
++
++# files() rather than a bare filegroup: the globbed sources are then also
++# exported as individual labels, which the config.mk parser in bazel-orfs
++# needs -- nangate45/mempool_group's VERILOG_FILES names files in this
++# directory one by one, and a bare filegroup makes them private to it.
++# The extra sources are the headers from sibling packages that the
++# include group has always carried.
++files(
++    "include",
++    extra_srcs = [
+         "//flow/designs/src/mempool_group/rtl/axi:assign.svh",
+         "//flow/designs/src/mempool_group/rtl/axi:typedef.svh",
+         "//flow/designs/src/mempool_group/rtl/common_cells:assertions.svh",
+         "//flow/designs/src/mempool_group/rtl/common_cells:registers.svh",
+         "//flow/designs/src/mempool_group/rtl/mempool:mempool.svh",
+     ],
+-    visibility = ["//visibility:public"],
+ )


### PR DESCRIPTION
`nangate45/mempool_group` fails analysis: its `VERILOG_FILES` names the files under `src/mempool_group/rtl` one by one, `config_mk_parser` turns each into a per-file label, and ORFS's shipped BUILD there is a bare `filegroup` over a glob, which makes those files private to the package. Every other `src/` package uses `files()`, which also exports each source as its own label. #912 excluded the design from the CI analysis step for this reason.

**Change.** Carry `patches/0049-orfs-mempool-rtl-files-include.patch`: the BUILD becomes `files("include", extra_srcs = ...)`, the same glob plus the same five sibling-package headers, plus the per-file exports. No change to what the `include` group contains. The CI exclusion goes.

**Not upstreamed.** The patch header says so: it is carried here until the fix has proven itself and the maintainer decides the timing is right for an ORFS pull request. Retire it at the first `//:bump` onto an ORFS that carries the change, and re-record `orfs_design_builds.bzl` then.

**Verified.** The CI analysis command over every platform, with no exclusion, exits 0 with all 61 `_route` targets analysed; `orfs_recorded_builds_test`, `orfs_design_builds_test` and `orfs_platforms_test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
