### PR TITLE
docs: what the host actually needs, and why a bump looks slow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ is what this buys you: the two things that broke were a host `curl` and a
 host Python that had leaked into the build, and both were fixed by making
 them hermetic.
 
+"A standard Linux install" is meant literally, and `bazelisk run
+//:host_tools` holds the line. What is used from the host, and nowhere
+else, is:
+
+- **Base tools** — `curl`, `sha256sum`, `tar`, `sed`, `find`, `nproc` and
+  the rest of coreutils/findutils/gawk. OpenROAD's `archive_override`
+  vendors three git submodules through `curl` + `sha256sum -c`, because a
+  GitHub `/archive/<sha>.tar.gz` does not carry submodules and
+  `archive_override`'s `integrity` does not cover bytes fetched by
+  `patch_cmds`. The curl flags stay within reach of curl 7.52 (2016) on
+  purpose; RHEL 8 ships 7.61.
+- **`python3`** — for a fetch-phase repository rule
+  (`private/designs.bzl` parses every ORFS `config.mk`), the mock tools,
+  and `//tools/pin`. Every such file stays parseable by Python 3.6, the
+  oldest `python3` on a distro still receiving updates.
+
+Not needed, and checked: `jq`, `yq`, `perl`, `bc`, `docker`, `cmake`,
+`wget`, `rsync`, `unzip`, `xz`. `yq` is fetched by Bazel with a pinned
+SHA256 rather than expected on the host; GNU Make is built from source.
+`klayout` is the one opt-in exception — the default is a mock, see
+[docs/klayout.md](docs/klayout.md).
+
 **Plumbing an AI understands.** bazel-orfs has turned out to be the
 right shape for AI-assisted work. Every input is a label, every stage is a
 target, every variable is checked against ORFS's own `variables.yaml`, and

--- a/docs/openroad.md
+++ b/docs/openroad.md
@@ -185,6 +185,42 @@ Detection works by checking `module(name = ...)` in `MODULE.bazel`:
 `bazel-orfs` and `openroad` are recognized; everything else is treated
 as a downstream project.
 
+### Why the bump looks slow
+
+A bump often appears to take minutes before it prints anything. Almost
+none of that is the bumper. `MODULE.bazel` declares OpenROAD as
+`bazel_dep` + `archive_override`, and bzlmod cannot resolve the module
+graph without reading every dependency's `MODULE.bazel`. A registry dep
+serves that file on its own — a few KB out of BCR. An `archive_override`
+has no way to hand Bazel just the module file, so to read those ~100
+lines Bazel downloads and unpacks the entire OpenROAD tarball and runs
+its `patch_cmds`, which themselves fetch three submodule archives. It
+happens in "Computing main repo mapping", before a single target is
+analyzed, and it is measured in minutes:
+
+```
+$ time bazelisk build --nobuild //:bump
+Computing main repo mapping:
+INFO: Repo openroad+ defined by rule http_archive ...
+real  6m56s
+```
+
+Every Bazel command in the workspace pays that once per pin —
+`//:fix_lint` and `bazelisk query` included. The bumper looks like the
+culprit only because it is the command that *creates* an unfetched pin: it
+rewrites the OpenROAD and ORFS commits and exits, so whatever runs next,
+very often the next `//:bump`, is the first to meet a SHA nothing has
+downloaded. The download is real work a build needs; the bumper needs
+none of it.
+
+Nothing about this is fixable inside the bumper. The fix would be serving
+openroad's module file from a registry instead of an override, and
+`source.json` has no `patch_cmds`, so the submodule vendoring and the
+`sv-lang` BUILD rewrites would have to become patches regenerated on every
+bump. That is a bigger, churn-prone change than the cost it saves, and it
+would only help this root — a downstream root writes its own
+`archive_override` from the template in the README.
+
 ### Shapes the bumper recognizes
 
 `bump.py` is a thin loader: it downloads the newest `bump_impl.py` from


### PR DESCRIPTION
Two documentation gaps, one commit each. No code.

**1. Host requirements.** `README.md` said "nothing to install" and cited
[#869](https://github.com/The-OpenROAD-Project/bazel-orfs/issues/869) —
where a leaked host `curl` and host Python were the two things that broke
on RHEL 8 — while the openroad `archive_override` vendors three submodules
with host `curl` + `sha256sum -c`, and three places run the host `python3`,
one of them a repository rule that hard-fails without it. True about the
build, silent about the fetch.

Now lists what is used from the host and what is deliberately not, with the
version floors that make the list safe (curl 7.52, Python 3.6), and points
at `//:host_tools`, which enforces it as of #951.

**2. Why a bump looks slow.** `docs/openroad.md` gains a section explaining
that the minutes before `//:bump` prints anything are bzlmod materializing
the entire OpenROAD tarball to read one `MODULE.bazel` — an
`archive_override` cannot serve a module file the way a registry can — and
that it lands on the bumper only because the bump is what writes a pin
nothing has fetched yet. Includes the measurement and why the registry
alternative (no `patch_cmds` in `source.json`, so submodule vendoring and
the `sv-lang` BUILD rewrites would become patches regenerated every bump)
costs more than it saves.

Docs only; `//:fix_lint` clean.