### PR TITLE
fix(hooks): $(pwd)/tmp is not /tmp

### DIFF
--- a/.claude/hooks/guard_tool.py
+++ b/.claude/hooks/guard_tool.py
@@ -79,9 +79,15 @@ BAZEL_OUTPUT_DIR = re.compile(r"(^|/)bazel-(out|bin|testlogs)(/|$)")
 CACHE_DIR = re.compile(r"(^|/)\.cache(/|$)")
 # Matches /tmp and /tmp/..., but not ./tmp or /somewhere/tmp.
 TMP_DIR = re.compile(r"^/tmp(/|$)")
-TMP_IN_COMMAND = re.compile(r"(?<![\w./])/tmp(?:/|(?![\w/]))")
+# What may not precede a real `/tmp`: a word character, `.` or `/` (so
+# `./tmp` and `/var/tmp` are someone else's directory), and also the three
+# ways a shell spells a path that only looks like it starts at the root --
+# `$(pwd)/tmp`, `${HOME}/tmp` and `~/tmp` are all local scratch, and denying
+# them sends the agent looking for a rule it has not broken.
+NOT_TMP = r"(?<![\w./)}~])"
+TMP_IN_COMMAND = re.compile(NOT_TMP + r"/tmp(?:/|(?![\w/]))")
 # The whole /tmp path, so each one can be judged on its own merits.
-TMP_PATH_IN_COMMAND = re.compile(r"(?<![\w./])(/tmp(?:/[^\s;&|<>()\'\"]*)?)")
+TMP_PATH_IN_COMMAND = re.compile(NOT_TMP + r"(/tmp(?:/[^\s;&|<>()\'\"]*)?)")
 
 # The agent's own tree under /tmp, which it does not get to choose: bundled
 # skill assets live at hardcoded `/tmp/claude-<uid>/bundled-skills/...` paths

--- a/.claude/hooks/guard_tool_test.py
+++ b/.claude/hooks/guard_tool_test.py
@@ -133,6 +133,14 @@ CASES = [
     ("path", "./tmp/scratch/x", None),
     ("path", "/var/tmp/x", None),
     ("cwd", "/tmp", "./tmp"),
+    # A path that merely ends in /tmp is not the global one. Every one of
+    # these is local scratch, and denying it sends the agent hunting for a
+    # rule it has not broken.
+    ("command", f"cp note.md $(pwd)/tmp/x", None),
+    ("command", "cp note.md ${PWD}/tmp/x", None),
+    ("command", "ls ~/tmp", None),
+    ("command", "ls $HOME/tmp", None),
+    ("path", "/var/tmp/x", None),
     # The narrow exemption cannot be expressed here: whether a /tmp path is
     # allowed depends on what is on disk. See TmpExemptionTest.
 ]


### PR DESCRIPTION
The `/tmp` matcher's lookbehind excludes a word character, `.` and `/`, so `./tmp` and `/var/tmp` are correctly left alone. It does not exclude the three ways a shell writes a path that only *looks* like it starts at the root:

```sh
cp x $(pwd)/tmp/y      # denied
cp x ${PWD}/tmp/y      # denied
ls ~/tmp               # denied
```

All three are ordinary local scratch. The first two came up in real use today.

A false denial is worse than a missed one here: the agent is told it broke a rule it did not break, so it goes looking for the rule rather than for the `)` in its own command line.

Adds `)`, `}` and `~` to the lookbehind, plus four table cases. The rule itself is unchanged, so `CLAUDE.md` is untouched and `//:guard_tool_test`'s doc assertion still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
