### PR TITLE
build: quiet the two warnings every //:bump run prints

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -112,6 +112,14 @@ py_binary(
         "bump.py",
         "bump_impl.py",
     ],
+    # rules_python's implicit __init__.py creation is deprecated and warns on
+    # every run (bazel-contrib/rules_python#2945). The module-wide opt-out
+    # (rules_python_config.explicit_init_py) is root-honored only, so it would
+    # silence the warning here and leave it in place for everyone running
+    # `bazelisk run @bazel-orfs//:bump`; setting it on the target travels with
+    # the target. bump.py imports nothing from the workspace, so there is no
+    # package to make importable.
+    legacy_create_init = 0,
     main = "bump.py",
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -254,6 +254,14 @@ bazel_dep(
     version = "2.3.2",
 )
 
+# No implicit __init__.py in any py target of this repo: the behaviour is
+# deprecated upstream (bazel-contrib/rules_python#2945) and warns on every
+# fresh analysis. Root-honored only, so it covers this repo's own targets;
+# the shipped public tools set legacy_create_init on the target instead, so
+# downstream consumers running them stay quiet too.
+rules_python_config = use_extension("@rules_python//python/extensions:config.bzl", "config")
+rules_python_config.explicit_init_py(default = True)
+
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",
     "python",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -244,9 +244,14 @@ register_toolchains(
     dev_dependency = True,
 )
 
+# 2.3.2, not 2.0.0: every module in the graph that depends on rules_python
+# (protobuf, sv-lang, yosys, rules_pkg, ...) asks for 2.3.2, so MVS resolves
+# there and a lower root pin only buys a --check_direct_dependencies warning
+# on every invocation. Raise this to whatever `bazelisk mod explain
+# rules_python` reports once a bump moves the graph again.
 bazel_dep(
     name = "rules_python",
-    version = "2.0.0",
+    version = "2.3.2",
 )
 
 python = use_extension(


### PR DESCRIPTION
`bazelisk run //:bump` printed two warnings on every invocation. Neither
was about the bump itself.

**1. Version mismatch.** The root pinned `rules_python` at 2.0.0 while the
resolved graph is 2.3.2:

```
WARNING: For repository 'rules_python', the root module requires module
version rules_python@2.0.0, but got rules_python@2.3.2 in the resolved
dependency graph.
```

`bazelisk mod explain rules_python` says nothing in the graph asks for
anything below 2.3.2 — protobuf, sv-lang, yosys, rules_pkg, rules_pycross
and the rest all want 2.3.2 — so the low pin bought a warning and nothing
else. Pinned at the version MVS resolves.

**2. Implicit `__init__.py`.** rules_python deprecated implicit
`__init__.py` creation (bazel-contrib/rules_python#2945) and warns per
target on fresh analysis. Two commits, because the two fixes are not
interchangeable:

- `legacy_create_init = 0` on `//:bump`. The module-wide opt-out
  (`rules_python_config.explicit_init_py`) is root-honored only, so it
  would quiet this repo and leave the warning in place for everyone
  running `bazelisk run @bazel-orfs//:bump`. Setting it on the target
  travels with the target.
- `explicit_init_py(default = True)` for the repo, because `//:bump` was
  never the only target that warned — `//:fix_lint` and every other py
  target does too.

## Verification

- All 34 `py_test` targets: 34 pass. Nothing was relying on an implicit
  `__init__.py` to make a package importable.
- Fresh analysis of `//:bump //:fix_lint //:public_surface` after a
  `shutdown` prints no WARNING and no DEBUG.
- `//:fix_lint` and `//:public_surface` clean.

Commits are one concern each, smallest diff first.