### PR TITLE
chore(hooks): building with CMake is verboten — bazel is the only build path

### DIFF
--- a/.claude/hooks/guard_tool.py
+++ b/.claude/hooks/guard_tool.py
@@ -64,6 +64,15 @@ QUOTED_SPAN = re.compile(r"'[^']*'|\"[^\"]*\"", re.S)
 BAZEL = r"(?<![\w.-])(?:bazelisk|bazel-[0-9][\w.]*|bazel)(?![\w-])"
 BAZEL_CLEAN = re.compile(BAZEL + r"(?:\s+--?\S+)*\s+clean(?![\w-])")
 
+# CMake in command position: a bare `cmake`, a path to one, or OpenROAD's
+# etc/Build.sh wrapper, optionally behind env assignments or sudo/time.
+# Anchored at the start of a segment on purpose -- `grep cmake CMakeLists.txt`
+# reads a cmake file, it does not run one.
+CMAKE_BUILD = re.compile(
+    r"^(?:\w+=\S*\s+)*(?:(?:sudo|time|nohup)\s+)*"
+    r"(?:\S*/)?(?:cmake|ccmake|cmake-gui|cmake3|Build\.sh)(?![\w-])"
+)
+
 BAZEL_OUTPUT_DIR = re.compile(r"(^|/)bazel-(out|bin|testlogs)(/|$)")
 CACHE_DIR = re.compile(r"(^|/)\.cache(/|$)")
 # Matches /tmp and /tmp/..., but not ./tmp or /somewhere/tmp.
@@ -211,6 +220,22 @@ def check_spelunking(request):
     return None
 
 
+CMAKE_MESSAGE = (
+    "Building with CMake is verboten. Use bazel: `bazelisk build //:openroad` "
+    "in an OpenROAD checkout, or `bazelisk build @openroad//:openroad` here. A "
+    "cmake build sidesteps the pinned hermetic toolchain, so the binary it "
+    "produces is not the binary the flow builds -- which silently invalidates "
+    "any measurement made with it."
+)
+
+
+def check_cmake(request):
+    for segment in segments(request.code):
+        if CMAKE_BUILD.match(segment):
+            return CMAKE_MESSAGE
+    return None
+
+
 def check_tmp(request):
     if request.code and TMP_IN_COMMAND.search(request.code):
         return TMP_MESSAGE
