### PR TITLE
chore(module): drop the glpk pin and the unused python host repo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -223,8 +223,6 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 
-bazel_dep(name = "glpk", version = "5.0.bcr.5")
-
 # Hermetic C++ toolchain for building OpenROAD (and yosys, gnumake) from
 # source: the BCR "llvm" module (hermetic-llvm) — the same statically linked,
 # zero-sysroot LLVM that OpenROAD itself registers. No host compiler and no
@@ -252,7 +250,6 @@ python.toolchain(
     is_default = True,
     python_version = "3.13",
 )
-use_repo(python, "python_3_13_host")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -199,8 +199,8 @@ patch if it's redundant.
 
 ### Direct-dependency drift
 A master bump pulls newer transitive versions; `root requires X but got Y`
-warnings mean you should sync the direct-dep pins (e.g. `rules_cc`, `abc`,
-`glpk`) and any lockstep maps (yosys ↔ abc in `bump.py`).
+warnings mean you should sync the direct-dep pins (e.g. `rules_cc`, `abc`)
+and any lockstep maps (yosys ↔ abc in `bump.py`).
 
 ### `--lockfile_mode=off`
 This repo runs with `--lockfile_mode=off`, so there is no `MODULE.bazel.lock` to


### PR DESCRIPTION
Two dead declarations in `MODULE.bazel`, no behaviour change.

- **`bazel_dep(name = "glpk")`**: nothing in this repo references it. It only acted as a version floor, and coin-or-lemon (via openroad) already requests the same 5.0.bcr.5, so `bazelisk mod explain glpk` resolves identically before and after. The stale mention in `docs/debugging.md` is fixed.
- **`use_repo(python, "python_3_13_host")`**: referenced nowhere. `python.toolchain` itself stays, since the pip hubs pin `python_version = "3.13"`.

Verified: `bazelisk build --nobuild //pythonwrapper:python3 //:bump //:deps //fork:liborfsfork.so`.

First of a series that trims the non-dev dependency surface, one concern per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
