### PR TITLE
chore(module): make rules_pycross and its extension dev dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -203,9 +203,12 @@ single_version_override(
     patches = ["//patches:rules_jvm_external_quiet.patch"],
 )
 
-bazel_dep(name = "rules_pycross", version = "0.8.3")
+# dev_dependency: configure_environments above is root-honored only, so
+# this pair does nothing for a downstream root, which must repeat it (as
+# ORFS does). sv-lang keeps pulling rules_pycross in transitively.
+bazel_dep(name = "rules_pycross", version = "0.8.3", dev_dependency = True)
 
-pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")
+pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross", dev_dependency = True)
 pycross.configure_environments(python_versions = ["3.13"])
 
 bazel_dep(name = "qt-bazel")


### PR DESCRIPTION
`pycross.configure_environments` is root-honored only, so this `bazel_dep` and extension usage do nothing for a downstream root, which has to repeat the pair itself (ORFS's own `MODULE.bazel` already marks exactly this pair dev). sv-lang keeps pulling `rules_pycross` in transitively for everyone, so nothing resolves differently downstream.

Verified from a scratch downstream root depending on bazel-orfs by `local_path_override`: `bazelisk mod explain rules_pycross` shows the same 0.8.3 via openroad and sv-lang, and an `orfs_flow` analyses to `_final` with `--nobuild`.

Part of the series trimming the non-dev dependency surface, one concern per PR. Independent of #918 and #919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
