### PR TITLE
Infrastructure for A/B-testing an OpenROAD PR's QoR effect

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ bazel_dep(name = "sv-elab", version = "2026-07-07")
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-OMm/0RskoU/QGyWOnkkPjbZziplDJDAHLwF575P0AgY=",
+    integrity = "sha256-yFYlQ1zckLkO3aarUqj18Fia3au5AJgbWJvELQ4prbI=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -63,8 +63,8 @@ archive_override(
         "find . -name BUILD -exec sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|g' {} +",
         "sed -i 's|defines = \\[|copts = [\"-include\", \"fmt/format.h\"],\\n    defines = [|' src/syn/src/elab/BUILD third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-39a75ec608d107a62b6d44fb8fb7c52a67071a9a",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/39a75ec608d107a62b6d44fb8fb7c52a67071a9a.tar.gz"],
+    strip_prefix = "OpenROAD-63fe72c577ef12d2ac2a0a944bbd842f9af8a0a7",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/63fe72c577ef12d2ac2a0a944bbd842f9af8a0a7.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.
@@ -290,8 +290,8 @@ orfs = use_extension("//:extension.bzl", "orfs_repositories")
 # `patches` on an override is honoured only from the root module and
 # would therefore land on whoever is root. Rewritten by //:bump.
 orfs.source(
-    commit = "8c0616910615e843780ba527526f2b83a564ba70",
-    integrity = "sha256-AbmwPa1L9X9hC0WF/eJuyi17uuViGNIxyDbb88/QJlI=",
+    commit = "68cc9bc974502b4786a68e9f51a092e0fcb56e82",
+    integrity = "sha256-WDyGyXbImaYvODGP4kePVDPpxz2UVi2ZpAMQAjFv8Rc=",
 )
 orfs.default(
     # Expose the slang yosys plugin (from BCR sv-elab) via

--- a/bump_reference_date.txt
+++ b/bump_reference_date.txt
@@ -1,4 +1,4 @@
 # Commit date of the ORFS pin in MODULE.bazel, written by //:bump.
 # The anchor //:bump_compat_test measures COMPAT markers against, so
 # that the cleanup policy runs on commit dates and not on the clock.
-2026-09-02
+2026-09-05

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -61,6 +61,18 @@ ORFS_PATCHES = [
     # are not visible. Not upstreamed yet -- carried here until it has
     # proven itself; retire at the bump onto an ORFS that carries it.
     Label("//patches:0049-orfs-mempool-rtl-files-include.patch"),
+    # global_route.tcl runs routing and the incremental repair phase in one
+    # straight line, so a repair study re-routes once per configuration.
+    # The patch factors the repair phase into a proc a hook can call, which
+    # is what //study forks on. Not upstreamed yet -- retire at the //:bump
+    # onto an ORFS that carries the hook.
+    Label("//patches:0050-orfs-forkable-grt-incremental-repair.patch"),
+    # asap7/aes with the full RVT/LVT/SLVT ladder and otherwise identical
+    # to asap7/aes, so a QoR delta between them isolates the VT ladder.
+    # A VT variant cannot be a run-time override: .odb fixes the master
+    # set at floorplan time. Not upstreamed -- retire at the //:bump onto
+    # an ORFS that carries the design.
+    Label("//patches:0051-orfs-asap7-aes-multivt-design.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/patches/0050-orfs-forkable-grt-incremental-repair.patch
+++ b/patches/0050-orfs-forkable-grt-incremental-repair.patch
@@ -1,0 +1,76 @@
+Make the global-route incremental-repair phase forkable.
+
+global_route.tcl runs pin_access, global_route and then an incremental
+repair-design/repair-timing phase in one straight line. A QoR study of a
+repair change therefore re-runs pin_access and global_route -- the
+majority of the stage's runtime -- once per configuration, even though
+routing is identical across all of them. On asap7/riscv32i that is ~113s
+of re-routing per configuration to reach a ~183s repair.
+
+Factor the incremental-repair phase into grt_incremental_repair and let
+GRT_REPAIR_HOOK_TCL stand in for the call, so one routed design can feed
+many repair configurations: the hook branches (fork, loop) and calls the
+proc itself.
+
+The phase's two bare `return`s meant "abandon the rest of
+global_route_helper" and, moved inside a proc, would only have abandoned
+the proc.  They become `return 0`, the phase returns 1 on success, and
+the caller propagates -- so the no-hook path behaves exactly as before.
+
+Not upstreamed. Carried here until the hook has proven itself and the
+maintainer decides the timing is right for an ORFS pull request; retire
+the patch at the first //:bump onto an ORFS that carries the change.
+
+diff --git a/flow/scripts/global_route.tcl b/flow/scripts/global_route.tcl
+--- a/flow/scripts/global_route.tcl
++++ b/flow/scripts/global_route.tcl
+@@ -71,7 +71,14 @@
+     set_dont_use $::env(DONT_USE_CELLS)
+   }
+ 
+-  if { !$::env(SKIP_INCREMENTAL_REPAIR) } {
++  # The incremental-repair phase is a proc, and a hook may stand in for
++  # the call, so that one routed design can feed many repair
++  # configurations. A QoR study of a repair change otherwise re-runs
++  # pin_access and global_route -- the majority of the stage -- once per
++  # configuration, even though routing is identical across them. The hook
++  # is expected to branch (fork, loop) and call grt_incremental_repair
++  # itself.
++  proc grt_incremental_repair { res_aware } {
+     if { $::env(DETAILED_METRICS) } {
+       report_metrics 5 "global route pre repair design"
+     }
+@@ -91,7 +98,7 @@
+       ![run_global_route_and_catch_failures -end_incremental {*}$res_aware \
+         -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_design.rpt]
+     } {
+-      return
++      return 0
+     }
+ 
+     # Repair timing using global route parasitics
+@@ -112,7 +119,7 @@
+       ![run_global_route_and_catch_failures -end_incremental {*}$res_aware \
+         -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt]
+     } {
+-      return
++      return 0
+     }
+ 
+     log_cmd estimate_parasitics -global_routing
+@@ -132,6 +139,15 @@
+         report_metrics 5 "global route post repair timing_opt_wns"
+       }
+     }
++    return 1
++  }
++
++  if { !$::env(SKIP_INCREMENTAL_REPAIR) } {
++    if { [env_var_exists_and_non_empty GRT_REPAIR_HOOK_TCL] } {
++      source $::env(GRT_REPAIR_HOOK_TCL)
++    } elseif { ![grt_incremental_repair $res_aware] } {
++      return
++    }
+   }
+ 
+   if { !$::env(OPT_POST_GRT_WNS) } {

--- a/patches/0051-orfs-asap7-aes-multivt-design.patch
+++ b/patches/0051-orfs-asap7-aes-multivt-design.patch
@@ -1,0 +1,100 @@
+Add asap7/aes_multivt: aes with the full RVT/LVT/SLVT ladder.
+
+ASAP7_USE_VT selects which VT liberties AND LEFs the flow reads, and it is
+declared for "All stages", so it cannot be applied to an already-placed
+design: load_design on a .odb calls read_db, not read_lef, and the master
+set was frozen at floorplan time. Setting it at run time over a pre-built
+ODB reads 15 liberty files and adds zero db masters -- measured as RVT
+202 cells/212 masters, LVT 202/0, SLVT 202/0 -- so the resizer cannot
+instantiate any of them, hasVtSwapCells() stays false, and the run
+completes with bit-identical results and no diagnostic of any kind.
+
+A VT variant is therefore a whole flow from synthesis onward, which in
+ORFS is spelled as a sibling design directory -- the same thing aes_lvt
+already does, and this follows aes_lvt's lead in the part that matters
+most.
+
+aes_lvt retimes the clock from aes's 380ps to 360ps. That is not
+incidental: ORFS designs sit a percent or two PAST closure (asap7/aes
+-4.78ps on 380ps, -1.3%; asap7/riscv32i -18.9ps on 950ps, -2.0%), which
+is what makes them useful QoR test cases -- there is work for
+optimization to do, but the design is not hopeless. A faster library at
+an unchanged period destroys that calibration: keeping 380ps with the
+full RVT/LVT/SLVT ladder closes the design outright (+0.09ps WNS, 0.0
+TNS) and a repair-stage experiment on it measures nothing at all,
+because there is no negative slack to repair.
+
+So the period here is retuned for the faster ladder, exactly as aes_lvt
+does for LVT.
+
+Used to measure how much a repair move that trades drive strength is
+worth when vt_swap is available to spend instead.
+
+Not upstreamed. Carried here until it has proven itself and the
+maintainer decides the timing is right for an ORFS pull request; retire
+the patch at the first //:bump onto an ORFS that carries the design.
+
+diff --git a/flow/designs/asap7/aes_multivt/config.mk b/flow/designs/asap7/aes_multivt/config.mk
+new file mode 100644
+--- /dev/null
++++ b/flow/designs/asap7/aes_multivt/config.mk
+@@ -0,0 +1,29 @@
++export PLATFORM               = asap7
++
++export DESIGN_NAME            = aes_cipher_top
++export DESIGN_NICKNAME        = aes_multivt
++
++# Same RTL as asap7/aes, with the clock retuned for the faster ladder --
++# the same thing aes_lvt does for LVT (360ps vs aes's 380ps).
++#
++# ORFS designs sit a percent or two PAST closure, which is what makes them
++# useful QoR test cases: there is work for optimization to do, but the
++# design is not hopeless. Keeping aes's 380ps with the full RVT/LVT/SLVT
++# ladder closes the design outright (+0.09ps WNS, 0.0 TNS) and any
++# repair-stage measurement on it is vacuous. Measured bracket:
++#
++#   304ps  +0.02ps WNS  (+0.01% of period)  -- closes
++#   285ps -10.35ps WNS  (-3.63% of period)  -- chosen
++#   266ps -28.37ps WNS (-10.67% of period)  -- too far gone
++export VERILOG_FILES = $(sort $(wildcard $(DESIGN_HOME)/src/aes/*.v))
++export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
++
++export ASAP7_USE_VT             = RVT LVT SLVT
++
++export CORE_UTILIZATION         = 70
++export CORE_ASPECT_RATIO        = 1
++export CORE_MARGIN              = 2
++export PLACE_DENSITY            = 0.65
++export TNS_END_PERCENT          = 100
++
++export SYNTH_USE_SYN = 1
+diff --git a/flow/designs/asap7/aes_multivt/constraint.sdc b/flow/designs/asap7/aes_multivt/constraint.sdc
+new file mode 100644
+--- /dev/null
++++ b/flow/designs/asap7/aes_multivt/constraint.sdc
+@@ -0,0 +1,17 @@
++set clk_name clk
++set clk_port_name clk
++set clk_period 285
++set clk_io_pct 0.2
++
++set clk_port [get_ports $clk_port_name]
++
++create_clock -name $clk_name -period $clk_period $clk_port
++set clk_io_name vclk_$clk_name
++create_clock -name $clk_io_name -period $clk_period
++set_clock_latency 77.930 [get_clocks $clk_name]
++set_clock_latency 77.930 [get_clocks $clk_io_name]
++
++set non_clock_inputs [all_inputs -no_clocks]
++
++set_input_delay [expr $clk_period * $clk_io_pct] -clock $clk_io_name $non_clock_inputs
++set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_io_name [all_outputs]
+diff --git a/flow/designs/asap7/aes_multivt/BUILD b/flow/designs/asap7/aes_multivt/BUILD
+new file mode 100644
+--- /dev/null
++++ b/flow/designs/asap7/aes_multivt/BUILD
+@@ -0,0 +1,3 @@
++load("//flow/designs:design.bzl", "design")
++
++design(config = "config.mk")

--- a/private/designs.bzl
+++ b/private/designs.bzl
@@ -63,6 +63,15 @@ def _orfs_designs_impl(repository_ctx):
     for config_file in config_files:
         repository_ctx.read(config_file)
 
+    # Reading the config.mk files found on THIS fetch watches only the files
+    # that already exist. A design added later -- by an ORFS patch, say --
+    # is in no watch set, so Bazel never re-fetches, DESIGNS never gains the
+    # key, and orfs_design() silently returns without declaring a single
+    # target: the design's package parses, its filegroups appear, and the
+    # flow targets simply do not exist. watch_tree covers creations and
+    # deletions as well as edits.
+    repository_ctx.watch_tree(designs_path.dirname)
+
     platforms_arg = ",".join(repository_ctx.attr.platforms)
     result = repository_ctx.execute(
         [python, str(parser_path), "--all", designs_dir, "--platforms", platforms_arg, "--json"],

--- a/study/BUILD
+++ b/study/BUILD
@@ -1,0 +1,76 @@
+"""A/B study of OpenROAD PR 11320 as a fork/join walk over a placed design.
+
+One orfs_run_executable per design. The arm -- which openroad binary runs
+the walk -- is chosen at invocation time, not baked into the target:
+
+    bazel run //study:riscv32i_walk -- \
+        OPENROAD_EXE=/abs/path/to/openroad \
+        STUDY_ARM=base \
+        RESULTS_OUT=/abs/path/to/out
+
+That is deliberate. Baking the binary in would put an absolute local path
+into a public repository and make the target unbuildable for anyone else;
+make's last-wins argument handling gives the same BYO override with a
+committed file that names no path at all.
+
+KEEP_VARS=1 is not optional: the walk sets per-leaf variables that
+erase_non_stage_variables would otherwise strip before cts and grt read
+them.
+"""
+
+load("//:openroad.bzl", "orfs_run_executable")
+
+STUDY_STAGES = [
+    "synth",
+    "floorplan",
+    "place",
+    "cts",
+    "grt",
+]
+
+# Designs are keyed by the platform/design pair they come from, because
+# the platform is a variable of the study (asap7 has a multi-Vt ladder
+# and a different cell-size ladder from sky130hd) rather than a detail.
+DESIGNS = {
+    "asap7_riscv32i": "@orfs//flow/designs/asap7/riscv32i:riscv_top_place",
+    "asap7_aes": "@orfs//flow/designs/asap7/aes:aes_cipher_top_place",
+    "asap7_ibex": "@orfs//flow/designs/asap7/ibex:ibex_core_place",
+    "asap7_jpeg": "@orfs//flow/designs/asap7/jpeg:jpeg_encoder_place",
+    "asap7_ethmac": "@orfs//flow/designs/asap7/ethmac:ethmac_place",
+    "sky130hd_aes": "@orfs//flow/designs/sky130hd/aes:aes_cipher_top_place",
+    "sky130hd_ibex": "@orfs//flow/designs/sky130hd/ibex:ibex_core_place",
+    "sky130hd_jpeg": "@orfs//flow/designs/sky130hd/jpeg:jpeg_encoder_place",
+    "asap7_aes_multivt": "@orfs//flow/designs/asap7/aes_multivt:aes_cipher_top_place",
+}
+
+[
+    orfs_run_executable(
+        name = design + "_walk",
+        src = src,
+        arguments = {"KEEP_VARS": "1"},
+        script = ":size_down_fanout.tcl",
+        stages = STUDY_STAGES,
+        tags = ["manual"],
+    )
+    for design, src in DESIGNS.items()
+]
+
+# Design-suitability probe: measures the two properties PR 11320 needs to
+# have anything to act on (high-fanout nets, and downsize headroom among
+# their loads), so designs are chosen by measurement rather than intuition.
+[
+    orfs_run_executable(
+        name = design + "_probe",
+        src = src,
+        arguments = {"KEEP_VARS": "1"},
+        script = ":probe_headroom.tcl",
+        stages = STUDY_STAGES,
+        tags = ["manual"],
+    )
+    for design, src in DESIGNS.items()
+]
+
+exports_files([
+    "probe_headroom.tcl",
+    "size_down_fanout.tcl",
+])

--- a/study/collect.py
+++ b/study/collect.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Collapse a walk's leaf JSON files into one CSV.
+
+Deliberately path-free output. The leaves are written into scratch
+directories whose absolute paths name a local user and machine, and this
+repository is public: a collector that copied source paths into a column
+would publish them the moment the CSV was committed. Only measured
+values cross into the CSV.
+"""
+
+import argparse
+import csv
+import json
+import pathlib
+import sys
+
+# Written by the walk; anything else in a leaf is ignored rather than
+# silently widening the published surface.
+FIELDS = [
+    "design",
+    "arm",
+    "period_scale",
+    "clock_period",
+    "time_unit",
+    "sequence",
+    "setup_margin",
+    "wns",
+    "tns",
+    "hold_wns",
+    "inst_count",
+    "buffer_count",
+    "design_area",
+    "elapsed_s",
+]
+
+
+def read_leaves(roots):
+    rows = []
+    for root in roots:
+        for path in sorted(pathlib.Path(root).rglob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+            except json.JSONDecodeError as exc:
+                # A crashed leaf can leave a truncated file. Report it and
+                # keep going: losing one leaf must not lose the walk.
+                print(f"skipping unreadable leaf {path.name}: {exc}", file=sys.stderr)
+                continue
+            missing = [f for f in FIELDS if f not in data]
+            if missing:
+                print(
+                    f"skipping incomplete leaf {path.name}: missing {missing}",
+                    file=sys.stderr,
+                )
+                continue
+            rows.append({f: data[f] for f in FIELDS})
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("roots", nargs="+", help="Directories of leaf JSON files")
+    parser.add_argument("-o", "--out", required=True, help="CSV to write")
+    args = parser.parse_args()
+
+    rows = read_leaves(args.roots)
+    if not rows:
+        sys.exit("no leaves found")
+
+    rows.sort(key=lambda r: (r["design"], r["period_scale"], r["sequence"], r["arm"]))
+    with open(args.out, "w", newline="") as fd:
+        writer = csv.DictWriter(fd, fieldnames=FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"wrote {len(rows)} leaves to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/study/plot.py
+++ b/study/plot.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Plot the A/B result from a collected CSV.
+
+Two figures, because the run answers two different questions:
+
+  * inertness -- does the PR change the DEFAULT flow at all? Plotted as
+    the per-sequence delta, where the "stock" bar being exactly zero is
+    the result rather than an axis label.
+  * pressure  -- does the effect grow as slack gets scarce? Plotted as
+    delta versus clock scale.
+
+Paths never enter the figures. The leaves are produced in scratch
+directories that name a local user and machine, and this repository is
+public.
+"""
+
+import argparse
+import csv
+from collections import defaultdict
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+SEQUENCES = ["stock", "before", "after", "only"]
+
+# Colour-blind-safe, and consistent across both figures.
+ARM_COLOR = {"base": "#4C72B0", "pr": "#DD8452"}
+
+
+def slug(design):
+    """Design labels reached the CSV in two spellings (asap7/riscv32i and
+    asap7_aes) because STUDY_DESIGN is free text. Normalise for filenames;
+    a "/" silently became a directory that did not exist."""
+    return design.replace("/", "_")
+
+
+def load(path):
+    rows = list(csv.DictReader(open(path)))
+    by = {}
+    for r in rows:
+        by[(r["design"], r["period_scale"], r["sequence"], r["arm"])] = r
+    return rows, by
+
+
+def deltas(by, design, scale):
+    """PR minus base, per sequence, for one design and clock scale."""
+    out = {}
+    for seq in SEQUENCES:
+        b = by.get((design, scale, seq, "base"))
+        p = by.get((design, scale, seq, "pr"))
+        if not (b and p):
+            continue
+        out[seq] = {
+            "wns": float(p["wns"]) - float(b["wns"]),
+            "tns": float(p["tns"]) - float(b["tns"]),
+            "insts": int(p["inst_count"]) - int(b["inst_count"]),
+            "area": (float(p["design_area"]) - float(b["design_area"])) * 1e12,
+        }
+    return out
+
+
+def fig_sequences(by, design, scale, out):
+    d = deltas(by, design, scale)
+    if not d:
+        return False
+    seqs = [s for s in SEQUENCES if s in d]
+    fig, axes = plt.subplots(1, 3, figsize=(11, 3.4))
+    for ax, key, label in zip(
+        axes,
+        ["wns", "tns", "area"],
+        ["Δ WNS (ps)", "Δ TNS (ps)", "Δ area (µm²)"],
+    ):
+        vals = [d[s][key] for s in seqs]
+        colors = ["#999999" if s == "stock" else "#DD8452" for s in seqs]
+        ax.bar(seqs, vals, color=colors)
+        ax.axhline(0, color="black", linewidth=0.8)
+        ax.set_title(label, fontsize=10)
+        ax.tick_params(labelsize=8)
+    fig.suptitle(
+        f"{design} @ clock scale {scale} — PR 11320 minus origin/master\n"
+        "positive Δ WNS/TNS is better; negative Δ area is better; "
+        "'stock' is the default sequence",
+        fontsize=9,
+    )
+    fig.tight_layout()
+    fig.savefig(out, dpi=140)
+    plt.close(fig)
+    return True
+
+
+def fig_pressure(by, design, out):
+    scales = sorted({k[1] for k in by if k[0] == design}, key=float)
+    series = defaultdict(list)
+    for scale in scales:
+        d = deltas(by, design, scale)
+        for seq in SEQUENCES:
+            series[seq].append(d.get(seq, {}).get("wns"))
+    fig, ax = plt.subplots(figsize=(6, 3.6))
+    for seq in SEQUENCES:
+        ys = series[seq]
+        if all(y is None for y in ys):
+            continue
+        ax.plot(scales, ys, marker="o", label=seq)
+    ax.axhline(0, color="black", linewidth=0.8)
+    ax.set_xlabel("clock scale (smaller = tighter)")
+    ax.set_ylabel("Δ WNS (ps), PR minus master")
+    ax.set_title(f"{design}: does the effect grow with timing pressure?", fontsize=10)
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out, dpi=140)
+    plt.close(fig)
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("csv")
+    ap.add_argument("-d", "--outdir", required=True)
+    args = ap.parse_args()
+
+    _, by = load(args.csv)
+    designs = sorted({k[0] for k in by})
+    for design in designs:
+        scales = sorted({k[1] for k in by if k[0] == design}, key=float)
+        for scale in scales:
+            name = f"{args.outdir}/{slug(design)}_scale{scale}_sequences.png"
+            if fig_sequences(by, design, scale, name):
+                print(f"wrote {name}")
+        if len(scales) > 1:
+            name = f"{args.outdir}/{slug(design)}_pressure.png"
+            fig_pressure(by, design, name)
+            print(f"wrote {name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/study/probe_headroom.tcl
+++ b/study/probe_headroom.tcl
@@ -1,0 +1,150 @@
+# Is a design suitable for studying PR 11320?
+#
+# The PR does two things: it stops rejecting drivers with fanout >= 10,
+# and it steps one drive size down instead of jumping to the minimum-cap
+# cell. Both are inert on a design that has nothing to downsize. On
+# asap7/riscv32i the move was rejected 21304 times with "Couldn't size
+# down any gates" and committed 19 downsizes, and the arms came out
+# bit-identical.
+#
+# So suitability is not "big" or "slow", it is two measurable properties:
+#
+#   1. HIGH-FANOUT DRIVERS -- nets with fanout >= 10. Below that
+#      threshold the old code and the new code consider the same drivers
+#      and change (a) cannot bite.
+#   2. DOWNSIZE HEADROOM among the loads of those nets -- a load whose
+#      liberty cell has a smaller-area swappable sibling. Without it the
+#      move is rejected however it is reached, and change (b) cannot
+#      bite either.
+#
+# A design scores well only on BOTH. Reported per design so the choice of
+# designs is a measurement rather than an intuition.
+
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 3_place.odb 3_place.sdc
+
+set fanout_threshold 10
+if { [info exists ::env(PROBE_FANOUT_THRESHOLD)] } {
+  set fanout_threshold $::env(PROBE_FANOUT_THRESHOLD)
+}
+
+# cell name -> 1 if some swappable sibling has strictly smaller area.
+# report_equiv_cells is OpenROAD's own notion of swappability, so this
+# does not re-derive one from cell-name conventions.
+# Area comes from the db master (width * height), not the liberty cell:
+# the Tcl LibertyCell object exposes no area method. Physical area is the
+# quantity the move trades against anyway.
+proc master_area { name } {
+  set master [[ord::get_db] findMaster $name]
+  if { $master eq "NULL" || $master eq "" } {
+    return -1
+  }
+  return [expr { [$master getWidth] * [$master getHeight] }]
+}
+
+# cell name -> 1 if some swappable sibling has strictly smaller area.
+# report_equiv_cells is OpenROAD's own notion of swappability, so this
+# does not re-derive one from cell-name conventions.
+proc has_smaller_sibling { cell_name cache_var } {
+  upvar 1 $cache_var cache
+  if { [info exists cache($cell_name)] } {
+    return $cache($cell_name)
+  }
+  set cache($cell_name) 0
+  set cells [get_lib_cells -quiet $cell_name]
+  if { [llength $cells] == 0 } {
+    return 0
+  }
+  set self_area [master_area $cell_name]
+  if { $self_area < 0 } {
+    return 0
+  }
+  # [list ...]: tee evaluates its body as `{*}$body`, which splits a braced
+  # body into words WITHOUT substituting them, so an unbraced command would
+  # reach report_equiv_cells as the literal words "[lindex" "$cells" "0]".
+  # tee STORES the captured text in the named variable and RETURNS the
+  # wrapped command's own result -- reading the return value yields "".
+  tee -variable captured -quiet [list report_equiv_cells -all [lindex $cells 0]]
+  set out $captured
+  # report_equiv_cells prints a TABLE (header, separators, then one row per
+  # cell: name, area, area ratio, leakage, leakage ratio, VT), not bare
+  # names -- so take the row's first token. Treating whole lines as names
+  # silently matched nothing and reported 0% headroom on every design.
+  foreach line [split $out "\n"] {
+    set name [lindex [string trim $line] 0]
+    if { $name eq "" || $name eq $cell_name } {
+      continue
+    }
+    set sib_area [master_area $name]
+    if { $sib_area >= 0 && $sib_area < $self_area } {
+      set cache($cell_name) 1
+      return 1
+    }
+  }
+  return 0
+}
+
+set block [ord::get_db_block]
+array set cache {}
+
+set nets_total 0
+set nets_high 0
+set loads_high 0
+set loads_high_with_headroom 0
+set loads_all 0
+set loads_all_with_headroom 0
+
+foreach net [$block getNets] {
+  if { [$net isSpecial] } {
+    continue
+  }
+  set loads {}
+  foreach iterm [$net getITerms] {
+    if { [[$iterm getMTerm] getIoType] eq "INPUT" } {
+      lappend loads $iterm
+    }
+  }
+  set fanout [llength $loads]
+  if { $fanout == 0 } {
+    continue
+  }
+  incr nets_total
+  set high [expr { $fanout >= $fanout_threshold }]
+  if { $high } {
+    incr nets_high
+  }
+  foreach iterm $loads {
+    set cell_name [[[$iterm getInst] getMaster] getName]
+    set headroom [has_smaller_sibling $cell_name cache]
+    incr loads_all
+    incr loads_all_with_headroom $headroom
+    if { $high } {
+      incr loads_high
+      incr loads_high_with_headroom $headroom
+    }
+  }
+}
+
+proc pct { n d } {
+  if { $d == 0 } {
+    return 0.0
+  }
+  return [format %.1f [expr { 100.0 * $n / $d }]]
+}
+
+set report [list \
+  design $::env(STUDY_DESIGN) \
+  fanout_threshold $fanout_threshold \
+  nets $nets_total \
+  nets_high_fanout $nets_high \
+  pct_nets_high_fanout [pct $nets_high $nets_total] \
+  loads $loads_all \
+  pct_loads_with_headroom [pct $loads_all_with_headroom $loads_all] \
+  loads_on_high_fanout_nets $loads_high \
+  loads_on_high_fanout_nets_with_headroom $loads_high_with_headroom \
+  pct_high_fanout_loads_with_headroom [pct $loads_high_with_headroom $loads_high]]
+
+puts "PROBE: $report"
+set fd [open $::env(RESULTS_OUT)/probe.txt w]
+puts $fd $report
+close $fd

--- a/study/size_down_fanout.tcl
+++ b/study/size_down_fanout.tcl
@@ -1,0 +1,235 @@
+# A/B study of OpenROAD PR 11320 (rsz: size_down_fanout less conservative
+# and high-fanout aware), as a fork/join walk over the global-route
+# incremental-repair phase.
+#
+# Which binary runs the walk is chosen OUTSIDE this script (fork cannot
+# swap the executable mid-process), so an arm is one invocation with a
+# different OPENROAD_EXE. Everything below is identical across arms.
+#
+# WHERE THE FORK POINT IS, AND WHY
+#
+# The move under test is a repair_timing move, so the study varies repair
+# configurations. Measured on asap7/riscv32i, a leaf that ran cts+grt
+# whole cost 453s of which only the design load -- ~1% -- was shared;
+# fork.md is explicit that fork earns its keep through the shared prefix,
+# and at that fork point it did not.
+#
+# So the prefix is everything up to and including global_route (CTS, the
+# post-CTS repair, pin_access, routing: ~270s, run once) and the leaf is
+# the incremental repair phase (~183s). That needs ORFS to expose a seam
+# between routing and repair, which patches/0050 adds as
+# GRT_REPAIR_HOOK_TCL.
+#
+# CONSEQUENCE FOR THE DIMENSIONS: only knobs that act at the post-GR
+# repair belong inside the fork. The clock period must be set before CTS,
+# so it is an outer dimension -- one invocation per period -- not a
+# forked one. Setting it after routing would constrain a design that had
+# already been placed, routed and CTS'd against a different target.
+#
+# KEEP_VARS=1 is required: erase_non_stage_variables would otherwise strip
+# the per-leaf variables the leaves set.
+
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 3_place.odb 3_place.sdc
+
+source $::env(ORFS_FORK_TCL)
+
+set ::study_out $::env(RESULTS_OUT)
+set ::study_arm $::env(STUDY_ARM)
+set ::study_design $::env(STUDY_DESIGN)
+set ::period_scale $::env(STUDY_PERIOD_SCALE)
+file mkdir $::study_out
+
+# The move sequences under test. "stock" is the default sequence spelled
+# out explicitly -- SetupLegacyBase builds exactly this when -sequence is
+# absent -- so every leaf goes down the same code path and the arms differ
+# only in the moves named.
+set ::sequences [dict create \
+  stock  "unbuffer,vt_swap,sizeup,swap,buffer,clone,split" \
+  before "unbuffer,vt_swap,size_down,sizeup,swap,buffer,clone,split" \
+  after  "unbuffer,vt_swap,sizeup,size_down,swap,buffer,clone,split" \
+  only   "unbuffer,vt_swap,size_down,swap,buffer,clone,split"]
+
+proc study_dim { var default } {
+  if { [info exists ::env($var)] && $::env($var) ne "" } {
+    return [split $::env($var) ","]
+  }
+  return $default
+}
+
+set ::dim_sequence [study_dim STUDY_SEQUENCES {stock before after only}]
+set ::dim_margin [study_dim STUDY_MARGINS {0}]
+
+proc escape_json { str } {
+  return "\"[string map { \" \\\" \\ \\\\ \n \\n \r \\r \t \\t } $str]\""
+}
+
+proc json_dict { pairs } {
+  set items {}
+  foreach { k v } $pairs {
+    if { [string is double -strict $v] } {
+      lappend items "[escape_json $k]: $v"
+    } else {
+      lappend items "[escape_json $k]: [escape_json $v]"
+    }
+  }
+  return "\{[join $items ", "]\}"
+}
+
+# Retarget every clock by a scale factor, before CTS. A repair-pressure
+# knob on a fixed placement: synthesis and placement still reflect the
+# stock period, so this is not a flow-level period sweep and is not
+# reported as one.
+proc rescale_clocks { scale } {
+  foreach clk [sta::all_clocks] {
+    set name [get_name $clk]
+    # [$clk period] is in STA-internal units (seconds); create_clock
+    # -period expects the user unit. Passing the raw value through creates
+    # a ~zero-period clock: slack went to -954 on asap7/riscv32i and
+    # repair ground for 10+ minutes on a hopeless design, which reads as a
+    # slow leaf rather than a units bug. time_sta_ui is the conversion
+    # Sdc.tcl itself uses in the opposite direction.
+    set period [expr { [sta::time_sta_ui [$clk period]] * $scale }]
+    create_clock -name $name -period $period [$clk sources]
+    # Read back the clock just set: a silently-wrong constraint is
+    # indistinguishable from a slow run, so make it loud instead.
+    set back ""
+    foreach c [sta::all_clocks] {
+      if { [get_name $c] eq $name } {
+        set back [sta::time_sta_ui [$c period]]
+      }
+    }
+    if { $back eq "" || $back < 0.5 * $period || $back > 2.0 * $period } {
+      error "clock rescale did not take: asked $period, read back $back"
+    }
+    set ::leaf_period $period
+    puts "STUDY: clock $name period $period[sta::unit_scale_abbreviation time]s (scale $scale)"
+  }
+}
+
+proc leaf_metrics { sequence margin elapsed } {
+  set insts [[ord::get_db_block] getInsts]
+  set buffers 0
+  foreach inst $insts {
+    if { [string match -nocase "*BUF*" [[$inst getMaster] getName]] } {
+      incr buffers
+    }
+  }
+  return [list \
+    design $::study_design \
+    arm $::study_arm \
+    period_scale $::period_scale \
+    clock_period $::leaf_period \
+    time_unit "[sta::unit_scale_abbreviation time]s" \
+    sequence $sequence \
+    setup_margin $margin \
+    wns [sta::worst_slack -max] \
+    tns [sta::total_negative_slack] \
+    hold_wns [sta::worst_slack -min] \
+    inst_count [llength $insts] \
+    buffer_count $buffers \
+    design_area [rsz::design_area] \
+    elapsed_s $elapsed]
+}
+
+# cts.tcl and global_route.tcl write ODBs, SDCs and reports; without
+# per-leaf directories every leaf clobbers every other leaf's artifacts.
+# global_route_congestion_report is captured into a global when load.tcl
+# is sourced, so resetting REPORTS_DIR alone is not enough.
+proc isolate_leaf_io { tag } {
+  set dir $::study_out/$tag
+  file mkdir $dir/results $dir/reports $dir/logs
+  set ::env(RESULTS_DIR) $dir/results
+  set ::env(REPORTS_DIR) $dir/reports
+  set ::env(LOG_DIR) $dir/logs
+  set ::global_route_congestion_report $dir/reports/congestion.rpt
+}
+
+# Called from the one-line hook that patches/0050 sources in place of the
+# incremental-repair call, so it runs inside global_route_helper's scope
+# and $res_aware is the caller's.
+#
+# A single flat fork over the cross product rather than nested forks: the
+# fan-out is what keeps the machine busy, and one level keeps $res_aware
+# resolution simple.
+proc study_grt_fork { res_aware } {
+  set configs {}
+  foreach sequence $::dim_sequence {
+    foreach margin $::dim_margin {
+      lappend configs [list $sequence $margin]
+    }
+  }
+  puts "STUDY: [llength $configs] leaves: $configs"
+
+  set walk_start [clock seconds]
+  set statuses [fork -jobs default config $configs {
+    lassign $config sequence margin
+    set tag "s${sequence}_m${margin}"
+    isolate_leaf_io $tag
+
+    set ::env(SETUP_MOVE_SEQUENCE) [dict get $::sequences $sequence]
+    set ::env(SETUP_SLACK_MARGIN) $margin
+
+    # Opt-in per-move debug. The move's own debugPrint output is the only
+    # direct evidence of WHY two arms agree or differ -- accepted-move
+    # counts alone cannot distinguish "never considered" from "considered
+    # and chose the same cell".
+    if { [info exists ::env(STUDY_DEBUG_MOVE)] && $::env(STUDY_DEBUG_MOVE) ne "" } {
+      set_debug_level RSZ size_down_fanout_move $::env(STUDY_DEBUG_MOVE)
+    }
+
+    set leaf_start [clock seconds]
+    # Per-leaf log. Forked siblings share one stdout, so their output
+    # interleaves arbitrarily and per-leaf facts -- the move sequence
+    # actually built, the accepted-move counts -- cannot be attributed to
+    # the leaf that produced them. -quiet keeps stdout for the walk's own
+    # progress rather than N interleaved stage logs.
+    # `tee`, not `utl::tee`: the latter is ambiguous with the C++
+    # teeFileBegin/teeStringBegin helpers in the same namespace.
+    #
+    # The command is built with [list] so res_aware is substituted HERE,
+    # by value. tee evaluates its body as `{*}$body`, which splits a
+    # braced body into words WITHOUT substituting them -- passing
+    # `grt_incremental_repair $res_aware` in braces handed the proc the
+    # literal string "$res_aware", which reached
+    # `global_route -end_incremental` as a bogus argument, failed the
+    # route, and returned early. See the status check below for why that
+    # was nearly invisible.
+    set ok [tee -file $::study_out/$tag/logs/repair.log -quiet \
+      [list grt_incremental_repair $res_aware]]
+
+    # ORFS catches a failed global_route, writes artifacts and returns
+    # rather than raising. The phase then skips repair_timing entirely and
+    # the leaf still produces a complete, plausible-looking metrics
+    # record -- of a design the move under test never touched. A study
+    # leaf must assert that the thing it is measuring actually ran.
+    if { !$ok } {
+      error "grt incremental repair did not complete for $tag"
+    }
+    set elapsed [expr { [clock seconds] - $leaf_start }]
+
+    set fd [open $::study_out/$tag.json w]
+    puts $fd [json_dict [leaf_metrics $sequence $margin $elapsed]]
+    close $fd
+  }]
+  puts "STUDY: walk finished in [expr { [clock seconds] - $walk_start }]s"
+  puts "STUDY: statuses $statuses"
+}
+
+rescale_clocks $::period_scale
+
+# CTS and its repair are the shared prefix, so they run at stock settings:
+# SETUP_MOVE_SEQUENCE is deliberately left unset here, making the post-CTS
+# repair a controlled variable rather than a swept one.
+source $::env(SCRIPTS_DIR)/cts.tcl
+
+# The hook is generated rather than shipped: all the logic is above, so
+# the file ORFS sources is a one-line shim, and there is no extra data
+# dependency to plumb through the BUILD file.
+set hook $::study_out/grt_repair_hook.tcl
+set fd [open $hook w]
+puts $fd "study_grt_fork \$res_aware"
+close $fd
+set ::env(GRT_REPAIR_HOOK_TCL) $hook
+
+source $::env(SCRIPTS_DIR)/global_route.tcl


### PR DESCRIPTION
Four independent pieces, least-churn-first. They stand on their own merit
whether or not any particular OpenROAD PR is ever tested again.

- **bump** openroad to `63fe72c577`, orfs to `68cc9bc97450`, so the placement a
  repair-stage measurement starts from and the code under test come from one
  revision instead of the placement lagging 63 commits behind.
- **fix(designs)**: the designs repository rule watched only the `config.mk`
  files present on the last fetch, so a design added later — by an ORFS patch,
  say — never invalidated it. `orfs_design()` then returned early on the missing
  key and declared *no targets, silently*; the error surfaced far away as
  "target not declared". Now watches the tree.
- **two carried ORFS patches**: `0050` factors `global_route.tcl`'s incremental
  repair phase into a proc a hook can stand in for, so one routed design feeds
  many repair configurations instead of re-routing per configuration (the
  extracted block's bare `return`s had to become a propagated status, or a
  failed route would have fallen through). `0051` adds `asap7/aes_multivt`,
  `aes` with the RVT/LVT/SLVT ladder and the clock retuned 380ps → 285ps —
  the retune is the point, since a faster library at an unchanged period closes
  the design and leaves a repair-stage measurement with nothing to measure.
- **`//study`**: a fork/join A/B harness. The arm is chosen per invocation via
  `OPENROAD_EXE`, so no local path is baked into a committed file. Leaves run
  ORFS's own `cts.tcl`/`global_route.tcl` on the inherited in-memory design
  rather than an imitation of them.

The harness carries three assertions, each corresponding to a bug that produced
clean, plausible, wrong numbers rather than an error — a caught-and-swallowed
stage failure, a clock constraint in the wrong units, and incomplete leaves.