### PR TITLE
docs: say what the config.mk DSL is for

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,24 @@ bazelisk query '@orfs//flow/designs/nangate45/aes:*' | grep '_final$'
 bazelisk run @orfs//flow/designs/nangate45/aes:aes_cipher_top_grt gui_grt
 ```
 
-Mileage varies. This is a testing facility, not a supported way to build
-every ORFS design: not all designs are hooked up, and an ORFS bump that
-upsets one is a fix here, not an incident. Nor is consuming `config.mk`
-as a domain-specific language the recommended way to describe your own
-project. For that, write idiomatic Bazel as in the next section.
+This is not how you describe your own project. The expectation is
+idiomatic Bazel: an `orfs_flow()` in your own BUILD file, as in the next
+section and in [examples/](examples/). Consuming `config.mk` as a
+domain-specific language is a facility for experiments inside bazel-orfs:
+try a theory across many real designs, carrying the OpenROAD, ORFS and
+bazel-orfs patches it needs in a single pull request, before anything is
+upstreamed. The canonical experiment is parameter tuning, such as racing
+and pinning floorplan parameters across every ORFS design with the
+auto-floorplan targets ([docs/auto_floorplan.md](docs/auto_floorplan.md)).
+The ORFS designs are the right test bed for that because the OpenROAD
+maintainers know every pebble on that beach: a shift in any of them is
+recognised for what it is.
 
-It exists here for one reason: a single pull request against bazel-orfs
-can exercise a change to bazel-orfs, ORFS, OpenROAD and Yosys at once,
-against real designs, before the pieces are upstreamed as individual PRs
-once the churn is over. See
-[docs/orfs-design-builds.md](docs/orfs-design-builds.md) for how the
-`config.mk` files are consumed.
+Mileage varies. It is a testing facility, not a supported way to build
+every ORFS design: not all designs are hooked up, and an ORFS bump that
+upsets one is a fix here, not an incident. See
+[docs/orfs-design-builds.md](docs/orfs-design-builds.md) for what the
+facility is for and how the `config.mk` files are consumed.
 
 ### Build the example flow
 
@@ -301,7 +307,7 @@ one by one and deleted here as they land.
 | Monitor a long-running build | [docs/performance.md](docs/performance.md#monitor-long-running-builds) |
 | Understand where CI time goes | [docs/performance.md](docs/performance.md#where-ci-time-goes) |
 | Query timing interactively | [docs/performance.md](docs/performance.md#query-timing-interactively) |
-| Build an ORFS design from `config.mk` | [docs/orfs-design-builds.md](docs/orfs-design-builds.md) |
+| Experiment across ORFS designs (the `config.mk` DSL) | [docs/orfs-design-builds.md](docs/orfs-design-builds.md) |
 | Debug or create a `make issue` archive | [docs/reference.md](docs/reference.md#create-a-make-issue-archive), [docs/debugging.md](docs/debugging.md) |
 | Diagnose a build failure on my host | [docs/debugging.md](docs/debugging.md#host-platform--older-distributions) |
 | Fast PPA estimate, gate a PR against merge-base | [docs/estimate.md](docs/estimate.md) |

--- a/docs/auto_floorplan.md
+++ b/docs/auto_floorplan.md
@@ -231,6 +231,10 @@ Without that argument the pin falls back to `BUILD_WORKSPACE_DIRECTORY`,
 which is right only when the design and the workspace are the same
 repository -- a design in this repo, or ORFS built as the root module.
 
+Running this campaign across ORFS's designs from a bazel-orfs checkout is
+the reason the `config.mk` DSL exists; see
+[docs/orfs-design-builds.md](orfs-design-builds.md#what-it-is-for).
+
 ## After pinning: rules-base.json comes from CI, not from here
 
 A pinned floorplan changes the design's QoR, so its `rules-base.json`

--- a/docs/orfs-design-builds.md
+++ b/docs/orfs-design-builds.md
@@ -13,6 +13,64 @@ nothing but which kind of files the directory holds:
 Their only reader is bazel, which ORFS does not itself use. bazel-orfs
 now generates them, so ORFS can stop carrying them.
 
+## What it is for
+
+The normal use case of bazel-orfs is idiomatic Bazel: a project writes
+`orfs_flow()` in its own BUILD file, next to its RTL and constraints, as
+[examples/BUILD](../examples/BUILD) does. That is the product. The
+`config.mk` DSL is the lab bench: it turns ORFS's own designs into Bazel
+targets so that an experiment can be run across all of them from this
+repository, with everything the experiment needs in a single pull
+request.
+
+One PR can carry an ORFS patch under `patches/`, an OpenROAD or Yosys
+patch on its `archive_override`, a change to bazel-orfs itself, and be
+judged against real designs by the CI steps that load and analyse every
+`@orfs//flow/designs` flow target. The pieces are upstreamed one by one
+when the churn is over, and the patches deleted here as they land. The
+[README](../README.md#carry-patches-while-upstream-decides) describes
+the patch-carrying side; this page describes the design side.
+
+The ORFS designs are the right test bed for two reasons. They are
+real: gcd through swerv_wrapper, six platforms, macros, hierarchy, the
+designs ORFS's own QoR dashboard tracks. And the OpenROAD maintainers
+know every pebble on that beach. A shift in `ibex` on asap7 or `aes` on
+nangate45 is recognised at a glance for what it is, noise, regression
+or improvement, in a way no private design can offer.
+
+The canonical experiment is parameter tuning. `CORE_UTILIZATION`,
+`CORE_MARGIN` and `PLACE_DENSITY` are human predictions standing where
+measurements should be; the auto-floorplan targets measure them
+instead. From this workspace, race candidate floorplans for as many
+designs as the machine warrants:
+
+```sh
+bazelisk build --keep_going \
+  @orfs//flow/designs/asap7/gcd:gcd_auto_floorplan_data \
+  @orfs//flow/designs/asap7/ibex:ibex_core_auto_floorplan_data
+```
+
+then write each winner into the design's `config.mk` in an ORFS checkout
+as ordinary variables, with the estimate JSON of that moment as the
+receipt:
+
+```sh
+bazelisk run @orfs//flow/designs/asap7/gcd:gcd_auto_floorplan_pin ~/ORFS
+```
+
+[docs/auto_floorplan.md](auto_floorplan.md) covers the race, the pin and
+the receipt; [docs/estimate.md](estimate.md#division-of-labor-recommendations-here-mechanics-in-orfs)
+the division of labour with ORFS's pin machinery. The same shape fits
+any theory that has to hold across designs rather than on one: a
+synthesis engine A/B (the `_syn_*` and `_yosys_*` variants the DSL
+emits), a repair_timing change, a new default for a flow variable.
+
+What it is not: a supported way to build every ORFS design, a DSL for
+describing your own project, or available downstream. Not all designs
+are hooked up, an ORFS bump that upsets one is a fix here rather than
+an incident, and the `@orfs_designs` repository only exists with
+bazel-orfs as the root module (see the next section).
+
 ## Driving an ORFS design from bazel-orfs
 
 The whole point of owning this knowledge here: an ORFS design can be built


### PR DESCRIPTION
The README already said the `config.mk` DSL is a testing facility and not how to describe your own project, but not what it enables. This states the expectation in one place: **idiomatic Bazel is the product, the `config.mk` DSL is the lab bench.** It lets an experiment run across ORFS's real designs from this repository, with the OpenROAD, ORFS and bazel-orfs patches it needs carried in a single PR before anything is upstreamed.

It names the canonical experiment, parameter tuning: racing and pinning floorplan parameters across every ORFS design with the auto-floorplan targets, with the commands as run from this workspace. And it says why the ORFS designs are the right test bed: they are real, and the OpenROAD maintainers know every pebble on that beach, so a shift in any of them is recognised at a glance for what it is.

- **README** quick start: the two paragraphs after the design commands rewritten; the find-your-way row renamed to "Experiment across ORFS designs".
- **docs/orfs-design-builds.md**: new opening section "What it is for", including what it is not (not a supported way to build every ORFS design, not a DSL for your own project, root-only).
- **docs/auto_floorplan.md**: one sentence in "Pinning a design in another repository" linking the cross-design pin campaign back to that section.

Verified the quoted target names against `bazelisk query` on `@orfs//flow/designs/asap7/{gcd,ibex}` and that every link anchor exists. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
