### PR TITLE
chore(hooks): exempt the agent's own /tmp tree, tiny files only

### DIFF
--- a/.claude/hooks/guard_tool.py
+++ b/.claude/hooks/guard_tool.py
@@ -32,7 +32,9 @@ prose can never drift from what is actually enforced.
 """
 
 import json
+import os
 import re
+import stat
 import sys
 
 # Keys the two dialects use for the shell command, the working directory, and
@@ -78,6 +80,20 @@ CACHE_DIR = re.compile(r"(^|/)\.cache(/|$)")
 # Matches /tmp and /tmp/..., but not ./tmp or /somewhere/tmp.
 TMP_DIR = re.compile(r"^/tmp(/|$)")
 TMP_IN_COMMAND = re.compile(r"(?<![\w./])/tmp(?:/|(?![\w/]))")
+# The whole /tmp path, so each one can be judged on its own merits.
+TMP_PATH_IN_COMMAND = re.compile(r"(?<![\w./])(/tmp(?:/[^\s;&|<>()\'\"]*)?)")
+
+# The agent's own tree under /tmp, which it does not get to choose: bundled
+# skill assets live at hardcoded `/tmp/claude-<uid>/bundled-skills/...` paths
+# and session files at `/tmp/claude-<uid>/<project>/<session>/...`. This is
+# the only part of /tmp the exemption reaches -- the rest stays blocked, so
+# the rule still means what it says.
+AGENT_TMP_TREE = re.compile(r"^/tmp/claude-\d+/")
+
+# ... and only for a file small enough that reading it cannot be the scratch
+# use the rule exists to prevent. A big session log is read with the task
+# tool, not with `cat`.
+TMP_TINY_BYTES = 64 * 1024
 
 READ_TOOLS = r"find|grep|tree|ls|fd|rg|cat|head|tail|less|sed|awk|wc|diff"
 SPELUNK_IN_COMMAND = re.compile(
@@ -106,7 +122,11 @@ GH_MERGE = re.compile(
     r"|branches/[^/\s]+/protection)"
 )
 
-TMP_MESSAGE = "Using /tmp is forbidden (it is small and shared). Always use ./tmp."
+TMP_MESSAGE = (
+    "Using /tmp is forbidden (it is small and shared). Always use ./tmp. The only "
+    "exception is an existing file of at most 64 KiB inside the agent's own "
+    "/tmp/claude-<uid>/ tree (bundled skill assets, session files)."
+)
 
 
 def strip_data_spans(command):
@@ -236,11 +256,33 @@ def check_cmake(request):
     return None
 
 
+def tmp_exempt(path):
+    """True when `path` is a small existing file in the agent's own /tmp tree.
+
+    Both halves matter. The tree keeps the exemption from opening /tmp up as
+    scratch space -- nothing the agent chooses the name of is in there. The
+    rest is deliberately a question about what is already on disk: a path
+    that is not there yet is a new scratch file, and a directory is a scratch
+    location, which is what the rule is for.
+    """
+    if not AGENT_TMP_TREE.match(path):
+        return False
+    try:
+        info = os.stat(path)
+    except OSError:
+        return False
+    return stat.S_ISREG(info.st_mode) and info.st_size <= TMP_TINY_BYTES
+
+
 def check_tmp(request):
     if request.code and TMP_IN_COMMAND.search(request.code):
-        return TMP_MESSAGE
+        # Judge every /tmp path in the command, not just the first: one
+        # oversized or not-yet-existing path is enough to deny the call.
+        found = TMP_PATH_IN_COMMAND.findall(request.code)
+        if not found or not all(tmp_exempt(path) for path in found):
+            return TMP_MESSAGE
     for path in request.paths:
-        if TMP_DIR.match(path):
+        if TMP_DIR.match(path) and not tmp_exempt(path):
             return TMP_MESSAGE
     return None
 
@@ -294,7 +336,11 @@ RULES = (
     (
         "tmp",
         "The use of the global `/tmp` directory is blocked. Always use a local "
-        "`./tmp` directory for scratch work.",
+        "`./tmp` directory for scratch work. Narrowly exempted: an existing "
+        "regular file of at most 64 KiB inside the agent's own "
+        "`/tmp/claude-<uid>/` tree, so the hardcoded paths of bundled skill "
+        "assets and session files stay reachable; the rest of `/tmp` stays "
+        "blocked.",
         check_tmp,
     ),
 )

--- a/.claude/hooks/guard_tool_test.py
+++ b/.claude/hooks/guard_tool_test.py
@@ -9,13 +9,22 @@ which is exactly how the two drifted apart before they shared this script.
 
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 GUARD = os.path.join(HERE, "guard_tool.py")
 CLAUDE_MD = os.path.join(HERE, os.pardir, os.pardir, "CLAUDE.md")
+
+# The /tmp rule now exempts small existing files inside the agent's own tree,
+# so a table case has to name a path that is *not* there -- "/tmp/x" is a
+# plausible thing for someone to have left lying around, and the table would
+# then be testing the machine rather than the policy. TmpExemptionTest
+# asserts this prefix is absent.
+ABSENT = "/tmp/guard_tool_test.absent"
 
 # (field, value, expected) — expected is None for "allowed", otherwise a
 # substring the deny reason must contain.
@@ -111,17 +120,21 @@ CASES = [
     # ... but a quoted single argument is still an argument.
     ("command", 'grep -rn foo "bazel-out/k8-fastbuild"', "context explosion"),
     ("command", 'git checkout "main"', "verboten"),
-    ("command", 'cat "/tmp/x"', "./tmp"),
+    ("command", f'cat "{ABSENT}/x"', "./tmp"),
     ("command", "cat <<'EOF' > note.md\nnever run bazel clean\nEOF", None),
     # --- /tmp ------------------------------------------------------------
+    ("command", f"mkdir -p {ABSENT}/scratch", "./tmp"),
+    ("command", f"python3 run.py --out {ABSENT}/x.json", "./tmp"),
     ("command", "mkdir -p /tmp/scratch", "./tmp"),
-    ("command", "python3 run.py --out /tmp/x.json", "./tmp"),
     ("command", "mkdir -p ./tmp/scratch", None),
     ("command", "cat ./tmp/notes.txt", None),
-    ("path", "/tmp/scratch/x", "./tmp"),
+    ("path", f"{ABSENT}/x", "./tmp"),
+    ("path", "/tmp", "./tmp"),
     ("path", "./tmp/scratch/x", None),
     ("path", "/var/tmp/x", None),
     ("cwd", "/tmp", "./tmp"),
+    # The narrow exemption cannot be expressed here: whether a /tmp path is
+    # allowed depends on what is on disk. See TmpExemptionTest.
 ]
 
 # How each neutral field is spelled in each dialect. A field absent from a
@@ -207,6 +220,88 @@ class PolicyTest(unittest.TestCase):
                     value,
                     expected,
                 )
+
+
+class TmpExemptionTest(unittest.TestCase):
+    """The narrow /tmp exemption, against real files.
+
+    Every other rule is a question about a string, which is why the table
+    above can hold them. This one asks the filesystem whether a path is an
+    existing, small, regular file, so these cases have to create something
+    for it to answer about.
+    """
+
+    def setUp(self):
+        # Mirror the shape the agent's environment really uses, since the
+        # exemption is scoped to it: /tmp/claude-<uid>/...
+        tree = f"/tmp/claude-{os.getuid()}"
+        try:
+            os.makedirs(tree, exist_ok=True)
+            self.directory = tempfile.mkdtemp(dir=tree, prefix="guard_tool_test.")
+            self.outside = tempfile.mkdtemp(dir="/tmp", prefix="guard_tool_test.")
+        except OSError as error:  # pragma: no cover - sandbox without /tmp
+            self.skipTest(f"/tmp is not writable here: {error}")
+        self.addCleanup(shutil.rmtree, self.directory, ignore_errors=True)
+        self.addCleanup(shutil.rmtree, self.outside, ignore_errors=True)
+
+    def make(self, name, size, directory=None):
+        path = os.path.join(directory or self.directory, name)
+        with open(path, "wb") as handle:
+            handle.write(b"x" * size)
+        return path
+
+    def reason(self, field, value):
+        """The Claude-dialect deny reason for one field, or None."""
+        return claude_reason(run_guard(CLAUDE_PAYLOAD[field](value)))
+
+    def test_the_tables_absent_prefix_is_really_absent(self):
+        # If this fails, the /tmp cases in CASES are testing the machine's
+        # leftovers rather than the policy.
+        self.assertFalse(os.path.exists(ABSENT), f"{ABSENT} exists; CASES is unsound")
+
+    def test_tiny_file_is_allowed(self):
+        path = self.make("small.md", 4096)
+        self.assertIsNone(self.reason("path", path))
+        self.assertIsNone(self.reason("command", f"cat {path}"))
+
+    def test_file_at_the_limit_is_allowed(self):
+        path = self.make("exactly.md", 64 * 1024)
+        self.assertIsNone(self.reason("path", path))
+
+    def test_file_over_the_limit_is_denied(self):
+        path = self.make("big.log", 64 * 1024 + 1)
+        self.assertIn("./tmp", self.reason("path", path) or "")
+        self.assertIn("./tmp", self.reason("command", f"cat {path}") or "")
+
+    def test_directory_is_denied(self):
+        # A directory is a scratch location, which is the whole point of the
+        # rule -- being small does not make /tmp a place to work in.
+        self.assertIn("./tmp", self.reason("path", self.directory) or "")
+
+    def test_missing_file_is_denied(self):
+        path = os.path.join(self.directory, "not-there-yet.json")
+        self.assertIn("./tmp", self.reason("path", path) or "")
+        self.assertIn("./tmp", self.reason("command", f"echo hi > {path}") or "")
+
+    def test_one_bad_path_denies_the_whole_command(self):
+        allowed = self.make("small.md", 128)
+        missing = os.path.join(self.directory, "out.json")
+        command = f"cp {allowed} {missing}"
+        self.assertIn("./tmp", self.reason("command", command) or "")
+
+    def test_tiny_file_outside_the_agent_tree_is_denied(self):
+        # The exemption is not "small files in /tmp are fine". A file the
+        # agent could have chosen the name of stays blocked however small.
+        path = self.make("small.md", 64, directory=self.outside)
+        self.assertIn("./tmp", self.reason("path", path) or "")
+        self.assertIn("./tmp", self.reason("command", f"cat {path}") or "")
+
+    def test_exemption_does_not_reach_other_rules(self):
+        # A tiny file under /tmp is exempt from the /tmp rule only. Anything
+        # else the command does is judged as it always was.
+        path = self.make("note.md", 64)
+        command = f"bazel clean && cat {path}"
+        self.assertIn("protects bazel cache", self.reason("command", command) or "")
 
 
 class ProtocolTest(unittest.TestCase):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ and missing for the other.
 - Deleting, moving or force-updating a local `master`/`main` (`git branch -f/-D`, `git update-ref`, `git worktree add`) is blocked.
 - Merging pull requests (`gh pr merge`, or a merge or branch-protection write through `gh api`) is blocked; merging is the human's call.
 - Spelunking in `bazel-*` output directories and `.cache` using native tools (`grep`, `find`, `cat`) or agent file-reading tools is blocked to prevent context explosion.
-- The use of the global `/tmp` directory is blocked. Always use a local `./tmp` directory for scratch work.
+- The use of the global `/tmp` directory is blocked. Always use a local `./tmp` directory for scratch work. Narrowly exempted: an existing regular file of at most 64 KiB inside the agent's own `/tmp/claude-<uid>/` tree, so the hardcoded paths of bundled skill assets and session files stay reachable; the rest of `/tmp` stays blocked.
 
 The list above is asserted equal to `guard_tool.py --explain` by
 `//:guard_tool_test`, so it cannot drift from what is actually enforced.


### PR DESCRIPTION
## The problem

The `/tmp` hard stop exists because `/tmp` is small and shared, and it does that job. But it also blocks the one part of `/tmp` an agent does not choose: bundled skills ship at hardcoded `/tmp/claude-<uid>/bundled-skills/...` paths, and session files at `/tmp/claude-<uid>/<project>/<session>/...`.

So a skill that instructs the agent to read its own reference files or run its own validator script could not be followed in this repository at all — not with `cat`, not with the file-reading tools, and not even by copying the bundle into `./tmp` first, since reading the source is itself a `/tmp` access. The failure is silent about its cause: the skill simply cannot be complied with.

## The change

Exempt exactly that, and nothing else: **an existing regular file of at most 64 KiB inside `/tmp/claude-<uid>/`.**

Every clause carries weight:

- **The tree scoping** is what keeps this from re-opening `/tmp` for general use. No path the agent picked the name of is ever exempt, so `/tmp` cannot become scratch space by this door.
- **Existing, and a regular file** — deliberately a question about what is already on disk. A path that is not there yet is a new scratch file; a directory is a scratch location. Both are what the rule is for, and both stay blocked, so `/tmp` can still never be a working directory.
- **64 KiB** keeps a large session log going through the task tool rather than `cat`, which is the context-explosion instinct the neighbouring spelunking rule encodes.

The command form judges *every* `/tmp` path on the line rather than just the first, so one oversized or not-yet-existing path denies the call. A path behind a shell variable stays denied — the guard cannot see what it expands to and does not guess.

## Test soundness bug found on the way

Two existing table cases named `/tmp/x` and `/tmp/scratch` — paths a machine may well have lying around. On this machine `/tmp/x` exists and is tiny, so with the exemption in place that case started passing for the wrong reason: it was testing the filesystem rather than the policy. Those cases now name a prefix that a new test asserts is absent.

The exemption itself cannot be expressed in the string table, because whether a path is allowed depends on what is on disk. It gets its own test class, which creates real files and checks both sides of the boundary — inside the agent's tree and outside it, at the size limit and over it, a directory, and a missing file — plus that a tiny exempt file does not shield the rest of a command line from the other rules.

## Verification

- `//:guard_tool_test`, `//test:fix_lint_test`, `//test:public_surface_test` pass.
- `//:fix_lint` and `//:public_surface` clean.
- `CLAUDE.md` is byte-equal to `guard_tool.py --explain`, as `//:guard_tool_test` asserts.
- Checked live rather than only in tests: a bundled skill's own 9 KB reference file and 18 KB validator script are reachable now, and the validator runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
