### PR TITLE
fix(design): stop printing the discovery-mode note at every package load

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -92,6 +92,34 @@ diff --git a/test/BUILD b/test/BUILD
      },
 ```
 
+### Hierarchical synthesis: discovered or pinned kept modules
+
+`SYNTH_HIERARCHICAL=1` synthesizes the kept modules in parallel, one
+yosys process per partition. Which modules are kept is decided one of two
+ways:
+
+- **Discovered** (no `SYNTH_KEEP_MODULES`): `synth_keep.tcl` runs ORFS's
+  keep decision, `keep_hierarchy -min_cost $SYNTH_MINIMUM_KEEP_SIZE`, at
+  build time, and a static 32 partitions divide the result. This is what
+  most hierarchical ORFS designs do, and it needs nothing from you.
+- **Pinned** (`SYNTH_KEEP_MODULES = a b c`): one partition and one
+  re-canonicalized RTLIL slice per named module. An RTL edit then re-runs
+  only the partitions whose module changed; in discovery mode every
+  partition re-runs, because none can key on a per-module slice.
+
+So pinning is a caching optimisation for a design you iterate on, not a
+requirement. To capture the list ORFS would discover:
+
+```sh
+make DESIGN_CONFIG=<config.mk> SYNTH_KEEP_MODULES= clean_synth synth
+cat results/<platform>/<design>/base/kept_modules.json
+```
+
+and paste the names into `SYNTH_KEEP_MODULES` in the design's config.mk
+or `arguments`. `asap7/swerv_wrapper` in ORFS is the worked example. The
+list drifts with the RTL: a renamed or removed module fails synthesis
+with a clear message rather than silently flattening.
+
 ## Work with macros and abstracts
 
 ### Generate abstracts

--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -240,16 +240,16 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
     # is identical across machines and remote cache hits are possible.  Users
     # who prefer local parallelism over caching can pass NUM_CPUS explicitly.
     if arguments.get("SYNTH_HIERARCHICAL") == "1":
+        # No SYNTH_KEEP_MODULES is discovery mode: synth_keep.tcl finds the
+        # kept modules inside a build action and the partitions read the
+        # global keep checkpoint. It works; what a pinned list adds is a
+        # per-module cache barrier (rules.bzl declares one slice action per
+        # name, which needs the names at analysis time). That is a
+        # performance choice for the design's owner, documented in
+        # docs/customize.md, not something to print at every load of the
+        # package -- twenty ORFS designs are in this mode, and a
+        # load-time note for a working configuration is noise.
         kept = keep_modules(arguments)
-        if not kept:
-            # Discovery mode: synth_keep.tcl finds the kept modules inside
-            # a build action and the partitions read the global keep
-            # checkpoint. It works, but every partition re-runs on any RTL
-            # edit, because none of them can key on a per-module slice
-            # (rules.bzl declares those from the names, which do not exist
-            # at analysis time). Pinning the list is the cache fix, and
-            # the capture recipe is the same as ORFS's.
-            print("%s sets SYNTH_HIERARCHICAL=1 with no SYNTH_KEEP_MODULES: parallel synthesis discovers the kept modules at build time, so every partition re-synthesizes on any RTL edit. To make partitions cache per module, pin the list in the design's config.mk -- capture it with `make DESIGN_CONFIG=<config.mk> SYNTH_KEEP_MODULES= clean_synth synth` and read results/<platform>/<design>/base/kept_modules.json." % name)  # buildifier: disable=print
 
         if "SYNTH_NUM_PARTITIONS" not in arguments:
             # One partition per pinned module; a static 32 in discovery


### PR DESCRIPTION
Since #911, `SYNTH_HIERARCHICAL=1` without `SYNTH_KEEP_MODULES` is a working configuration: the kept modules are discovered at build time and the partitions read the global keep checkpoint. What a pinned list adds is a per-module cache barrier, a performance choice for the design's owner. Twenty ORFS designs are in discovery mode, so the `orfs_design.bzl` note fired twenty times on every load of `@orfs//flow/designs/...` for configurations that are fine.

**Change.** Drop the `print`. The discovered-versus-pinned choice and the capture recipe move to `docs/customize.md`, as a subsection next to the existing `SYNTH_HIERARCHICAL` example. The dropped-`VERILOG_FILES` warning stays: that one reports a possible loss.

Verified: loading `@orfs//flow/designs/asap7/riscv32i` prints nothing; `keep_modules_test` and `orfs_platforms_test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)