### PR TITLE
build: bump openroad to 5d6f167322 (master HEAD)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ bazel_dep(name = "sv-elab", version = "2026-07-07")
 bazel_dep(name = "openroad")
 archive_override(
     module_name = "openroad",
-    integrity = "sha256-yFYlQ1zckLkO3aarUqj18Fia3au5AJgbWJvELQ4prbI=",
+    integrity = "sha256-9u+fk79uPulUTtQ0b8nFVdHSFpx4cSfgLmwkXz4RrbA=",
     # GitHub /archive/<sha>.tar.gz tarballs don't carry submodules,
     # so vendor src/sta (OpenSTA) and third-party/abc from their own
     # GitHub auto-archives at the SHAs OpenROAD's .gitmodules pins
@@ -63,8 +63,8 @@ archive_override(
         "find . -name BUILD -exec sed -i 's|\"@slang\"|\"@sv-lang//:libsvlang\"|g' {} +",
         "sed -i 's|defines = \\[|copts = [\"-include\", \"fmt/format.h\"],\\n    defines = [|' src/syn/src/elab/BUILD third-party/slang-elab/src/BUILD",
     ],
-    strip_prefix = "OpenROAD-63fe72c577ef12d2ac2a0a944bbd842f9af8a0a7",
-    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/63fe72c577ef12d2ac2a0a944bbd842f9af8a0a7.tar.gz"],
+    strip_prefix = "OpenROAD-5d6f1673228eb21d6e4b55ccaf1234790e31d6e8",
+    urls = ["https://github.com/The-OpenROAD-Project/OpenROAD/archive/5d6f1673228eb21d6e4b55ccaf1234790e31d6e8.tar.gz"],
 )
 
 # OpenROAD pins sv-lang 10.0.bcr.2, which is not yet published in BCR.


### PR DESCRIPTION
`bazelisk run //:bump -- --head=openroad`, run as a dogfood of the bumper now that #944 removed the pin window and its dated bookkeeping.

**Single concern:** the openroad pin. `archive_override(module_name = "openroad")` moves to `5d6f1673228e` — OpenROAD's own master HEAD, ahead of the sha ORFS's `tools/OpenROAD` submodule carries — with the matching integrity. ORFS was already at its target commit (`68cc9bc97450`), so the re-hash was skipped and its pin is untouched. `MODULE.bazel.lock` needed no update.

```
  orfs already at target commit; skipping re-hash
Updated MODULE.bazel (bazel-orfs project):
  orfs -> 68cc9bc97450
  qt-bazel -> 5587ebcaf61b
  yosys -> 0.68.bcr.1 (BCR <= ORFS tools/yosys 0.68)
  openroad -> 5d6f1673228e (HEAD of The-OpenROAD-Project/OpenROAD)
```

**What the dogfood was checking:** the run left nothing behind in the tree except the pin it was asked to move. No `bump_reference_date.txt` reappeared, and with the window gone a self-bump makes one fewer GitHub API call.

## Verification

- `bazelisk fetch @openroad//:openroad` — the new archive downloads, the integrity verifies, and the submodule-vendoring `patch_cmds` (OpenSTA, abc) plus the sv-lang/slang `sed` rewrites all apply.
- `bazelisk run //:fix_lint`, `bazelisk run //:public_surface` — both clean.
- A full source build of `@openroad//:openroad` at this pin is running locally; CI covers it too. Since `--head=openroad` deliberately runs ahead of ORFS's pin, that build is the check worth waiting for before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)