### PR TITLE
fix(designs): watch the designs tree so a new config.mk re-fetches

### DIFF
--- a/private/designs.bzl
+++ b/private/designs.bzl
@@ -63,6 +63,15 @@ def _orfs_designs_impl(repository_ctx):
     for config_file in config_files:
         repository_ctx.read(config_file)
 
+    # Reading the config.mk files found on THIS fetch watches only the files
+    # that already exist. A design added later -- by an ORFS patch, say --
+    # is in no watch set, so Bazel never re-fetches, DESIGNS never gains the
+    # key, and orfs_design() silently returns without declaring a single
+    # target: the design's package parses, its filegroups appear, and the
+    # flow targets simply do not exist. watch_tree covers creations and
+    # deletions as well as edits.
+    repository_ctx.watch_tree(designs_path.dirname)
+
     platforms_arg = ",".join(repository_ctx.attr.platforms)
     result = repository_ctx.execute(
         [python, str(parser_path), "--all", designs_dir, "--platforms", platforms_arg, "--json"],


### PR DESCRIPTION
The designs repository rule reads every `config.mk` it finds, which registers those files as watched inputs. That covers edits to designs that already exist and nothing else: a design added later — by an ORFS patch, say — is in no watch set, so Bazel never re-fetches and `DESIGNS` never gains the key.

The failure is silent. `orfs_design()` returns early on an unknown key (by design — block sub-packages take that path), so the new design's package parses, its filegroups appear, and its flow targets simply do not exist. The error surfaces far away as `target 'foo_place' not declared`.

`watch_tree` covers creations and deletions as well as edits.