### PR TITLE
chore(module): make the @orfs_designs repo a dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -325,6 +325,10 @@ orfs_designs = use_repo_rule("//private:designs.bzl", "orfs_designs")
 orfs_designs(
     name = "orfs_designs",
     designs_dir = "@orfs//flow/designs:BUILD",
+    # Only bazel-orfs as root loads @orfs//flow/designs/...; ORFS and
+    # OpenROAD instantiate their own orfs_designs, so this one is dev-only
+    # and a downstream root never has to resolve it.
+    dev_dependency = True,
     # MODULE.bazel cannot load(), so this list is spelled out rather
     # than shared with ORFS_BAZEL_PLATFORMS in orfs_source.bzl, which
     # drives design BUILD generation. //test:orfs_platforms_test holds

--- a/docs/orfs-design-builds.md
+++ b/docs/orfs-design-builds.md
@@ -24,6 +24,15 @@ bazelisk run @orfs//flow/designs/asap7/gcd:gcd_final
 bazelisk test @orfs//flow/designs/asap7/gcd:gcd_test
 ```
 
+This works from a clone of bazel-orfs only. The `@orfs_designs` repository
+the generated BUILDs load from is declared `dev_dependency = True` in
+`MODULE.bazel`, so a downstream root that depends on bazel-orfs does not
+get it, and `@orfs//flow/designs/...` fails to load there with "no
+repository visible as `@orfs_designs`". ORFS and OpenROAD each declare
+their own `orfs_designs` for their own design trees, and a project that
+wants ORFS's designs from its own workspace does the same (see the
+`orfs_designs` call at the end of `MODULE.bazel`).
+
 Note the path: designs live under **`flow/designs/`**, not `designs/`.
 `@orfs//designs/asap7/gcd` fails with
 


### PR DESCRIPTION
Only bazel-orfs as root loads `@orfs//flow/designs/...` (the README quick start and the two CI design steps). ORFS and OpenROAD each instantiate their own `orfs_designs` for their own design trees, and nothing in the shipped rules references `@orfs//flow/designs`, so a downstream root never needs this repo. Mark it `dev_dependency = True` and document that in `docs/orfs-design-builds.md`.

Verified:
- From a scratch downstream root depending on bazel-orfs by `local_path_override`, an `orfs_flow` analyses to `_final` with `--nobuild` and no `orfs_designs` declared.
- The same root fails on `@orfs//flow/designs/asap7/gcd:all` with the documented `No repository visible as '@orfs_designs'`.
- From this root, `bazelisk query '@orfs//flow/designs/...:*'` (the CI load step) still enumerates every design target.

Part of the series trimming the non-dev dependency surface, one concern per PR. Independent of #918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