@@ -227,6 +252,12 @@ RULES = (
         "bazel-clean",
         "`bazelisk clean` and `bazel clean` are blocked.",
         check_bazel_clean,
+    ),
+    (
+        "cmake-build",
+        "Building with CMake (`cmake`, `ccmake`, OpenROAD's `etc/Build.sh`) is "
+        "blocked; bazel is the only build path.",
+        check_cmake,
     ),
     (
         "git-local-branch",

--- a/.claude/hooks/guard_tool_test.py
+++ b/.claude/hooks/guard_tool_test.py
@@ -25,6 +25,20 @@ CLAUDE_MD = os.path.join(HERE, os.pardir, os.pardir, "CLAUDE.md")
 #   "path"    — a file/directory argument of a read/write/search tool
 #   "cwd"     — the working directory of a shell command
 CASES = [
+    # --- cmake -----------------------------------------------------------
+    ("command", "cmake -S . -B build", "verboten"),
+    ("command", "cmake --build build -j16", "verboten"),
+    ("command", "/usr/bin/cmake ..", "verboten"),
+    ("command", "ccmake .", "verboten"),
+    ("command", "CC=clang cmake -DCMAKE_BUILD_TYPE=Release .", "verboten"),
+    ("command", "sudo cmake --install build", "verboten"),
+    ("command", "./etc/Build.sh", "verboten"),
+    ("command", "cd src && ./etc/Build.sh -cmake='-DX=1'", "verboten"),
+    # Reading or editing cmake files is not building with cmake.
+    ("command", "grep -n add_library CMakeLists.txt", None),
+    ("command", "sed -i 's/foo/bar/' src/CMakeLists.txt", None),
+    ("command", "git log --oneline -- CMakeLists.txt", None),
+    ("command", "bazelisk build @openroad//:openroad", None),
     # --- bazel clean -----------------------------------------------------
     ("command", "bazel clean", "protects bazel cache"),
     ("command", "bazelisk clean --expunge", "protects bazel cache"),

--- a/.claude/skills/byo-openroad/SKILL.md
+++ b/.claude/skills/byo-openroad/SKILL.md
@@ -77,12 +77,26 @@ design directory.
 ```bash
 # 1. Build openroad from your checkout (the working tree is the source).
 cd /path/to/OpenROAD          # your OpenROAD checkout / ORFS tools/OpenROAD
-bazelisk build //:openroad    # (or the checkout's cmake build)
+bazelisk build //:openroad    # bazel only -- see below
 
 # 2. Point the flow / extracted stage harness at it.
 export OPENROAD_EXE="$(readlink -f bazel-bin/openroad)"
 # ... then run the ORFS stage (make do-<stage>, or an extracted _deps run).
 ```
+
+**Building with CMake is VERBOTEN, and the guard blocks it.** Not a style
+preference: a cmake build uses whatever compiler, flags and system libraries
+the machine happens to have, while the flow's binary comes from the pinned
+hermetic bazel toolchain. Swap one for the other and the binary under test is
+no longer the binary the flow builds, so every number measured with it is
+measuring the toolchain as much as the change -- silently, because it still
+runs and still produces plausible output. `bazelisk build //:openroad` in the
+checkout, or `bazelisk build @openroad//:openroad` here.
+
+A raw `git clone` of OpenROAD will NOT build: the GitHub tarball and a
+blobless clone both arrive without `src/sta` and `third-party/abc`. bazel-orfs
+vendors those in the `@openroad` `archive_override`'s `patch_cmds`, which is
+the other reason to build through this repository rather than beside it.
 
 The ODB is compatible across the two binaries as long as your checkout and the
 flow's pinned OpenROAD share a base revision.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ stops. Antigravity reaches the same file through
 and missing for the other.
 
 - `bazelisk clean` and `bazel clean` are blocked.
+- Building with CMake (`cmake`, `ccmake`, OpenROAD's `etc/Build.sh`) is blocked; bazel is the only build path.
 - Git operations (`checkout`, `switch`, `rebase`, `cherry-pick`, `merge`, `reset`, `pull`) on local `master` or `main` branches are blocked. Use remote-tracking branches or detached HEADs instead.
 - `git push` to `master` or `main` is blocked; push a feature branch and open a pull request instead.
 - Deleting, moving or force-updating a local `master`/`main` (`git branch -f/-D`, `git update-ref`, `git worktree add`) is blocked.


### PR DESCRIPTION
A hard stop, not a convention.

A cmake build of OpenROAD picks up whatever compiler, flags and system libraries the machine happens to have. The flow's binary comes from the pinned hermetic bazel toolchain. Swap one for the other and the binary under test stops being the binary the flow builds — so a measurement made with it is measuring the toolchain as much as the change, silently, because it still runs and still prints plausible numbers.

That is the most expensive failure mode this repository has, so it gets a guard rather than a note.

## What is blocked

`cmake`, `ccmake`, `cmake-gui`, `cmake3` and OpenROAD's `etc/Build.sh`, in **command position only** — optionally behind env assignments, `sudo`, `time` or `nohup`. Reading or editing a `CMakeLists.txt` is not building with cmake and stays allowed; the tests pin both directions:

```
cmake -S . -B build                      blocked
CC=clang cmake -DCMAKE_BUILD_TYPE=... .  blocked
./etc/Build.sh                           blocked
grep -n add_library CMakeLists.txt       allowed
sed -i s/foo/bar/ src/CMakeLists.txt     allowed
bazelisk build @openroad//:openroad      allowed
```

## The other half of the lesson

`.claude/skills/byo-openroad/SKILL.md` had the invitation in it — `bazelisk build //:openroad    # (or the checkout's cmake build)`. That aside is gone, and the skill now also records why reaching for cmake feels necessary in the first place: **a raw clone of OpenROAD does not build.** The GitHub tarball and a blobless clone both arrive without `src/sta` and `third-party/abc`; bazel-orfs vendors them in the `@openroad` `archive_override`'s `patch_cmds`. Build through this repository, not beside it.

## Enforcement cannot drift

`//:guard_tool_test` asserts the CLAUDE.md guardrail list equals `guard_tool.py --explain`, so the rule, its documentation and its enforcement move together or the test fails. Both agents reach the same file — antigravity through `.agents/scripts/guard_tool.py` — so the rule cannot be live for one and missing for the other.

`//:guard_tool_test` passes; `//:fix_lint` clean.