### PR TITLE
fix(pin): //tools/pin was dead on every distro with python < 3.10, and guard the host-tool surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
       - name: Public surface
         run: bazelisk run //:public_surface
 
+      # What a consumer must already have installed: see host_tools.py for
+      # the denied tools and the host-python version floor.
+      - name: Host tools
+        run: bazelisk run //:host_tools
+
       # --- @orfs design packages ---
       #
       # Loading every design package catches API skew between this repo and

--- a/BUILD
+++ b/BUILD
@@ -275,6 +275,24 @@ py_binary(
     main = "public_surface.py",
 )
 
+# `bazelisk run //:host_tools` checks what a consumer must already have
+# installed: no shipped script or patch_cmds entry reaching for a tool a
+# stock Linux install may not have, and no host-run python file using
+# syntax newer than the oldest supported distro's python3 (3.6). CI runs
+# it after the public surface check. Reads the tree through git, so it is
+# a run, not a hermetic test; //test:host_tools_test covers the rules.
+py_library(
+    name = "host_tools_lib",
+    srcs = ["host_tools.py"],
+    visibility = ["//test:__pkg__"],
+)
+
+py_binary(
+    name = "host_tools",
+    srcs = ["host_tools.py"],
+    main = "host_tools.py",
+)
+
 # Not public: buildifier_prebuilt is a dev dependency, so this can only
 # ever run from a clone of this repo.
 py_binary(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,16 @@ nothing shipped uses, on a shipped file naming a dev-only repo, and on a
 public target under `test/`; the docstring in `public_surface.py` is the
 policy. CI runs it after lint.
 
+When touching a shell script, a `patch_cmds` entry, or a python file the
+host interpreter runs, also run `bazelisk run //:host_tools`. Bazelisk is
+the only thing a consumer must install; beyond it, nothing may be needed
+that has not been on every supported Linux for a decade. It fails on a
+denied tool (`jq`, `yq`, `perl`, `docker`, `cmake`, ...) in a shipped
+script or `patch_cmds`, on an undeclared host-`python3` call site, and on
+a host-run python file whose syntax floor is above 3.6 (RHEL 8, SLES 15);
+the docstring in `host_tools.py` is the policy. CI runs it after
+`//:public_surface`.
+
 ## Bumping
 
 `bazelisk run //:bump` rewrites the override shapes it recognizes and

--- a/host_tools.py
+++ b/host_tools.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""The host tools bazel-orfs is allowed to rely on.
+
+README.md promises that a developer machine or a CI runner needs nothing
+but Bazelisk and a standard Linux install.  Two things quietly break that
+promise if nobody is watching:
+
+1. A shipped script, or a patch_cmds entry, reaching for a tool a stock
+   install does not have -- `jq`, `yq`, `perl`, `bc`, `docker`, `cmake`.
+
+2. A Python file that the *host* interpreter runs -- not the hermetic
+   toolchain -- using syntax newer than the oldest supported distro's
+   `python3`.  RHEL 8 and SLES 15 ship 3.6, Ubuntu 20.04 ships 3.8, and a
+   fetch-phase repository rule or a `bazel run` wrapper gets whatever is
+   on PATH.  That is not a warning: it is a SyntaxError before the first
+   line runs, and it had already happened -- tools/pin/pin.py carried a
+   match statement, so `//tools/pin` was dead on every distro older than
+   Python 3.10.
+
+Rule 1 is a denylist on purpose.  Recognising every command in a shell
+script needs a shell parser; a regex that guesses produces false positives
+until someone deletes the test.  Naming what we have decided not to depend
+on is precise, and a genuinely new dependency is usually one of these.
+
+Run it: `bazelisk run //:host_tools`.  CI runs it after the public surface
+check.  Reads the tree through git, so it is a run, not a hermetic test;
+//test:host_tools_test covers the rules.
+"""
+
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Oldest `python3` on a distro still receiving updates: RHEL 8 / SLES 15.
+HOST_PYTHON_FLOOR = (3, 6)
+
+# Python files the host interpreter runs, each with the caller that does
+# it.  Everything else runs under the hermetic toolchain (py_binary,
+# py_test) and may use whatever that toolchain supports.
+HOST_PYTHON = {
+    "config_mk_parser.py": 'private/designs.bzl: repository_ctx.which("python3")',
+    "tools/pin/pin.py": "tools/pin/pin.sh.tpl: python3 ${PINNER}",
+    "mock/klayout/src/bin/klayout.py": "mock/klayout/src/bin/klayout.sh: exec python3",
+    "mock/openroad/src/bin/openroad.py": "mock/openroad/src/bin/openroad.sh: exec python3",
+    "mock/yosys/src/bin/yosys.py": "mock/yosys/src/bin/yosys.sh: exec python3",
+    "bump.py": "runs standalone, before any toolchain exists",
+    "bump_impl.py": "bump.py: subprocess.run([sys.executable, local_impl])",
+}
+
+# Files that invoke the host python3.  Kept equal to what a scan of the
+# shipped surface finds, so a new call site has to be declared -- and with
+# it, the version floor the file it runs now has to respect.
+HOST_PYTHON_CALLERS = frozenset(
+    [
+        "mock/klayout/src/bin/klayout.sh",
+        "mock/openroad/src/bin/openroad.sh",
+        "mock/yosys/src/bin/yosys.sh",
+        "mock_klayout.bzl",
+        "private/designs.bzl",
+        "tools/pin/pin.sh.tpl",
+    ],
+)
+
+# Tools we have decided not to depend on: absent from a minimal install of
+# at least one still-supported distro, or hermetic here by design -- yq is
+# downloaded with a pinned SHA256 by load_json_file.bzl, and cmake is
+# banned outright because bazel is the only build path.
+#
+# Removing an entry is a decision about what a consumer must install.
+DENIED_TOOLS = frozenset(
+    """
+    jq yq perl bc column shuf getopt flock docker podman cmake ccmake ninja meson
+    wget rsync scp unzip zip xz zstd bzip2 numfmt pip pip3 conda brew apt apt-get
+    yum dnf pacman zypper snap gh xdg-open klayout
+    """.split(),
+)
+
+# Where a denied tool is nevertheless tolerated, and why.
+TOLERATED = {
+    # Dev convenience: opens a report in a browser. Fails loudly, and no
+    # build depends on it.
+    "open_html.sh": {"xdg-open"},
+    # Opt-in escape hatch. The default klayout is @mock_klayout, so a stock
+    # consumer never runs this. See docs/klayout.md.
+    "klayout.sh": {"klayout"},
+}
+
+# Not shipped: tests, captured reproducers, scratch, agent tooling, docs
+# and CI.  mock/ *is* shipped -- @mock_klayout is the default klayout.
+EXCLUDED = (
+    ".agents/",
+    ".claude/",
+    ".github/",
+    "docs/",
+    "gallery/",
+    "test/",
+    "tmp/",
+)
+
+SCANNED_SUFFIXES = (".sh", ".tpl", ".bzl", ".bazel")
+
+HOST_PYTHON_CALL = re.compile(r'(?:exec\s+)?python3?\s+["$]|which\("python3"\)')
+
+# `#` starting a word through end of line.  Crude, but a denied tool named
+# in a comment is not a dependency and should not fail the check.
+COMMENT = re.compile(r"(?:^|\s)#.*$", re.MULTILINE)
+
+# One patch_cmds entry: a string at archive_override's list indentation.
+PATCH_CMD = re.compile(r'^\s{8}"(.*)",$', re.MULTILINE)
+
+
+def python_floor(source):
+    """Lowest 3.x that parses this source, as a (3, minor) tuple."""
+    for minor in range(4, 20):
+        try:
+            ast.parse(source, feature_version=(3, minor))
+        except SyntaxError:
+            continue
+        return (3, minor)
+    return None
+
+
+def denied_tools_in(text, tolerated=frozenset()):
+    """Denied tools appearing where a command goes.
+
+    Matching the bare name anywhere hits prose -- an `echo` explaining a
+    table column is not a dependency on column(1) -- so the name has to sit
+    at the start of a line or after a `;`, `|`, `&&`, `$(` or `exec`.
+    """
+    text = COMMENT.sub("", text)
+    return sorted(
+        tool
+        for tool in DENIED_TOOLS - frozenset(tolerated)
+        if re.search(
+            r"(?:^|[;&|(]|&&|\|\||\bexec\b|\$\()\s*%s(?![-\w])" % re.escape(tool),
+            text,
+            re.MULTILINE,
+        )
+    )
+
+
+def shipped(files):
+    return [f for f in files if not str(f).startswith(EXCLUDED)]
+
+
+def _read(root, path):
+    return (root / path).read_text(encoding="utf-8", errors="replace")
+
+
+def check(root, files):
+    """Every host-tool violation in `files`, as a list of messages."""
+    problems = []
+    paths = shipped(files)
+
+    for path, caller in sorted(HOST_PYTHON.items()):
+        if not (root / path).exists():
+            problems.append(
+                "%s is declared as host-run python but does not exist; "
+                "update HOST_PYTHON in host_tools.py" % path,
+            )
+            continue
+        floor = python_floor(_read(root, path))
+        if floor is None:
+            problems.append("%s does not parse as python at all" % path)
+        elif floor > HOST_PYTHON_FLOOR:
+            problems.append(
+                "%s needs python %d.%d, but the host interpreter runs it "
+                "(%s) and that is %d.%d on the oldest supported distro"
+                % (path, floor[0], floor[1], caller, *HOST_PYTHON_FLOOR),
+            )
+
+    found = {
+        str(f)
+        for f in paths
+        if str(f).endswith(SCANNED_SUFFIXES) and HOST_PYTHON_CALL.search(_read(root, f))
+    }
+    for path in sorted(found - HOST_PYTHON_CALLERS):
+        problems.append(
+            "%s runs the host python3 without being declared; add it to "
+            "HOST_PYTHON_CALLERS and the file it runs to HOST_PYTHON, so "
+            "that file's version floor is checked -- or use a py_binary "
+            "and the hermetic interpreter instead" % path,
+        )
+    for path in sorted(HOST_PYTHON_CALLERS - found):
+        problems.append(
+            "%s no longer runs the host python3; drop it from "
+            "HOST_PYTHON_CALLERS" % path,
+        )
+
+    for f in paths:
+        if not str(f).endswith((".sh", ".tpl")):
+            continue
+        for tool in denied_tools_in(
+            _read(root, f),
+            TOLERATED.get(os.path.basename(str(f)), frozenset()),
+        ):
+            problems.append(
+                "%s runs %s, which a stock Linux install may not have" % (f, tool),
+            )
+
+    module = root / "MODULE.bazel"
+    if module.exists():
+        for cmd in PATCH_CMD.findall(module.read_text(encoding="utf-8")):
+            for tool in denied_tools_in(cmd):
+                problems.append(
+                    "a patch_cmds entry runs %s, which a stock Linux install "
+                    "may not have -- and patch_cmds run before any toolchain "
+                    "exists" % tool,
+                )
+
+    return problems
+
+
+def tracked_files(root):
+    out = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    return [Path(p.decode()) for p in out.split(b"\0") if p]
+
+
+def main(argv):
+    root = Path(
+        argv[1] if len(argv) > 1 else os.environ.get("BUILD_WORKSPACE_DIRECTORY", "."),
+    ).resolve()
+    problems = check(root, tracked_files(root))
+    for p in problems:
+        print(p)
+    if problems:
+        print("\n%d host-tool violation(s); see host_tools.py" % len(problems))
+        return 1
+    print("host tools: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/test/BUILD
+++ b/test/BUILD
@@ -1840,6 +1840,12 @@ py_test(
     deps = ["//:public_surface_lib"],
 )
 
+py_test(
+    name = "host_tools_test",
+    srcs = ["host_tools_test.py"],
+    deps = ["//:host_tools_lib"],
+)
+
 sh_test(
     name = "klayout_wrapper_test",
     srcs = ["tool_wrapper_test.sh"],

--- a/test/host_tools_test.py
+++ b/test/host_tools_test.py
@@ -1,0 +1,168 @@
+"""Unit tests for the host-tool rules in //:host_tools.
+
+The binary reads the real tree through git; these tests build small
+synthetic trees so each rule can be shown to fire and to stay quiet.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import host_tools
+
+
+def tree(**files):
+    """A temporary root holding the given repo-relative files."""
+    root = Path(tempfile.mkdtemp())
+    for path, content in files.items():
+        dest = root / path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+    return root
+
+
+def check(root):
+    return host_tools.check(root, [Path(p) for p in _walk(root)])
+
+
+def _walk(root):
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            yield os.path.relpath(os.path.join(dirpath, name), root)
+
+
+# A tree with every declared host-python file present and harmless, so a
+# test can add exactly the one thing it is about.
+def clean_tree(**extra):
+    files = {path: "x = 1\n" for path in host_tools.HOST_PYTHON}
+    files.update(
+        {caller: 'python3 "$X"\n' for caller in host_tools.HOST_PYTHON_CALLERS}
+    )
+    files.update(extra)
+    return tree(**files)
+
+
+class HostPythonFloorTest(unittest.TestCase):
+    def test_clean_tree_has_no_problems(self):
+        self.assertEqual(check(clean_tree()), [])
+
+    def test_syntax_above_the_floor_is_a_problem(self):
+        root = clean_tree(
+            **{"tools/pin/pin.py": "match x:\n    case _:\n        pass\n"}
+        )
+        problems = check(root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("tools/pin/pin.py needs python 3.10", problems[0])
+        self.assertIn("3.6 on the oldest supported distro", problems[0])
+
+    def test_syntax_at_the_floor_is_fine(self):
+        # f-strings are 3.6, the floor itself.
+        self.assertEqual(check(clean_tree(**{"bump.py": 'x = f"{1}"\n'})), [])
+
+    def test_a_declared_file_that_vanished_is_a_problem(self):
+        files = {path: "x = 1\n" for path in host_tools.HOST_PYTHON}
+        del files["bump_impl.py"]
+        files.update({c: 'python3 "$X"\n' for c in host_tools.HOST_PYTHON_CALLERS})
+        problems = check(tree(**files))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("bump_impl.py is declared as host-run python", problems[0])
+
+
+class HostPythonCallSiteTest(unittest.TestCase):
+    def test_an_undeclared_call_site_is_a_problem(self):
+        problems = check(clean_tree(**{"upload.sh": 'python3 "$RUNFILES/upload.py"\n'}))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("upload.sh runs the host python3", problems[0])
+
+    def test_a_call_site_that_went_away_is_a_problem(self):
+        root = clean_tree(**{"private/designs.bzl": "# no python here any more\n"})
+        problems = check(root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn(
+            "private/designs.bzl no longer runs the host python3", problems[0]
+        )
+
+    def test_repository_ctx_which_counts_as_a_call_site(self):
+        root = clean_tree(**{"fetch.bzl": 'p = repository_ctx.which("python3")\n'})
+        problems = check(root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("fetch.bzl runs the host python3", problems[0])
+
+    def test_test_and_docs_trees_are_not_scanned(self):
+        root = clean_tree(
+            **{
+                "test/helper.sh": 'python3 "$X"\n',
+                "docs/example.sh": "jq . foo.json\n",
+                "gallery/tmp/run/test.sh": "docker run x\n",
+            },
+        )
+        self.assertEqual(check(root), [])
+
+
+class DeniedToolTest(unittest.TestCase):
+    def test_a_denied_tool_in_a_shipped_script_is_a_problem(self):
+        problems = check(clean_tree(**{"report.sh": "jq -r .x foo.json\n"}))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("report.sh runs jq", problems[0])
+
+    def test_a_denied_tool_after_a_pipe_is_a_problem(self):
+        problems = check(clean_tree(**{"report.sh": "cat foo.json | jq -r .x\n"}))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("report.sh runs jq", problems[0])
+
+    def test_a_tool_named_in_prose_is_not_a_dependency(self):
+        root = clean_tree(
+            **{
+                "report.sh": (
+                    "# docker is not used here\n"
+                    'echo "  column -> the second column of the table"\n'
+                ),
+            },
+        )
+        self.assertEqual(check(root), [])
+
+    def test_a_longer_name_starting_with_a_denied_tool_is_not_a_match(self):
+        self.assertEqual(check(clean_tree(**{"r.sh": "pipefail_helper --x\n"})), [])
+
+    def test_tolerated_tools_are_allowed_only_in_their_own_file(self):
+        self.assertEqual(check(clean_tree(**{"open_html.sh": "exec xdg-open x\n"})), [])
+        problems = check(clean_tree(**{"other.sh": "exec xdg-open x\n"}))
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("other.sh runs xdg-open", problems[0])
+
+    def test_a_denied_tool_in_patch_cmds_is_a_problem(self):
+        root = clean_tree(
+            **{
+                "MODULE.bazel": (
+                    "archive_override(\n"
+                    '    module_name = "openroad",\n'
+                    "    patch_cmds = [\n"
+                    '        "wget https://example.com/x.tar.gz",\n'
+                    "    ],\n"
+                    ")\n"
+                ),
+            },
+        )
+        problems = check(root)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("a patch_cmds entry runs wget", problems[0])
+
+    def test_curl_in_patch_cmds_is_allowed(self):
+        root = clean_tree(
+            **{
+                "MODULE.bazel": (
+                    "archive_override(\n"
+                    "    patch_cmds = [\n"
+                    '        "curl -sSfL -o x.tar.gz https://example.com/x.tar.gz",\n'
+                    "    ],\n"
+                    ")\n"
+                ),
+            },
+        )
+        self.assertEqual(check(root), [])
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())

--- a/tools/pin/BUILD.bazel
+++ b/tools/pin/BUILD.bazel
@@ -1,6 +1,23 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 exports_files(
     [
         "pin.py",
         "pin.sh.tpl",
     ],
+)
+
+# pin.py is run by pin.sh.tpl with the host `python3`, so it has to stay
+# within reach of the oldest supported distro's interpreter. //:host_python
+# guards the syntax floor; this library exists so the behaviour has tests.
+py_library(
+    name = "pin_lib",
+    srcs = ["pin.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "pin_test",
+    srcs = ["pin_test.py"],
+    deps = [":pin_lib"],
 )

--- a/tools/pin/pin.py
+++ b/tools/pin/pin.py
@@ -76,47 +76,45 @@ class ArtifactAction(argparse.Action):
         setattr(namespace, self.dest, artifacts)
 
 
+def _is_single_file_named_after_label(artifact):
+    """Does the artifact hold exactly one file, named like the label itself?
+
+    Such an artifact is re-exported with exports_files() rather than wrapped
+    in a filegroup, so `//pkg:name` keeps naming the file and not a group
+    containing it.
+    """
+    files = sorted(artifact.files)
+    if len(files) != 1:
+        return False
+    return (
+        os.path.relpath(files[0].archive_path(), artifact.label.package)
+        == artifact.label.name
+    )
+
+
+def _print_srcs(artifact, output):
+    print("  srcs = [", file=output)
+    for f in sorted(artifact.files):
+        print(
+            "    {},".format(
+                repr(os.path.relpath(f.archive_path(), artifact.label.package))
+            ),
+            file=output,
+        )
+    print("  ],", file=output)
+
+
 def build_write(artifacts, output):
     for artifact in artifacts:
-        match sorted(artifact.files):
-            case [x] if (
-                os.path.relpath(x.archive_path(), artifact.label.package)
-                == artifact.label.name
-            ):
-                print("exports_files(", file=output)
-                print("  srcs = [", file=output)
-                for file in artifact.files:
-                    print(
-                        "    {},".format(
-                            repr(
-                                os.path.relpath(
-                                    file.archive_path(), artifact.label.package
-                                )
-                            )
-                        ),
-                        file=output,
-                    )
-                print("  ],".format(artifact.label), file=output)
-                print('  visibility = ["//visibility:public"],', file=output)
-                print(")", file=output)
-            case _:
-                print("filegroup(", file=output)
-                print("  name = {},".format(repr(artifact.label.name)), file=output)
-                print("  srcs = [", file=output)
-                for file in sorted(artifact.files):
-                    print(
-                        "    {},".format(
-                            repr(
-                                os.path.relpath(
-                                    file.archive_path(), artifact.label.package
-                                )
-                            )
-                        ),
-                        file=output,
-                    )
-                print("  ],".format(artifact.label), file=output)
-                print('  visibility = ["//visibility:public"],', file=output)
-                print(")", file=output)
+        if _is_single_file_named_after_label(artifact):
+            print("exports_files(", file=output)
+            _print_srcs(artifact, output)
+        else:
+            print("filegroup(", file=output)
+            print("  name = {},".format(repr(artifact.label.name)), file=output)
+            _print_srcs(artifact, output)
+        print('  visibility = ["//visibility:public"],', file=output)
+        print(")", file=output)
 
 
 def gs(bucket, path):

--- a/tools/pin/pin.py
+++ b/tools/pin/pin.py
@@ -11,6 +11,7 @@ import typing
 import urllib.parse
 from pathlib import Path
 
+
 class Label(typing.NamedTuple):
     repo: str
     package: str
@@ -18,8 +19,8 @@ class Label(typing.NamedTuple):
 
 
 def label(s):
-    (repo, path) = s.split("//")
-    (package, name) = path.split(":")
+    repo, path = s.split("//")
+    package, name = path.split(":")
     return Label(repo=repo, package=package, name=name)
 
 
@@ -29,16 +30,16 @@ class File(typing.NamedTuple):
     workspace_root: str
 
     def runfile_path(self):
-        attempt = os.path.join(os.environ["RUNFILES"],
-                               os.path.relpath(self.path, self.root))
+        attempt = os.path.join(
+            os.environ["RUNFILES"], os.path.relpath(self.path, self.root)
+        )
         if not os.path.exists(attempt):
             base = Path(os.environ["RUNFILES"])
             while base.name != "bazel-out":
                 base = base.parent
             attempt = os.path.join(base.parent, self.path)
             if not os.path.exists(attempt):
-                raise RuntimeError("Unable to find path of {}".format(
-                    self.path))
+                raise RuntimeError("Unable to find path of {}".format(self.path))
 
         return attempt
 
@@ -49,7 +50,7 @@ class File(typing.NamedTuple):
 
 
 def file(s):
-    (path, root, workspace_root) = s.split("@")
+    path, root, workspace_root = s.split("@")
     return File(path=path, root=root, workspace_root=workspace_root)
 
 
@@ -66,7 +67,7 @@ class ArtifactAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         artifacts = []
         for artifact in values:
-            (l, root, files) = artifact.split(",")
+            l, root, files = artifact.split(",")
             artifacts.append(
                 Artifact(
                     label=label(l), files=frozenset([file(s) for s in files.split(":")])

--- a/tools/pin/pin_test.py
+++ b/tools/pin/pin_test.py
@@ -1,0 +1,91 @@
+"""Unit tests for the BUILD file the pinner writes.
+
+build_write() used to be a match/case statement, which made pin.py a
+Python 3.10 file executed by whatever `python3` the host has -- a
+SyntaxError on RHEL 8 (3.6), SLES 15 (3.6) and Ubuntu 20.04 (3.8).  These
+tests nail down the output of both branches so the rewrite can be checked
+against what the match statement emitted.
+"""
+
+import io
+import unittest
+
+import pin
+
+
+def artifact(name, paths, package="pinned"):
+    return pin.Artifact(
+        label=pin.Label(repo="", package=package, name=name),
+        files=frozenset(
+            pin.File(
+                path="bazel-out/k8-fastbuild/bin/" + p,
+                root="bazel-out/k8-fastbuild/bin",
+                workspace_root="",
+            )
+            for p in paths
+        ),
+    )
+
+
+def build_file(*artifacts):
+    out = io.StringIO()
+    pin.build_write(list(artifacts), out)
+    return out.getvalue()
+
+
+class BuildWriteTest(unittest.TestCase):
+    def test_single_file_named_after_label_exports_the_file(self):
+        # One file whose archive path is the label name: the label has to
+        # keep naming the file itself, so it is re-exported rather than
+        # wrapped in a group.
+        self.assertEqual(
+            build_file(artifact("6_final.gds", ["pinned/6_final.gds"])),
+            "exports_files(\n"
+            "  srcs = [\n"
+            "    '6_final.gds',\n"
+            "  ],\n"
+            '  visibility = ["//visibility:public"],\n'
+            ")\n",
+        )
+
+    def test_several_files_become_a_filegroup(self):
+        self.assertEqual(
+            build_file(artifact("results", ["pinned/a.def", "pinned/b.odb"])),
+            "filegroup(\n"
+            "  name = 'results',\n"
+            "  srcs = [\n"
+            "    'a.def',\n"
+            "    'b.odb',\n"
+            "  ],\n"
+            '  visibility = ["//visibility:public"],\n'
+            ")\n",
+        )
+
+    def test_single_file_not_named_after_label_becomes_a_filegroup(self):
+        self.assertEqual(
+            build_file(artifact("netlist", ["pinned/6_final.v"])),
+            "filegroup(\n"
+            "  name = 'netlist',\n"
+            "  srcs = [\n"
+            "    '6_final.v',\n"
+            "  ],\n"
+            '  visibility = ["//visibility:public"],\n'
+            ")\n",
+        )
+
+    def test_srcs_are_sorted_so_the_generated_file_is_stable(self):
+        forward = build_file(artifact("r", ["pinned/a.def", "pinned/b.odb"]))
+        reverse = build_file(artifact("r", ["pinned/b.odb", "pinned/a.def"]))
+        self.assertEqual(forward, reverse)
+
+    def test_every_artifact_gets_its_own_block(self):
+        text = build_file(
+            artifact("6_final.gds", ["pinned/6_final.gds"]),
+            artifact("results", ["pinned/a.def", "pinned/b.odb"]),
+        )
+        self.assertEqual(text.count("exports_files("), 1)
+        self.assertEqual(text.count("filegroup("), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`README.md` promises a developer machine or CI runner needs nothing but
Bazelisk and a standard Linux install. A sweep of every shipped script,
`patch_cmds` entry and host-run Python file found one place where that is
not true, so this fixes it and then makes the promise checkable.

## The violation

`tools/pin/pin.sh.tpl` runs `pin.py` with the host `python3`, and
`build_write()` was a `match`/`case` statement — Python 3.10 syntax. RHEL 8
and SLES 15 ship 3.6, Ubuntu 20.04 ships 3.8, so on all of them the pinner
died with a SyntaxError before doing anything, and `tools/pin/README.md`
hands that pinner to downstream projects.

Rewritten as an `if`/`else` with the predicate named, dropping the file's
syntax floor to 3.6. `pin_test.py` nails down the output of both branches
and was written against the `match` statement first — it passes unchanged
on either implementation, so the rewrite is provably behaviour-preserving.

A `py_binary` on the hermetic interpreter would be the deeper fix, but
rules_python's default `system_python` bootstrap needs a host Python >= 3.7
anyway (see the comment in `.bazelrc`), so it would trade one 3.6 failure
for another unless every consumer also sets `bootstrap_impl=script`.

## The guard

`bazelisk run //:host_tools` fails on:

- a denied tool (`jq`, `yq`, `perl`, `docker`, `cmake`, `wget`, ...) at
  command position in a shipped script or a `patch_cmds` entry — the
  strictest place of all, since `patch_cmds` run during module resolution
  before any toolchain exists;
- an undeclared host-`python3` call site, so a new one has to name the file
  it runs and take on that file's version floor;
- a host-run Python file whose syntax floor is above 3.6.

A denylist, not an allowlist: recognising every command in a shell script
needs a shell parser, and a regex that guesses flags `then`, `do` and prose
inside an `echo`. Naming what we have decided not to depend on is precise,
and a new dependency is usually one of these anyway.

Shaped like `//:public_surface` — it reads the tree through git, so CI runs
it (after the public-surface step) rather than `bazel test`, and
`//test:host_tools_test` covers the rules on synthetic trees. Tolerated
exceptions carry their reason in the source: `xdg-open` in `open_html.sh`,
`klayout` in `klayout.sh` where the default is `@mock_klayout`.

## What the sweep found otherwise

Clean. `yq` arrives via the Bazel downloader with a pinned SHA256, GNU Make
is built from source, and no shipped script uses a version-sensitive flag
(`grep -P`, `sed -z`, `sort -V`, `tar --transform`, `env -S` — none). The
openroad `patch_cmds` do need host `curl`, `sha256sum`, `tar`, `sed` and
`find`, all base tools, with the curl flags already held at 7.52 by
`test/bump/bump_test.py` because RHEL 8 ships 7.61.

## Verification

- `//tools/pin:pin_test` (5 tests) and `//test:host_tools_test` (15 tests) pass.
- The guard was shown to bite: restoring the `match` statement makes it
  report `tools/pin/pin.py needs python 3.10`, and adding a `jq` call to a
  shipped script makes it report that too.
- `//:host_tools`, `//:public_surface`, `//:fix_lint` and `//:guard_tool_test` clean.

Commits are one concern each, least churn first: `pin.py` had never been
through black, so that reformat is separated from the fix.