### PR TITLE
ideas: scoring an OpenROAD pull request — a Pareto front and a design ledger

### DIFF
--- a/docs/studies/pr-lifecycle/collect.py
+++ b/docs/studies/pr-lifecycle/collect.py
@@ -1,0 +1,217 @@
+"""Measure who reviews OpenROAD pull requests, and what becomes of them.
+
+Reads the GitHub API through `gh` and writes data.json. No arguments, no
+credentials of its own: it borrows whatever `gh auth` already has.
+
+The question is not "how many pull requests are abandoned" -- that number
+is easy and uninteresting. It is which kind of attention a pull request
+gets before it dies: machine review, human review, or none.
+
+Definitions, stated here because every number below depends on them:
+
+  * A REVIEW THREAD is one inline conversation on a diff line, attributed
+    to whoever opened it. Threads, not comments, so a long back-and-forth
+    counts once.
+  * HUMAN ENGAGEMENT is any review, review thread or issue comment from a
+    human who is not the pull request's own author. A pull request with
+    zero human engagement is one no person said anything about.
+  * A BOT is matched by login substring (see BOTS). This under-counts if a
+    new bot appears and over-counts nothing, since the names are distinct.
+  * COMMITS AFTER BOT, BEFORE HUMAN counts commits whose committedDate
+    falls after the first bot thread and before any human engagement. It
+    uses committedDate, which can precede the push, so it UNDER-counts.
+
+Sampling: the N most recently updated pull requests in each state. That is
+recency-weighted on purpose -- the question is about how the project works
+now -- and it is not a random sample of the year, which is why no
+significance test is reported and none should be inferred.
+"""
+
+import datetime
+import json
+import subprocess
+import statistics
+import sys
+
+OWNER = "The-OpenROAD-Project"
+NAME = "OpenROAD"
+SAMPLE = 120
+
+BOTS = (
+    "gemini-code-assist",
+    "github-actions",
+    "clang-tidy",
+    "openroad-ci",
+    "codex",
+    "chatgpt-codex-connector",
+    "copilot",
+    "dependabot",
+    "coderabbitai",
+)
+
+QUERY = """
+query($cursor:String, $states:[PullRequestState!], $owner:String!, $name:String!) {
+ repository(owner:$owner, name:$name) {
+  pullRequests(states:$states, first:25,
+               orderBy:{field:UPDATED_AT, direction:DESC}, after:$cursor) {
+   pageInfo { hasNextPage endCursor }
+   nodes {
+    number createdAt mergedAt closedAt merged
+    author { login }
+    commits(first:100) { totalCount nodes { commit { committedDate } } }
+    reviews(first:60) { nodes { author { login } state submittedAt } }
+    comments(first:60) { nodes { author { login } createdAt } }
+    reviewThreads(first:60) {
+      nodes { comments(first:1) { nodes { author { login } createdAt } } } }
+   }
+  }
+ }
+}
+"""
+
+
+def is_bot(login):
+    login = (login or "").lower().replace("[bot]", "")
+    return any(bot in login for bot in BOTS)
+
+
+def when(stamp):
+    return datetime.datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+
+
+def fetch(states, want):
+    nodes, cursor = [], None
+    while len(nodes) < want:
+        args = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            "query=" + QUERY,
+            "-F",
+            "states=" + states,
+            "-F",
+            "owner=" + OWNER,
+            "-F",
+            "name=" + NAME,
+        ]
+        if cursor:
+            args += ["-F", "cursor=" + cursor]
+        done = subprocess.run(args, capture_output=True, text=True)
+        if done.returncode != 0:
+            sys.exit("gh api failed: " + done.stderr.strip())
+        page = json.loads(done.stdout)["data"]["repository"]["pullRequests"]
+        nodes += page["nodes"]
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+    return nodes[:want]
+
+
+def rows_for(nodes):
+    rows = []
+    for node in nodes:
+        author = (node["author"] or {}).get("login", "")
+        # Bot-authored pull requests (dependabot, the CI mirror) are a
+        # different population and would swamp the human one.
+        if is_bot(author):
+            continue
+
+        threads = [
+            thread["comments"]["nodes"][0]
+            for thread in node["reviewThreads"]["nodes"]
+            if thread["comments"]["nodes"]
+        ]
+        bot_threads = [
+            t for t in threads if is_bot((t["author"] or {}).get("login", ""))
+        ]
+        human_threads = [t for t in threads if t not in bot_threads]
+
+        human_reviews = [
+            r
+            for r in node["reviews"]["nodes"]
+            if r["author"] and not is_bot(r["author"]["login"]) and r["submittedAt"]
+        ]
+        human_comments = [
+            c
+            for c in node["comments"]["nodes"]
+            if c["author"]
+            and not is_bot(c["author"]["login"])
+            and c["author"]["login"] != author
+        ]
+
+        human_events = (
+            [when(t["createdAt"]) for t in human_threads]
+            + [when(r["submittedAt"]) for r in human_reviews]
+            + [when(c["createdAt"]) for c in human_comments]
+        )
+        bot_events = [when(t["createdAt"]) for t in bot_threads]
+        first_human = min(human_events) if human_events else None
+        first_bot = min(bot_events) if bot_events else None
+
+        commits = [when(c["commit"]["committedDate"]) for c in node["commits"]["nodes"]]
+        after_bot_only = sum(
+            1
+            for c in commits
+            if first_bot and c > first_bot and (not first_human or c < first_human)
+        )
+
+        closed = node["mergedAt"] or node["closedAt"]
+        rows.append(
+            {
+                "number": node["number"],
+                "merged": node["merged"],
+                "bot_threads": len(bot_threads),
+                "human_threads": len(human_threads),
+                "human_engagement": len(human_events),
+                "commits": node["commits"]["totalCount"],
+                "commits_after_bot_before_human": after_bot_only,
+                "days_open": (
+                    ((when(closed) - when(node["createdAt"])).total_seconds() / 86400)
+                    if closed
+                    else None
+                ),
+            }
+        )
+    return rows
+
+
+def summarise(rows, label):
+    total = len(rows)
+    bot = sum(r["bot_threads"] for r in rows)
+    human = sum(r["human_threads"] for r in rows)
+    silent = sum(1 for r in rows if r["human_engagement"] == 0)
+    churn = sum(1 for r in rows if r["commits_after_bot_before_human"] > 0)
+    days = [r["days_open"] for r in rows if r["days_open"] is not None]
+    return {
+        "label": label,
+        "pull_requests": total,
+        "bot_threads": bot,
+        "human_threads": human,
+        "bot_thread_share": round(bot / max(1, bot + human), 3),
+        "zero_human_engagement": silent,
+        "zero_human_engagement_share": round(silent / max(1, total), 3),
+        "commits_after_bot_before_human": churn,
+        "commits_after_bot_before_human_share": round(churn / max(1, total), 3),
+        "median_days_open": round(statistics.median(days), 2) if days else None,
+    }
+
+
+def main():
+    merged = rows_for(fetch("MERGED", SAMPLE))
+    abandoned = rows_for([n for n in fetch("CLOSED", SAMPLE) if not n["merged"]])
+    out = {
+        "collected": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+        "repository": f"{OWNER}/{NAME}",
+        "sample_per_state": SAMPLE,
+        "summary": [summarise(merged, "merged"), summarise(abandoned, "abandoned")],
+        "rows": {"merged": merged, "abandoned": abandoned},
+    }
+    with open("data.json", "w") as handle:
+        json.dump(out, handle, indent=2)
+    for block in out["summary"]:
+        print(json.dumps(block, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/studies/pr-lifecycle/data.json
+++ b/docs/studies/pr-lifecycle/data.json
@@ -1,0 +1,2147 @@
+{
+  "collected": "2026-09-06",
+  "repository": "The-OpenROAD-Project/OpenROAD",
+  "sample_per_state": 120,
+  "summary": [
+    {
+      "label": "merged",
+      "pull_requests": 112,
+      "bot_threads": 248,
+      "human_threads": 52,
+      "bot_thread_share": 0.827,
+      "zero_human_engagement": 12,
+      "zero_human_engagement_share": 0.107,
+      "commits_after_bot_before_human": 45,
+      "commits_after_bot_before_human_share": 0.402,
+      "median_days_open": 0.96
+    },
+    {
+      "label": "abandoned",
+      "pull_requests": 99,
+      "bot_threads": 431,
+      "human_threads": 45,
+      "bot_thread_share": 0.905,
+      "zero_human_engagement": 30,
+      "zero_human_engagement_share": 0.303,
+      "commits_after_bot_before_human": 36,
+      "commits_after_bot_before_human_share": 0.364,
+      "median_days_open": 9.24
+    }
+  ],
+  "rows": {
+    "merged": [
+      {
+        "number": 11262,
+        "merged": true,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 6,
+        "commits": 4,
+        "commits_after_bot_before_human": 2,
+        "days_open": 7.769016203703703
+      },
+      {
+        "number": 9169,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.3370486111111111
+      },
+      {
+        "number": 11224,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 10,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 11.026284722222222
+      },
+      {
+        "number": 11330,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 8,
+        "commits_after_bot_before_human": 3,
+        "days_open": 0.964224537037037
+      },
+      {
+        "number": 11342,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.002685185185185185
+      },
+      {
+        "number": 11341,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.005092592592592593
+      },
+      {
+        "number": 11331,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.4056828703703704
+      },
+      {
+        "number": 11319,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.7367939814814815
+      },
+      {
+        "number": 11332,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.2532986111111111
+      },
+      {
+        "number": 11313,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.4790625
+      },
+      {
+        "number": 11282,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 2,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.8581712962962964
+      },
+      {
+        "number": 11268,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 2.906388888888889
+      },
+      {
+        "number": 11299,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.14748842592592593
+      },
+      {
+        "number": 11255,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 16,
+        "commits_after_bot_before_human": 0,
+        "days_open": 5.373402777777778
+      },
+      {
+        "number": 11294,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.3216550925925926
+      },
+      {
+        "number": 11284,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.283599537037037
+      },
+      {
+        "number": 11288,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 1,
+        "human_engagement": 5,
+        "commits": 7,
+        "commits_after_bot_before_human": 2,
+        "days_open": 0.9120254629629629
+      },
+      {
+        "number": 10977,
+        "merged": true,
+        "bot_threads": 5,
+        "human_threads": 2,
+        "human_engagement": 6,
+        "commits": 44,
+        "commits_after_bot_before_human": 4,
+        "days_open": 40.11122685185185
+      },
+      {
+        "number": 11232,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 7.228310185185185
+      },
+      {
+        "number": 11289,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 5,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.26438657407407407
+      },
+      {
+        "number": 11256,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.16677083333333334
+      },
+      {
+        "number": 11121,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 2,
+        "human_engagement": 7,
+        "commits": 24,
+        "commits_after_bot_before_human": 14,
+        "days_open": 19.863344907407406
+      },
+      {
+        "number": 11264,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 1,
+        "human_engagement": 3,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.5708333333333333
+      },
+      {
+        "number": 11252,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 8,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.9363078703703703
+      },
+      {
+        "number": 11257,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.008946759259259258
+      },
+      {
+        "number": 11243,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.3399421296296297
+      },
+      {
+        "number": 11246,
+        "merged": true,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 17,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.8772453703703704
+      },
+      {
+        "number": 11251,
+        "merged": true,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.7226851851851852
+      },
+      {
+        "number": 11181,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 9,
+        "commits_after_bot_before_human": 0,
+        "days_open": 7.98869212962963
+      },
+      {
+        "number": 11254,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.01607638888888889
+      },
+      {
+        "number": 11230,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 5,
+        "commits_after_bot_before_human": 3,
+        "days_open": 0.4163425925925926
+      },
+      {
+        "number": 11244,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 1,
+        "human_engagement": 5,
+        "commits": 10,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.20041666666666666
+      },
+      {
+        "number": 11239,
+        "merged": true,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 5,
+        "commits": 6,
+        "commits_after_bot_before_human": 4,
+        "days_open": 0.6516203703703703
+      },
+      {
+        "number": 11233,
+        "merged": true,
+        "bot_threads": 4,
+        "human_threads": 1,
+        "human_engagement": 10,
+        "commits": 7,
+        "commits_after_bot_before_human": 3,
+        "days_open": 0.95625
+      },
+      {
+        "number": 11212,
+        "merged": true,
+        "bot_threads": 8,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 5,
+        "commits_after_bot_before_human": 4,
+        "days_open": 2.8093518518518517
+      },
+      {
+        "number": 11240,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.04880787037037037
+      },
+      {
+        "number": 11238,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.07228009259259259
+      },
+      {
+        "number": 11102,
+        "merged": true,
+        "bot_threads": 7,
+        "human_threads": 1,
+        "human_engagement": 8,
+        "commits": 15,
+        "commits_after_bot_before_human": 13,
+        "days_open": 18.05369212962963
+      },
+      {
+        "number": 11227,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.7565393518518518
+      },
+      {
+        "number": 11231,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 1,
+        "human_engagement": 5,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.3661111111111111
+      },
+      {
+        "number": 11228,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.6816782407407408
+      },
+      {
+        "number": 11235,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.12284722222222222
+      },
+      {
+        "number": 11089,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 1,
+        "human_engagement": 8,
+        "commits": 20,
+        "commits_after_bot_before_human": 1,
+        "days_open": 14.74900462962963
+      },
+      {
+        "number": 11216,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 2,
+        "human_engagement": 8,
+        "commits": 8,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.140648148148148
+      },
+      {
+        "number": 10706,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 65.51524305555556
+      },
+      {
+        "number": 11215,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.2829745370370371
+      },
+      {
+        "number": 11207,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 2.8319907407407405
+      },
+      {
+        "number": 11201,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 3.3729282407407406
+      },
+      {
+        "number": 11221,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.055011574074074074
+      },
+      {
+        "number": 11220,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.040636574074074075
+      },
+      {
+        "number": 11213,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 1,
+        "human_engagement": 4,
+        "commits": 5,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.7642245370370371
+      },
+      {
+        "number": 10972,
+        "merged": true,
+        "bot_threads": 8,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 12,
+        "commits_after_bot_before_human": 6,
+        "days_open": 32.29613425925926
+      },
+      {
+        "number": 11210,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.5627893518518519
+      },
+      {
+        "number": 10966,
+        "merged": true,
+        "bot_threads": 10,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 11,
+        "commits_after_bot_before_human": 6,
+        "days_open": 32.50853009259259
+      },
+      {
+        "number": 10946,
+        "merged": true,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 5,
+        "commits_after_bot_before_human": 3,
+        "days_open": 35.98517361111111
+      },
+      {
+        "number": 10910,
+        "merged": true,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 9,
+        "commits_after_bot_before_human": 2,
+        "days_open": 39.178263888888885
+      },
+      {
+        "number": 11193,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 4,
+        "commits_after_bot_before_human": 1,
+        "days_open": 2.1133217592592595
+      },
+      {
+        "number": 11208,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.07393518518518519
+      },
+      {
+        "number": 10878,
+        "merged": true,
+        "bot_threads": 5,
+        "human_threads": 2,
+        "human_engagement": 7,
+        "commits": 7,
+        "commits_after_bot_before_human": 0,
+        "days_open": 42.308877314814815
+      },
+      {
+        "number": 11202,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 4,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.4409722222222222
+      },
+      {
+        "number": 11155,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 8,
+        "human_engagement": 11,
+        "commits": 4,
+        "commits_after_bot_before_human": 0,
+        "days_open": 5.8435648148148145
+      },
+      {
+        "number": 11203,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.32180555555555557
+      },
+      {
+        "number": 11187,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 5,
+        "commits_after_bot_before_human": 4,
+        "days_open": 1.9706712962962962
+      },
+      {
+        "number": 11195,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 4,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.0064814814814815
+      },
+      {
+        "number": 11206,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.07587962962962963
+      },
+      {
+        "number": 11186,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 4,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.784560185185185
+      },
+      {
+        "number": 11190,
+        "merged": true,
+        "bot_threads": 5,
+        "human_threads": 3,
+        "human_engagement": 11,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 1.0983912037037038
+      },
+      {
+        "number": 11199,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.18182870370370371
+      },
+      {
+        "number": 11134,
+        "merged": true,
+        "bot_threads": 7,
+        "human_threads": 8,
+        "human_engagement": 23,
+        "commits": 6,
+        "commits_after_bot_before_human": 1,
+        "days_open": 7.913043981481482
+      },
+      {
+        "number": 11194,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.047581018518518516
+      },
+      {
+        "number": 11191,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.12148148148148148
+      },
+      {
+        "number": 10726,
+        "merged": true,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 60.449930555555554
+      },
+      {
+        "number": 11185,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.7981018518518519
+      },
+      {
+        "number": 11177,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 23,
+        "commits_after_bot_before_human": 3,
+        "days_open": 1.0651388888888889
+      },
+      {
+        "number": 11136,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 1,
+        "human_engagement": 4,
+        "commits": 6,
+        "commits_after_bot_before_human": 3,
+        "days_open": 6.3836458333333335
+      },
+      {
+        "number": 11176,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 1,
+        "human_engagement": 3,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.1122800925925926
+      },
+      {
+        "number": 11184,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.05193287037037037
+      },
+      {
+        "number": 11154,
+        "merged": true,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 3.7100115740740742
+      },
+      {
+        "number": 11182,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.07961805555555555
+      },
+      {
+        "number": 11145,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 4.684641203703704
+      },
+      {
+        "number": 11149,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 9,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 4.04537037037037
+      },
+      {
+        "number": 11095,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 8,
+        "commits_after_bot_before_human": 0,
+        "days_open": 11.03587962962963
+      },
+      {
+        "number": 11174,
+        "merged": true,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 5,
+        "commits_after_bot_before_human": 5,
+        "days_open": 0.12726851851851853
+      },
+      {
+        "number": 11173,
+        "merged": true,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.06759259259259259
+      },
+      {
+        "number": 11172,
+        "merged": true,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 3,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.16163194444444445
+      },
+      {
+        "number": 11112,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 8.178460648148148
+      },
+      {
+        "number": 11147,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 3.819027777777778
+      },
+      {
+        "number": 11161,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 2,
+        "human_engagement": 7,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.0172916666666667
+      },
+      {
+        "number": 11168,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 4,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.6165972222222222
+      },
+      {
+        "number": 11170,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 3,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.1373611111111111
+      },
+      {
+        "number": 10975,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 7,
+        "human_engagement": 19,
+        "commits": 17,
+        "commits_after_bot_before_human": 0,
+        "days_open": 26.086030092592594
+      },
+      {
+        "number": 11138,
+        "merged": true,
+        "bot_threads": 9,
+        "human_threads": 2,
+        "human_engagement": 7,
+        "commits": 22,
+        "commits_after_bot_before_human": 11,
+        "days_open": 4.185381944444444
+      },
+      {
+        "number": 11148,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 2.9304050925925926
+      },
+      {
+        "number": 11101,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.6591203703703703
+      },
+      {
+        "number": 11113,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.3352199074074074
+      },
+      {
+        "number": 11053,
+        "merged": true,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 28,
+        "commits_after_bot_before_human": 23,
+        "days_open": 14.201099537037036
+      },
+      {
+        "number": 11156,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 0.2884837962962963
+      },
+      {
+        "number": 11157,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.27828703703703705
+      },
+      {
+        "number": 11158,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.15855324074074073
+      },
+      {
+        "number": 11144,
+        "merged": true,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 4,
+        "commits_after_bot_before_human": 2,
+        "days_open": 1.3169212962962964
+      },
+      {
+        "number": 11150,
+        "merged": true,
+        "bot_threads": 26,
+        "human_threads": 0,
+        "human_engagement": 13,
+        "commits": 8,
+        "commits_after_bot_before_human": 4,
+        "days_open": 0.49265046296296294
+      },
+      {
+        "number": 11107,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 4,
+        "commits_after_bot_before_human": 1,
+        "days_open": 5.269780092592592
+      },
+      {
+        "number": 11143,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.42721064814814813
+      },
+      {
+        "number": 11141,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 1,
+        "human_engagement": 3,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.7556828703703704
+      },
+      {
+        "number": 11142,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.6396527777777777
+      },
+      {
+        "number": 10931,
+        "merged": true,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.277662037037037
+      },
+      {
+        "number": 11035,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 6,
+        "commits_after_bot_before_human": 3,
+        "days_open": 8.73542824074074
+      },
+      {
+        "number": 11139,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.02607638888888889
+      },
+      {
+        "number": 11125,
+        "merged": true,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 11,
+        "commits_after_bot_before_human": 5,
+        "days_open": 2.2711111111111113
+      },
+      {
+        "number": 11057,
+        "merged": true,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 4,
+        "commits_after_bot_before_human": 2,
+        "days_open": 9.627465277777778
+      },
+      {
+        "number": 11092,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 1,
+        "human_engagement": 6,
+        "commits": 4,
+        "commits_after_bot_before_human": 0,
+        "days_open": 6.276400462962963
+      },
+      {
+        "number": 11131,
+        "merged": true,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.9355324074074074
+      }
+    ],
+    "abandoned": [
+      {
+        "number": 8040,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.28954861111111113
+      },
+      {
+        "number": 10633,
+        "merged": false,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 7,
+        "commits_after_bot_before_human": 0,
+        "days_open": 85.98016203703703
+      },
+      {
+        "number": 11099,
+        "merged": false,
+        "bot_threads": 8,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 18,
+        "commits_after_bot_before_human": 2,
+        "days_open": 27.974247685185187
+      },
+      {
+        "number": 11253,
+        "merged": false,
+        "bot_threads": 6,
+        "human_threads": 3,
+        "human_engagement": 10,
+        "commits": 6,
+        "commits_after_bot_before_human": 0,
+        "days_open": 8.581400462962963
+      },
+      {
+        "number": 10776,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 66.32981481481481
+      },
+      {
+        "number": 11236,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 9.134328703703703
+      },
+      {
+        "number": 11214,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 4,
+        "human_engagement": 9,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 10.512071759259259
+      },
+      {
+        "number": 10630,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 15.504166666666666
+      },
+      {
+        "number": 10647,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 13.20835648148148
+      },
+      {
+        "number": 10631,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 15.175266203703703
+      },
+      {
+        "number": 10678,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 7,
+        "commits": 3,
+        "commits_after_bot_before_human": 1,
+        "days_open": 8.851435185185185
+      },
+      {
+        "number": 10638,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 81.43842592592593
+      },
+      {
+        "number": 11249,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 1,
+        "human_engagement": 3,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 3.9829050925925924
+      },
+      {
+        "number": 11152,
+        "merged": false,
+        "bot_threads": 13,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 8,
+        "commits_after_bot_before_human": 6,
+        "days_open": 15.711458333333333
+      },
+      {
+        "number": 11276,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.15091435185185184
+      },
+      {
+        "number": 11275,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.15091435185185184
+      },
+      {
+        "number": 11274,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.15091435185185184
+      },
+      {
+        "number": 11260,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.06547453703703704
+      },
+      {
+        "number": 11259,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.006597222222222222
+      },
+      {
+        "number": 9743,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 1,
+        "human_engagement": 5,
+        "commits": 4,
+        "commits_after_bot_before_human": 0,
+        "days_open": 167.84491898148147
+      },
+      {
+        "number": 11084,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 8.367106481481482
+      },
+      {
+        "number": 11086,
+        "merged": false,
+        "bot_threads": 23,
+        "human_threads": 0,
+        "human_engagement": 25,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 8.290868055555556
+      },
+      {
+        "number": 11072,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 4,
+        "commits_after_bot_before_human": 1,
+        "days_open": 9.315555555555555
+      },
+      {
+        "number": 11073,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 9.244814814814815
+      },
+      {
+        "number": 10049,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 1,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 144.84381944444445
+      },
+      {
+        "number": 11189,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 4.864710648148148
+      },
+      {
+        "number": 10520,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 87.66401620370371
+      },
+      {
+        "number": 10581,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 7,
+        "commits_after_bot_before_human": 1,
+        "days_open": 81.02731481481482
+      },
+      {
+        "number": 10231,
+        "merged": false,
+        "bot_threads": 10,
+        "human_threads": 3,
+        "human_engagement": 25,
+        "commits": 12,
+        "commits_after_bot_before_human": 1,
+        "days_open": 120.95601851851852
+      },
+      {
+        "number": 10721,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 61.48778935185185
+      },
+      {
+        "number": 10725,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 60.63390046296296
+      },
+      {
+        "number": 10184,
+        "merged": false,
+        "bot_threads": 6,
+        "human_threads": 6,
+        "human_engagement": 21,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 123.41954861111111
+      },
+      {
+        "number": 11166,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 20,
+        "commits_after_bot_before_human": 1,
+        "days_open": 1.9409722222222223
+      },
+      {
+        "number": 11151,
+        "merged": false,
+        "bot_threads": 14,
+        "human_threads": 1,
+        "human_engagement": 24,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 3.5980555555555553
+      },
+      {
+        "number": 11146,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 4.751469907407407
+      },
+      {
+        "number": 11179,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.25376157407407407
+      },
+      {
+        "number": 11164,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.9439930555555556
+      },
+      {
+        "number": 10803,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 11,
+        "commits_after_bot_before_human": 0,
+        "days_open": 45.2962037037037
+      },
+      {
+        "number": 10489,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 2,
+        "human_engagement": 15,
+        "commits": 3,
+        "commits_after_bot_before_human": 0,
+        "days_open": 86.9816087962963
+      },
+      {
+        "number": 11133,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.7710069444444444
+      },
+      {
+        "number": 11135,
+        "merged": false,
+        "bot_threads": 14,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 2,
+        "days_open": 0.22177083333333333
+      },
+      {
+        "number": 11023,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 3,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.19436342592592593
+      },
+      {
+        "number": 11032,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.1774537037037037
+      },
+      {
+        "number": 10484,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 81.04445601851852
+      },
+      {
+        "number": 11108,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.004525462962962963
+      },
+      {
+        "number": 11036,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 7.913055555555555
+      },
+      {
+        "number": 11008,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 10.79238425925926
+      },
+      {
+        "number": 11071,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 3,
+        "human_engagement": 15,
+        "commits": 5,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.9083101851851851
+      },
+      {
+        "number": 10788,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 36.76643518518519
+      },
+      {
+        "number": 10988,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 9,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 1.3019791666666667
+      },
+      {
+        "number": 11083,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.005532407407407408
+      },
+      {
+        "number": 10987,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 9.45619212962963
+      },
+      {
+        "number": 10430,
+        "merged": false,
+        "bot_threads": 7,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 81.18335648148148
+      },
+      {
+        "number": 10405,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 1,
+        "human_engagement": 14,
+        "commits": 3,
+        "commits_after_bot_before_human": 1,
+        "days_open": 82.72878472222222
+      },
+      {
+        "number": 11051,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 1,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.1110300925925926
+      },
+      {
+        "number": 11044,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.016793981481481483
+      },
+      {
+        "number": 10394,
+        "merged": false,
+        "bot_threads": 10,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 6,
+        "commits_after_bot_before_human": 0,
+        "days_open": 81.09703703703704
+      },
+      {
+        "number": 10724,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 24.46736111111111
+      },
+      {
+        "number": 9704,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 7,
+        "commits": 10,
+        "commits_after_bot_before_human": 1,
+        "days_open": 141.8977199074074
+      },
+      {
+        "number": 10985,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.2192939814814814
+      },
+      {
+        "number": 10942,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 7,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 7.650752314814815
+      },
+      {
+        "number": 10943,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 1.1566087962962963
+      },
+      {
+        "number": 10980,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.00125
+      },
+      {
+        "number": 9192,
+        "merged": false,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 32,
+        "commits_after_bot_before_human": 13,
+        "days_open": 100.26318287037037
+      },
+      {
+        "number": 9578,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 13,
+        "commits": 5,
+        "commits_after_bot_before_human": 0,
+        "days_open": 143.69208333333333
+      },
+      {
+        "number": 10876,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 18,
+        "commits_after_bot_before_human": 0,
+        "days_open": 11.23204861111111
+      },
+      {
+        "number": 10583,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 49.10123842592593
+      },
+      {
+        "number": 10954,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.8488078703703704
+      },
+      {
+        "number": 10295,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 4,
+        "commits_after_bot_before_human": 1,
+        "days_open": 82.26049768518519
+      },
+      {
+        "number": 10753,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.005868055555555555
+      },
+      {
+        "number": 10174,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 1,
+        "human_engagement": 5,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 90.87091435185185
+      },
+      {
+        "number": 10758,
+        "merged": false,
+        "bot_threads": 7,
+        "human_threads": 0,
+        "human_engagement": 4,
+        "commits": 5,
+        "commits_after_bot_before_human": 0,
+        "days_open": 20.667349537037037
+      },
+      {
+        "number": 10923,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.0069328703703703705
+      },
+      {
+        "number": 10912,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.19532407407407407
+      },
+      {
+        "number": 10818,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 12,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.7586458333333334
+      },
+      {
+        "number": 10822,
+        "merged": false,
+        "bot_threads": 13,
+        "human_threads": 0,
+        "human_engagement": 7,
+        "commits": 14,
+        "commits_after_bot_before_human": 0,
+        "days_open": 7.948206018518518
+      },
+      {
+        "number": 10872,
+        "merged": false,
+        "bot_threads": 11,
+        "human_threads": 0,
+        "human_engagement": 11,
+        "commits": 26,
+        "commits_after_bot_before_human": 10,
+        "days_open": 3.6764699074074074
+      },
+      {
+        "number": 10797,
+        "merged": false,
+        "bot_threads": 4,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 11,
+        "commits_after_bot_before_human": 0,
+        "days_open": 11.936944444444444
+      },
+      {
+        "number": 10222,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 83.05122685185185
+      },
+      {
+        "number": 10871,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 2.3837152777777777
+      },
+      {
+        "number": 10891,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.21685185185185185
+      },
+      {
+        "number": 10202,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 2,
+        "human_engagement": 7,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 81.92597222222223
+      },
+      {
+        "number": 10857,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 8,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.2380555555555555
+      },
+      {
+        "number": 10851,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 0,
+        "human_engagement": 1,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 1.6985416666666666
+      },
+      {
+        "number": 10821,
+        "merged": false,
+        "bot_threads": 0,
+        "human_threads": 1,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 4.9612847222222225
+      },
+      {
+        "number": 10183,
+        "merged": false,
+        "bot_threads": 6,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 1,
+        "days_open": 81.04201388888889
+      },
+      {
+        "number": 5352,
+        "merged": false,
+        "bot_threads": 60,
+        "human_threads": 0,
+        "human_engagement": 59,
+        "commits": 30,
+        "commits_after_bot_before_human": 0,
+        "days_open": 729.2909490740741
+      },
+      {
+        "number": 10170,
+        "merged": false,
+        "bot_threads": 3,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 81.21438657407407
+      },
+      {
+        "number": 10164,
+        "merged": false,
+        "bot_threads": 8,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 81.07010416666667
+      },
+      {
+        "number": 10809,
+        "merged": false,
+        "bot_threads": 2,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 0.016608796296296295
+      },
+      {
+        "number": 10823,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 1,
+        "human_engagement": 6,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 0.281875
+      },
+      {
+        "number": 10365,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 3,
+        "commits": 2,
+        "commits_after_bot_before_human": 0,
+        "days_open": 58.051770833333336
+      },
+      {
+        "number": 10091,
+        "merged": false,
+        "bot_threads": 9,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 6,
+        "commits_after_bot_before_human": 5,
+        "days_open": 86.9065625
+      },
+      {
+        "number": 10719,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 3,
+        "commits_after_bot_before_human": 2,
+        "days_open": 12.188148148148148
+      },
+      {
+        "number": 9809,
+        "merged": false,
+        "bot_threads": 33,
+        "human_threads": 0,
+        "human_engagement": 13,
+        "commits": 10,
+        "commits_after_bot_before_human": 6,
+        "days_open": 107.8228125
+      },
+      {
+        "number": 10121,
+        "merged": false,
+        "bot_threads": 5,
+        "human_threads": 0,
+        "human_engagement": 0,
+        "commits": 1,
+        "commits_after_bot_before_human": 1,
+        "days_open": 81.51166666666667
+      },
+      {
+        "number": 10417,
+        "merged": false,
+        "bot_threads": 14,
+        "human_threads": 13,
+        "human_engagement": 37,
+        "commits": 44,
+        "commits_after_bot_before_human": 11,
+        "days_open": 50.327777777777776
+      },
+      {
+        "number": 10791,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 0.3276851851851852
+      },
+      {
+        "number": 10760,
+        "merged": false,
+        "bot_threads": 1,
+        "human_threads": 0,
+        "human_engagement": 2,
+        "commits": 1,
+        "commits_after_bot_before_human": 0,
+        "days_open": 5.178587962962963
+      }
+    ]
+  }
+}

--- a/ideas/qor-score.md
+++ b/ideas/qor-score.md
@@ -19,6 +19,63 @@ or rebaselines them, which converts every quality trade into "the goldens
 moved" -- a fact carrying no direction. A contributor who improves WNS at the
 cost of area has no vocabulary to say so and no way to be believed.
 
+### How often that happens
+
+`docs/studies/pr-lifecycle/` measures it. The 120 most recently updated
+OpenROAD pull requests in each state, bot-authored ones dropped, collected
+2026-09-06; `collect.py` regenerates `data.json`.
+
+| | merged | abandoned |
+|---|---|---|
+| pull requests in sample | 112 | 99 |
+| inline review threads opened by bots | 248 | 431 |
+| inline review threads opened by humans | 52 | 45 |
+| bot share of review threads | 83% | 90% |
+| **pull requests with zero human engagement** | **11%** | **30%** |
+| commits after bot feedback, before any human | 40% | 36% |
+| median days open | 0.96 | 9.24 |
+
+Machines write most of the review, and the volume does not discriminate: the
+abandoned population received *more* machine attention than the merged one and
+*less* human attention. What separates them is whether any person said
+anything at all, and there the gap is near enough three times. Merged pull
+requests close in about a day; abandoned ones take nine, which is not a quick
+no but a long silence.
+
+This does not show the machine comments are wrong or trivial -- the automated
+reviewer labels its own inline threads medium and above, and this did not
+adjudicate them -- nor does it show causation. It shows that machine review is
+most of the volume and does not predict the outcome, while sparse human review
+does. A score exists to make the human half cheap enough to happen.
+
+### What a stalled pull request looks like up close
+
+OpenROAD PR 10662 adds a resizer move that replaces one buffer with a pair of
+cascaded inverters. Its eight inline review threads, checked against the code
+at its head commit rather than against the discussion:
+
+| finding | source | severity | status at head |
+|---|---|---|---|
+| footprint filter rejects every inverter, disabling the move | bot | high | **live, unfixed** |
+| `makeInstance` return values unchecked | bot | medium | fixed by the author |
+| driver location ignored for block terminals | bot | medium | not applicable -- the code uses `dbNetwork::location()`, which resolves BTerms |
+| load centroid excludes block terminals | bot | medium | not applicable -- same |
+| move type naming | human | -- | fixed by the author |
+| naming suggestion answered | human | -- | applied |
+| `estimate()` not overridden, so the MT policy cannot rank the move | human | -- | live, deferred by the author |
+| endorsement of the footprint finding | human | -- | -- |
+
+Of the automated reviewer's four findings, one was real and important, one had
+already been fixed, and two did not apply to the code as written. The real one
+disables the move on an entire platform; a maintainer agreed in the thread
+that the check should go; it is still there. The pull request was then marked
+stale.
+
+The question that would have unblocked it -- *"Do you have QoR results for the
+public designs?"* -- is not among the inline threads at all. Nobody answered
+it. That is the gap a score is for, and it is why the review being thorough
+did not help.
+
 ## What was measured
 
 These numbers come from an actual run, not an estimate. sky130hd/aes, 18383
@@ -157,6 +214,40 @@ What 30 minutes buys:
 request. What can run per-commit is the free tier; the measured tier runs on
 demand and its output is the ledger. Confusing the two turns an instrument
 into an unmaintainable CI burden.
+
+## The weakness: bespoke cost per pull request
+
+The strongest objection, and it comes from the exercise that motivated this
+document. Scoring 10662 needed work that no harness derived:
+
+* **A seam in ORFS.** `patches/0050` cuts `global_route.tcl` between routing
+  and incremental repair so one routed design can feed many repair
+  configurations. Worth being precise about what it bought: without it the
+  study still works, each leaf just re-runs pin access and routing for another
+  13 minutes. **The seam bought budget compliance, not correctness.** It is
+  also per *stage*, not per pull request -- every post-GR repair change reuses
+  it -- so the cost is bounded at maybe five to ten seams for the whole flow.
+* **Per-change semantics, which do not automate away.** Where the change acts,
+  what turns it on, and what counts as "it fired". For 10662: a repair move,
+  opt-in via `-sequence`, self-reporting through `Replaced N buffers with
+  inverters`. All three came from reading the source.
+* **Instrumentation asymmetry, the worst case.** The admission rule rests on
+  the algorithm reporting its own actions. rsz happens to print that count; a
+  change in `gpl` or `drt` may print nothing comparable, and then counting has
+  to be *added*. Add it only to the arm and the comparison is corrupted; add
+  it to both and neither binary is the one under review. There is no clean
+  answer, only disclosure.
+
+So the honest scope is narrower than the pitch: **cheap for the Nth pull
+request in a class already paid for, expensive for the first of a new class.**
+The rsz move cohort is cheap now because 10662 paid the entry fee; a `drt`
+change starts from zero.
+
+That should be falsifiable rather than argued. **Record the setup cost per
+pull request in the ledger** beside the verdict -- seams written, gate
+predicate lines, whether instrumentation was needed. If that cost does not
+fall sharply by the second and third pull request in a class, the idea has
+failed on its own terms and should be dropped rather than defended.
 
 ## What is deliberately not decided
 

--- a/ideas/qor-score.md
+++ b/ideas/qor-score.md
@@ -1,0 +1,174 @@
+# Scoring an OpenROAD pull request: a Pareto front and a design ledger
+
+> **Status: idea, not a plan.** Written 2026-09-06 while scoring a single
+> pull request by hand. Everything under "What was measured" is measured;
+> everything under "The idea" is not built. The immediate work is scoring one
+> pull request end to end, and this document exists so the larger shape is
+> recorded rather than rebuilt from memory later.
+
+## The problem
+
+An OpenROAD pull request that changes QoR cannot easily be given an opinion.
+The evidence a maintainer needs costs days of flow wrangling to produce, so
+asking for it is close to equivalent to closing the pull request, and the
+change either stalls or is merged on faith. Neither outcome tells anyone
+whether the algorithm helps.
+
+The existing answer is golden files. A change either leaves `.ok` files alone
+or rebaselines them, which converts every quality trade into "the goldens
+moved" -- a fact carrying no direction. A contributor who improves WNS at the
+cost of area has no vocabulary to say so and no way to be believed.
+
+## What was measured
+
+These numbers come from an actual run, not an estimate. sky130hd/aes, 18383
+instances, ~10 cores busy, forked at the seam `patches/0050` cuts between
+global routing and incremental repair:
+
+| phase | wall time |
+|---|---|
+| shared prefix: CTS, post-CTS repair, pin access, routing | ~13 min |
+| each repair leaf | ~22 min |
+| one arm, end to end | 35 min |
+
+**The noise floor is exactly zero.** Two leaves with identical configuration,
+forked off one routed prefix, returned bit-identical metrics -- WNS
+`-0.1868625307379131` twice, same TNS, same instance count, same buffer count,
+same area. Only wall-clock differed, by one second.
+
+That is the load-bearing measurement. It means better/worse can be *decided*
+rather than argued, without statistics. It also means that when a flow-level
+A/B of a repair change produces "some designs better, some worse", the cause
+is not run-to-run variance: repair runs at floorplan, place, CTS and global
+route, so an early difference changes the placement and everything after it.
+The ambiguity is confounding, and no amount of hardware fixes it. Forking one
+stage off a shared prefix does.
+
+## The idea
+
+### A verdict vocabulary, with the nulls named
+
+    not-applicable   a platform or library gate closed before the algorithm
+                     was reachable at all
+    inert            reachable, ran, committed nothing
+    better           dominates on every declared axis
+    worse            dominated on every declared axis
+    trade            better on some axes, worse on others
+    not-scored       the budget ran out; the count is UNKNOWN, not zero
+
+The last two are the ones that matter. `trade` is the vocabulary the golden
+files lack. `not-scored` exists because a killed leaf and a leaf that
+committed nothing produce identical silence in the log, and reporting the
+first as the second publishes a null as a result.
+
+**No verdict is admissible unless the algorithm's own committed-move count is
+non-zero and the phase is known to have completed.** Most arms measure
+nothing; a scorer that does not check this reports noise as an effect.
+
+### A front, not a default
+
+`repair_timing -sequence` is already a configuration space and the moves are
+already the algorithms under development, so a front over sequences is a name
+for what the architecture implies rather than a new concept.
+
+The value is that it changes the reviewable question from "is this better?",
+which is usually unanswerable, to "does this add an undominated point, and
+which region does it own?", which is decidable and cheap. A change that helps
+wire-dominated designs and hurts others currently has to beat the default
+everywhere or die; on a front it has somewhere to land.
+
+Three constraints, or it rots:
+
+* **Never average across designs.** The front is per design; the aggregate is
+  a count of dominance. A mean over designs where the change is inert dilutes
+  toward zero and reports as a small win -- which is exactly the shape of the
+  unfalsifiable "average improvement on public CI benchmarks" claim that
+  motivates this document.
+* **A relevance gate.** A degenerate variant can be undominated at a corner
+  no real design occupies. Without a gate the front becomes a museum.
+* **A retirement rule.** Every point on the front is code someone maintains
+  through every refactor. Dominated points get deleted.
+
+A front does not choose the default. Somebody still has to say what runs when
+the user says nothing, and that is a policy decision that should be made out
+loud rather than fall out of a chart.
+
+### The ledger is the durable artifact
+
+Not the harness -- the accumulated record of **per-design yield**: which
+designs produce verdicts, for which classes of change, and which have never
+produced one. A design that scores `inert` for every change ever measured is
+spending CI time and returning no information, and this says so with a number.
+One that is the only design to catch some change is load-bearing and must
+never be dropped.
+
+That is a measured answer to "what should OpenROAD test", and it is the half
+of this that gets more valuable with each pull request scored, rather than
+being read once.
+
+Its sharpest use is the **minimum sufficient design**: the cheapest design
+that still yields a verdict for a given class of change. Under a fixed budget,
+choosing the design *is* the score's central decision.
+
+### Calibrate by back-testing merged pull requests
+
+Merged QoR changes are free ground-truth labels: hundreds of changes
+maintainers believed were improvements. Running them through the scorer gives
+the suite a property it currently lacks -- a detection rate -- and turns "our
+benchmark set is good" from an assertion into a measurement.
+
+Two cautions:
+
+* **Revert-from-master is not the counterfactual.** It measures removing a
+  change from a tree that has grown around it. The true counterfactual is
+  applying forward at the merge base. Use revert as a cheap screen and apply
+  forward for what the screen flags.
+* **"Merged" is a noisy label.** Many changes merge without anyone measuring
+  anything, so an inert back-test cannot distinguish a blind suite from a
+  change that did nothing. Only the committed-move count separates them.
+
+The natural first cohort is the rsz move pull requests: self-contained
+additions gated behind `repair_timing -sequence`, so the A/B is a string
+rather than a build.
+
+## The budget decides the shape
+
+The score gets **30 minutes on one CI server**. Against the measured costs
+above, three arms run sequentially on one design is 105 minutes, so the shape
+follows from the budget rather than the other way round:
+
+1. **Cache the pre-repair routed ODB.** The prefix is a pure function of
+   (design, base binary) and is currently recomputed identically per arm --
+   13 minutes burned three times to produce the same bytes. The seam that
+   creates the fork point is where the cache cut belongs. A cache *miss* means
+   no score, not a slow score.
+2. **Run arms concurrently.** Separate processes, different binaries.
+3. **Spend the budget on one design**, chosen by the ledger.
+
+What 30 minutes buys:
+
+| tier | cost | result |
+|---|---|---|
+| static gate | seconds | `not-applicable` verdicts, free |
+| bit-identity check | one hash | full verdict for the "byte-identical, faster" class |
+| one scored design | ~22 min | one region, one verdict |
+
+**A durable test here does not mean a CI gate.** Flow runs cannot gate a pull
+request. What can run per-commit is the free tier; the measured tier runs on
+demand and its output is the ledger. Confusing the two turns an instrument
+into an unmaintainable CI burden.
+
+## What is deliberately not decided
+
+* Where the ledger lives, and what the target is called.
+* Whether reducing `-repair_tns` or capping `max_passes` to fit the budget
+  preserves the verdict. It cuts leaf time directly and it can silently make
+  an arm inert, so it is adoptable only after a full run and a reduced run are
+  shown to agree on the same change.
+* Whether a third-party score is something maintainers would act on. Untested,
+  and the only way to find out is to produce one.
+
+## What is happening instead, now
+
+Scoring a single pull request end to end. If that does not produce something a
+maintainer can hold an opinion about, none of the above is worth building.


### PR DESCRIPTION
A yak-shave, parked. Recorded because it came up while scoring one pull request by hand, and the shape is worth keeping even though building it is not the work right now.

The document is explicit about which half is which: **the costs and the noise floor are measured; everything after "The idea" is not built.**

## The measured half

sky130hd/aes, forked at the `patches/0050` seam between global routing and incremental repair:

| phase | wall time |
|---|---|
| shared prefix (CTS, post-CTS repair, pin access, routing) | ~13 min |
| each repair leaf | ~22 min |
| one arm end to end | 35 min |

**The noise floor is exactly zero.** Two leaves with identical configuration returned bit-identical metrics — WNS `-0.1868625307379131` twice, same TNS, instance count, buffer count, area. Only wall-clock differed, by one second.

That is the load-bearing result. `better`/`worse` can be *decided* rather than argued, with no statistics. And the familiar "some designs better, some worse" outcome of a flow-level A/B is **confounding, not variance**: repair runs at floorplan, place, CTS and global route, so an early difference moves the placement and everything downstream. No amount of hardware fixes that. Forking one stage off a shared prefix does.

## The idea half

- A verdict vocabulary that **names its nulls** — `not-applicable`, `inert`, `not-scored (budget)` — and refuses any verdict unless the algorithm's own committed-move count is non-zero and the phase is known to have completed. A killed leaf and a leaf that committed nothing produce identical silence in the log; reporting the first as the second publishes a null as a result.
- A **front over `repair_timing` sequences** rather than one blessed default, so a change that helps wire-dominated designs and hurts others has somewhere to land instead of having to beat the default everywhere or die. With three constraints or it rots: never average across designs, gate for relevance, retire dominated points.
- A **ledger of per-design yield** — the durable artifact, because it answers "what should OpenROAD test" with a number, and grows more useful with each pull request scored rather than being read once. Its sharpest use is the *minimum sufficient design*: the cheapest design that still yields a verdict for a class of change.
- **Back-testing merged pull requests** as calibration, with its two traps: revert-from-master is not the counterfactual, and "merged" is a noisy label.

## What the 30-minute budget does to it

Three arms sequentially on one design is 105 minutes, so the shape follows from the budget: cache the pre-repair routed ODB (13 min recomputed three times to produce the same bytes), run arms concurrently, spend the budget on one design chosen by the ledger. And a durable test here does **not** mean a CI gate — the free tier (static gate, bit-identity hash) can run per-commit; the measured tier runs on demand.

## Not decided

Where the ledger lives, whether trimming `-repair_tns` to fit the budget preserves the verdict, and whether a third-party score is something maintainers would act on at all.

The last section says what is happening instead: **scoring one pull request end to end.** If that produces nothing a maintainer can hold an opinion about, none of the rest is worth building.

`//:fix_lint` clean.