### PR TITLE
chore(module): make the qt-bazel bazel_dep a dev dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -208,7 +208,11 @@ bazel_dep(name = "rules_pycross", version = "0.8.3")
 pycross = use_extension("@rules_pycross//pycross/extensions:pycross.bzl", "pycross")
 pycross.configure_environments(python_versions = ["3.13"])
 
-bazel_dep(name = "qt-bazel")
+# dev_dependency: this version-less bazel_dep only exists so the root-only
+# git_override below has something to apply to. Downstream, openroad's own
+# bazel_dep(qt-bazel) plus the consumer's root override carry it, as
+# README.md and docs/openroad.md already require.
+bazel_dep(name = "qt-bazel", dev_dependency = True)
 git_override(
     module_name = "qt-bazel",
     commit = "5587ebcaf61bab7abe8e69c4db6d068b35562245",


### PR DESCRIPTION
The version-less `bazel_dep(name = "qt-bazel")` exists only so the root-only `git_override` has something to apply to. Downstream, openroad's own `bazel_dep(qt-bazel)` plus the consumer's root override carry it, which `README.md`, `docs/tools.md` and `docs/openroad.md` already require. ORFS marks its copy dev the same way.

Verified:
- From a scratch downstream root with the documented override, `bazelisk mod explain qt-bazel` resolves it via openroad, and an `orfs_flow` analyses to `_final` with `--nobuild`.
- From this root, `//examples:mac_final` (whose runfiles carry `openroad_qt` for `gui_final`) still analyses.

Part of the series trimming the non-dev dependency surface, one concern per PR. Independent of #918, #919 and #920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
