### PR TITLE
docs: stop pointing at CMake, and correct two stale current-state sections

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -144,10 +144,9 @@ yosys, abc, GNU Make and Qt come from their own modules, so they are additional
 from-source surface beyond what this check covers.
 
 ### Bring your own OpenROAD when the from-source build won't go
-If the standalone build fails on your host but you have a working OpenROAD
-installed some other way (e.g. built with the classic CMake flow via
-OpenROAD's `etc/DependencyInstaller.sh`), point bazel-orfs at it and skip the
-from-source build entirely:
+If the standalone build fails on your host but you already have a working
+OpenROAD — your distribution's package, a vendor build, a binary a colleague
+handed you — point bazel-orfs at it and skip the from-source build entirely:
 
 ```starlark
 orfs.default(
@@ -164,6 +163,19 @@ the remaining from-source deps (yosys, abc, GNU Make), but it is often enough
 to get a flow running on a host the full source build can't handle. See
 [openroad.md](openroad.md), "Using a Locally Installed OpenROAD".
 
+**This is an escape hatch for getting a flow to run, never a base for a
+measurement.** A PATH binary was built with whatever compiler, flags and
+system libraries its builder happened to have, so a number measured against
+it is measuring that toolchain as much as your design or your change —
+silently, because the flow still runs and still prints plausible output.
+Anything you intend to compare, publish or file upstream has to come from the
+pinned hermetic build.
+
+Nor should you reach for CMake to produce that binary yourself: building with
+CMake is blocked here (see the guardrails in `CLAUDE.md`), for the reason
+above. If the from-source build won't go on your host, the answer is this
+escape hatch or a different host, not a hand-rolled build.
+
 ### No CI below ubuntu-22.04 — old distributions are unsupported in practice
 bazel-orfs CI runs on `ubuntu-22.04` and nothing else
 (`.github/workflows/ci.yml`). OpenROAD's Bazel CI runs on `ubuntu-latest` and
@@ -175,8 +187,10 @@ one-off fix is not a support promise, and the next bump can undo it.
 
 Note that OpenROAD's *CMake* build supports considerably more platforms than
 its Bazel build — `etc/DependencyInstaller.sh` covers RHEL/Rocky/Alma,
-openSUSE and Debian. A distribution appearing there says nothing about the
-Bazel path bazel-orfs uses; that combination is the bring-your-own case above.
+openSUSE and Debian. That is a fact about upstream, not a route through this
+repository: bazel-orfs builds with Bazel only, and a distribution appearing on
+that list says nothing about the Bazel path. If your host is on it but not on
+the Bazel path, the bring-your-own case above is what you have.
 
 ## Dependency bumps
 

--- a/ideas/toolchains.md
+++ b/ideas/toolchains.md
@@ -1,5 +1,13 @@
 # Caching and Pinning: Toolchains and Packages
 
+> **Status: partly overtaken by events.** Written when bazel-orfs built yosys
+> and ABC from source in-tree. Both now come from the Bazel Central Registry
+> (`bazel_dep(name = "yosys", ...)`, `bazel_dep(name = "abc", ...)`), which is
+> the outcome the "proper long-term fix" paragraph below asks for, so the
+> Yosys half of this proposal has effectively shipped by another route. The
+> OpenROAD half stands: it is still built from source on every host that
+> cannot hit a cache. Read the pinning argument, not the file layouts.
+
 ## Context
 
 bazel-orfs relies on two large foundational tools -- yosys and
@@ -58,9 +66,9 @@ should not capture this intention -- that is what pinning is for.
 
 Additionally:
 
-- **Build time**: yosys takes 10-20 minutes from source, OpenROAD
-  takes 30-60+ minutes. Both require a C++20 compiler, cmake, and
-  platform-specific development headers.
+- **Build time**: OpenROAD takes 30-60+ minutes from source and needs a
+  C++20 toolchain and a long tail of platform development headers. yosys
+  used to cost another 10-20 minutes here; it now comes from BCR.
 
 - **Clone size**: ORFS is a 1.1 GB git checkout. bazel-orfs only
   needs ~830 KB of scripts/makefiles plus PDK platform files, but
@@ -135,12 +143,13 @@ The plan:
 
 ### Current state
 
-`bazel-orfs/yosys/` downloads yosys, ABC, cxxopts, yosys-slang, slang,
-fmt, TCL, and flex sources, then builds everything via a genrule that
-shells out to `make install` and `cmake`. The resulting binaries
-(`yosys`, `yosys-abc`) and share directory (techmap, plugins including
-`slang.so`) are consumed through `CONFIG_YOSYS` / `CONFIG_YOSYS_ABC` /
-`CONFIG_YOSYS_SHARE` in `global_config.bzl`.
+**Superseded.** This section described a `bazel-orfs/yosys/` tree that
+downloaded yosys, ABC and their dependencies and built them from source. That
+tree is gone: yosys and ABC are `bazel_dep`s on the Bazel Central Registry,
+pinned in lockstep by `//:bump`, and the slang frontend is an out-of-tree
+plugin module. `CONFIG_YOSYS` / `CONFIG_YOSYS_ABC` / `CONFIG_YOSYS_SHARE`
+still name the binaries, but nothing here builds them any more. The proposed
+structure below is kept for the shape of the argument, not as a plan.
 
 ### Proposed structure
 
@@ -255,11 +264,12 @@ This eliminates `CONFIG_YOSYS`, `CONFIG_YOSYS_ABC`, and
 
 ### Current state
 
-OpenROAD is pulled via `git_override` in `MODULE.bazel`, pointing at a
-specific commit of `The-OpenROAD-Project/OpenROAD.git`. It builds from
+OpenROAD is pulled via `archive_override` in `MODULE.bazel`, pinned to a
+specific commit tarball, with `src/sta` and `third-party/abc` vendored by
+`patch_cmds` because a GitHub tarball carries no submodules. It builds from
 source as a full C++20 project with LLVM toolchain, boost, or-tools,
 tcmalloc, Eigen, SWIG, and many other dependencies. Build time is
-30-60+ minutes cold.
+30-60+ minutes cold. Bazel is the only supported way to build it.
 
 The binaries (`openroad`, `opensta`) are wired through `CONFIG_OPENROAD`
 and `CONFIG_OPENSTA` in `global_config.bzl`, with per-rule attribute


### PR DESCRIPTION
Documentation half of the CMake ban. Stacks on #941, which adds the guard rule this text refers to.

## The sweep

`examples/`, `README.md`, `docs/openroad.md` and `docs/tools.md` had no CMake references at all. Two files did, and in both the CMake mention turned out to be a symptom of text that had gone stale rather than a stray word.

## `docs/debugging.md`

Offered *"built with the classic CMake flow via `etc/DependencyInstaller.sh`"* as the way to obtain a bring-your-own binary.

The escape hatch is still right — a distribution package or a vendor build gets a flow running on a host the source build cannot handle — but how that binary was produced is not this repository's recommendation to make, and CMake is blocked now. So the section drops the recommendation and gains the warning that matters more:

> **This is an escape hatch for getting a flow to run, never a base for a measurement.** A PATH binary was built with whatever compiler, flags and system libraries its builder happened to have, so a number measured against it is measuring that toolchain as much as your design or your change — silently, because the flow still runs and still prints plausible output.

The "OpenROAD's CMake build supports more platforms" note keeps the upstream fact but stops reading like a route through this repository.

## `ideas/toolchains.md`

Described a `bazel-orfs/yosys/` tree that downloaded yosys, ABC, slang and friends and built them "via a genrule that shells out to `make install` and `cmake`".

**That tree does not exist.** yosys and ABC are `bazel_dep`s from BCR, pinned in lockstep by `//:bump`. The OpenROAD section was stale too — it still said `git_override`, which is now an `archive_override` with `src/sta` and `third-party/abc` vendored by `patch_cmds`.

Both corrected, and the document gains a status banner: its own "the proper long-term fix is for yosys and OpenROAD to publish [modules]" **has shipped for yosys**, by another route. The Yosys half of the proposal is history; the pinning argument is what is left worth reading.

## Left alone

`bump_impl.py` reads yosys's `cmake/YosysVersionData.cmake` through the GitHub API to extract version numbers. Parsing an upstream file is not building with CMake.

## A question for you

`ideas/toolchains.md` is 1227 lines of an unimplemented proposal whose yosys half has now been overtaken. I corrected it rather than retired it, because deleting it is your call, not a side effect of a CMake sweep. If you want the `ideas/eta.md` treatment — retire the machinery, keep the answer — say so and it is a separate pull request.

`//:fix_lint` clean.