### PR TITLE
feat(bump): check ORFS_PATCHES against the bumped ORFS before writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,13 @@ What it updates:
 - **bazel-orfs** git commit (latest from GitHub)
 - **OpenROAD** git commit (latest from GitHub, if configured)
 
+Before writing anything it checks that the ORFS patches bazel-orfs itself
+carries (`ORFS_PATCHES` in `orfs_source.bzl`) still fit the ORFS commit it
+is moving you to, and stops naming the patch and the commit if not -- the
+alternative is a `ctx.patch` failure inside bazel-orfs's patch dir during
+`mod tidy`, after `MODULE.bazel` was already rewritten. `--ignore` turns
+that into a warning.
+
 In downstream projects, it also injects commented-out boilerplate for
 [building OpenROAD from source](docs/openroad.md) — uncomment to test the
 latest OpenROAD before ORFS catches up. This is useful when an OpenROAD bug

--- a/bump_impl.py
+++ b/bump_impl.py
@@ -354,6 +354,183 @@ def compute_sha256_hex(url):
     return h.hexdigest()
 
 
+# --- ORFS_PATCHES pairing check ------------------------------------------
+#
+# bazel-orfs carries patches against ORFS (ORFS_PATCHES in orfs_source.bzl)
+# and applies them inside its orfs_repositories extension, below any patches
+# the consumer adds.  The bump follows ORFS master while bazel-orfs main may
+# still pin an older ORFS, so a consumer can be moved to an ORFS commit that
+# bazel-orfs's own patches no longer fit -- and the first sign is
+# ``ctx.patch`` failing inside bazel-orfs's patch dir during ``mod tidy``,
+# with MODULE.bazel already rewritten.  These helpers check each patch's
+# pre-image against the ORFS tree at the target commit first, reading only
+# the touched files, so the bump can name the patch and the commit instead.
+
+BAZEL_ORFS_REPO = "The-OpenROAD-Project/bazel-orfs"
+ORFS_SOURCE_BZL = "orfs_source.bzl"
+
+_HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def fetch_raw_text(github_repo, ref, path):
+    """Text of ``path`` in ``github_repo`` at ``ref``; None if absent there."""
+    url = f"https://raw.githubusercontent.com/{github_repo}/{ref}/{path}"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def read_local_text(root, path):
+    """Text of ``path`` under ``root``; None if absent."""
+    full = os.path.join(root, path)
+    if not os.path.isfile(full):
+        return None
+    with open(full, encoding="utf-8", errors="replace") as fh:
+        return fh.read()
+
+
+def parse_orfs_patch_labels(orfs_source_text):
+    """Repo-relative patch paths named in ``ORFS_PATCHES``, in list order.
+
+    ``Label("//patches:x.patch")`` becomes ``patches/x.patch`` and
+    ``Label("//:x.patch")`` becomes ``x.patch``.
+    """
+    m = re.search(r"^ORFS_PATCHES\s*=\s*\[(.*?)^\]", orfs_source_text, re.S | re.M)
+    if not m:
+        return []
+    return [
+        f"{pkg}/{name}" if pkg else name
+        for pkg, name in re.findall(r'Label\("//([^:"]*):([^"]+)"\)', m.group(1))
+    ]
+
+
+def parse_unified_diff(patch_text):
+    """``[(path, creates, [(hunk_header, pre_image_lines)])]`` per file.
+
+    ``path`` is the ``+++`` side without its ``b/`` prefix (the ``---`` side
+    for a deletion); ``creates`` is True when the ``---`` side is
+    ``/dev/null``.  Old-side line counts from the hunk header decide where a
+    hunk ends, so removed lines that happen to start with ``--`` are not
+    mistaken for a file header.
+    """
+    files = []
+    lines = patch_text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if (
+            line.startswith("--- ")
+            and i + 1 < len(lines)
+            and lines[i + 1].startswith("+++ ")
+        ):
+            old = line[4:].split("\t")[0]
+            new = lines[i + 1][4:].split("\t")[0]
+            path = old if new == "/dev/null" else new
+            path = re.sub(r"^[ab]/", "", path)
+            files.append((path, old == "/dev/null", []))
+            i += 2
+            continue
+        m = _HUNK_HEADER_RE.match(line)
+        if m and files:
+            old_count = int(m.group(2)) if m.group(2) is not None else 1
+            pre = []
+            i += 1
+            while len(pre) < old_count and i < len(lines):
+                hunk_line = lines[i]
+                i += 1
+                if hunk_line.startswith("\\") or hunk_line.startswith("+"):
+                    continue
+                pre.append(hunk_line[1:] if hunk_line[:1] in (" ", "-") else "")
+            files[-1][2].append((line, pre))
+            continue
+        i += 1
+    return files
+
+
+def _contains_slice(haystack, needle):
+    if not needle:
+        return True
+    n = len(needle)
+    return any(haystack[i : i + n] == needle for i in range(len(haystack) - n + 1))
+
+
+def check_patch_against_tree(patch_path, patch_text, read_file_fn):
+    """Problems a unified diff would hit against a tree; ``[]`` when clean.
+
+    ``read_file_fn(path)`` returns the file's text or None if it does not
+    exist.  A hunk is clean when its pre-image (context plus removed lines)
+    occurs in the file; a created file must be absent, any other file present.
+    """
+    problems = []
+    for path, creates, hunks in parse_unified_diff(patch_text):
+        text = read_file_fn(path)
+        if creates:
+            if text is not None:
+                problems.append(f"{patch_path}: creates {path}, which already exists")
+            continue
+        if text is None:
+            problems.append(f"{patch_path}: {path} does not exist")
+            continue
+        file_lines = text.splitlines()
+        for header, pre in hunks:
+            if not _contains_slice(file_lines, pre):
+                problems.append(f"{patch_path}: {path}: hunk {header} does not match")
+    return problems
+
+
+def check_orfs_patches(read_bazel_orfs_fn, read_orfs_fn):
+    """Problems bazel-orfs's ``ORFS_PATCHES`` would hit against an ORFS tree.
+
+    ``read_bazel_orfs_fn(path)`` reads bazel-orfs files (``orfs_source.bzl``
+    and the patches it names); ``read_orfs_fn(path)`` reads ORFS files at the
+    target commit.  Both return None for a missing file.
+    """
+    source = read_bazel_orfs_fn(ORFS_SOURCE_BZL)
+    if source is None:
+        return [f"{ORFS_SOURCE_BZL} not found in bazel-orfs; cannot check ORFS_PATCHES"]
+    problems = []
+    for patch_path in parse_orfs_patch_labels(source):
+        text = read_bazel_orfs_fn(patch_path)
+        if text is None:
+            problems.append(
+                f"{patch_path}: named in ORFS_PATCHES but not in bazel-orfs"
+            )
+            continue
+        problems.extend(check_patch_against_tree(patch_path, text, read_orfs_fn))
+    return problems
+
+
+def verify_orfs_patch_pairing(
+    orfs_commit, read_bazel_orfs_fn, read_orfs_fn, where, ignore_errors=False
+):
+    """Refuse an ORFS commit that bazel-orfs's own patches do not fit.
+
+    Returns the list of problems (empty when the pairing is clean).  Raises
+    ``BumpError`` on problems unless ``ignore_errors``, in which case they are
+    printed as a warning and the bump goes on.
+    """
+    problems = check_orfs_patches(read_bazel_orfs_fn, read_orfs_fn)
+    if not problems:
+        return problems
+    msg = (
+        f"ORFS patches carried by {where} do not apply to ORFS "
+        f"{orfs_commit[:12]}:\n  " + "\n  ".join(problems) + "\n"
+        "bazel-orfs applies these below any consumer patches, so the fetch "
+        "would fail inside bazel-orfs's patch dir. Bump bazel-orfs onto this "
+        "ORFS first (retire or rebase the patch there), or pin orfs to the "
+        "commit bazel-orfs itself pins. Re-run with --ignore to write "
+        "MODULE.bazel anyway."
+    )
+    if ignore_errors:
+        print(f"WARNING: {msg}", file=sys.stderr)
+        return problems
+    raise BumpError(msg)
+
+
 def fetch_submodule_sha(parent_repo, parent_commit, path):
     """Submodule SHA at ``path`` inside ``parent_repo`` at ``parent_commit``.
 
@@ -1589,6 +1766,7 @@ def bump(
     fetch_bcr_versions_fn=fetch_bcr_versions,
     fetch_sha256_hex_fn=compute_sha256_hex,
     fetch_submodule_sha_fn=fetch_submodule_sha,
+    fetch_raw_text_fn=fetch_raw_text,
     workspace_dir=None,
     head_tools=None,
     ignore_errors=False,
@@ -1626,6 +1804,7 @@ def bump(
     bazel_orfs_dir = os.path.dirname(os.path.abspath(__file__))
 
     # --- Update bazel-orfs commit (skip for bazel-orfs itself) ---
+    bazel_orfs_commit = None
     if project != "bazel-orfs":
         bazel_orfs_commit = fetch_commit_fn("The-OpenROAD-Project/bazel-orfs", "main")
         _expect(
@@ -1677,6 +1856,29 @@ def bump(
             ignore_errors=ignore_errors,
         )
         updated_modules.append(f"orfs -> {orfs_commit[:12]}")
+
+    # --- Refuse an ORFS commit bazel-orfs's own ORFS_PATCHES do not fit ---
+    # The consumer follows ORFS master; bazel-orfs main may still pin an
+    # older ORFS, and its patches apply below the consumer's, so a mismatch
+    # otherwise surfaces as a ctx.patch failure in bazel-orfs's patch dir
+    # during mod tidy, after MODULE.bazel is rewritten.
+    if orfs_commit is not None:
+        if project == "bazel-orfs":
+            checkout = os.path.dirname(os.path.abspath(module_file))
+            read_bazel_orfs = lambda path: read_local_text(checkout, path)
+            where = "this checkout"
+        else:
+            read_bazel_orfs = lambda path: fetch_raw_text_fn(
+                BAZEL_ORFS_REPO, bazel_orfs_commit, path
+            )
+            where = f"bazel-orfs {bazel_orfs_commit[:12]}"
+        verify_orfs_patch_pairing(
+            orfs_commit,
+            read_bazel_orfs,
+            lambda path: fetch_raw_text_fn(ORFS_REPO, orfs_commit, path),
+            where,
+            ignore_errors=ignore_errors,
+        )
 
     # --- Update qt-bazel commit ---
     if has_bazel_dep(content, "qt-bazel"):

--- a/bump_impl_test.py
+++ b/bump_impl_test.py
@@ -360,3 +360,146 @@ orfs.default(
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestOrfsPatchPairing(unittest.TestCase):
+    ORFS_SOURCE = """ORFS_BAZEL_PLATFORMS = ["asap7"]
+
+ORFS_PATCHES = [
+    Label("//patches:0037-single-writer.patch"),
+    # a comment between entries
+    Label("//patches:0047-export-flow-tcl.patch"),
+    Label("//:root-level.patch"),
+]
+
+OTHER = [Label("//patches:not-an-orfs-patch.patch")]
+"""
+
+    FLOW_BUILD = 'exports_files(\n    ["scripts/synth.tcl", "scripts/flow.tcl"],\n)\n'
+
+    EXPORT_PATCH = """diff --git a/flow/BUILD b/flow/BUILD
+--- a/flow/BUILD
++++ b/flow/BUILD
+@@ -1,3 +1,3 @@
+ exports_files(
+-    ["scripts/synth.tcl", "scripts/flow.tcl"],
++    ["scripts/synth.tcl", "scripts/flow.tcl", "scripts/variables.yaml"],
+ )
+"""
+
+    def test_parse_orfs_patch_labels_reads_only_the_list(self):
+        self.assertEqual(
+            bump_impl.parse_orfs_patch_labels(self.ORFS_SOURCE),
+            [
+                "patches/0037-single-writer.patch",
+                "patches/0047-export-flow-tcl.patch",
+                "root-level.patch",
+            ],
+        )
+        self.assertEqual(bump_impl.parse_orfs_patch_labels("X = 1\n"), [])
+
+    def test_parse_unified_diff_uses_old_counts_and_marks_creation(self):
+        patch = (
+            "--- a/x.txt\n+++ b/x.txt\n@@ -1,3 +1,2 @@\n one\n--- dashes\n-three\n"
+            "+new\n--- /dev/null\n+++ b/made.txt\n@@ -0,0 +1 @@\n+hello\n"
+        )
+        files = bump_impl.parse_unified_diff(patch)
+        self.assertEqual(
+            files,
+            [
+                ("x.txt", False, [("@@ -1,3 +1,2 @@", ["one", "-- dashes", "three"])]),
+                ("made.txt", True, [("@@ -0,0 +1 @@", [])]),
+            ],
+        )
+
+    def test_clean_patch_reports_nothing(self):
+        tree = {"flow/BUILD": self.FLOW_BUILD}
+        self.assertEqual(
+            bump_impl.check_patch_against_tree("p.patch", self.EXPORT_PATCH, tree.get),
+            [],
+        )
+
+    def test_deleted_file_is_named(self):
+        problems = bump_impl.check_patch_against_tree(
+            "patches/0047-export-flow-tcl.patch", self.EXPORT_PATCH, {}.get
+        )
+        self.assertEqual(
+            problems,
+            ["patches/0047-export-flow-tcl.patch: flow/BUILD does not exist"],
+        )
+
+    def test_moved_context_is_named_by_hunk(self):
+        tree = {"flow/BUILD": 'exports_files(["scripts/other.tcl"])\n'}
+        problems = bump_impl.check_patch_against_tree(
+            "p.patch", self.EXPORT_PATCH, tree.get
+        )
+        self.assertEqual(
+            problems, ["p.patch: flow/BUILD: hunk @@ -1,3 +1,3 @@ does not match"]
+        )
+
+    def test_creation_patch_needs_the_file_absent(self):
+        patch = "--- /dev/null\n+++ b/new.tcl\n@@ -0,0 +1 @@\n+puts hi\n"
+        self.assertEqual(bump_impl.check_patch_against_tree("p", patch, {}.get), [])
+        self.assertEqual(
+            bump_impl.check_patch_against_tree("p", patch, {"new.tcl": "x\n"}.get),
+            ["p: creates new.tcl, which already exists"],
+        )
+
+    def test_check_orfs_patches_walks_the_list(self):
+        bazel_orfs = {
+            bump_impl.ORFS_SOURCE_BZL: self.ORFS_SOURCE,
+            "patches/0037-single-writer.patch": self.EXPORT_PATCH,
+            "patches/0047-export-flow-tcl.patch": self.EXPORT_PATCH,
+        }
+        orfs = {"flow/BUILD": self.FLOW_BUILD}
+        self.assertEqual(
+            bump_impl.check_orfs_patches(bazel_orfs.get, orfs.get),
+            ["root-level.patch: named in ORFS_PATCHES but not in bazel-orfs"],
+        )
+        self.assertEqual(
+            bump_impl.check_orfs_patches(bazel_orfs.get, {}.get),
+            [
+                "patches/0037-single-writer.patch: flow/BUILD does not exist",
+                "patches/0047-export-flow-tcl.patch: flow/BUILD does not exist",
+                "root-level.patch: named in ORFS_PATCHES but not in bazel-orfs",
+            ],
+        )
+        self.assertEqual(
+            bump_impl.check_orfs_patches({}.get, orfs.get),
+            ["orfs_source.bzl not found in bazel-orfs; cannot check ORFS_PATCHES"],
+        )
+
+    def test_verify_raises_with_patch_and_commit_or_warns_under_ignore(self):
+        bazel_orfs = {
+            bump_impl.ORFS_SOURCE_BZL: 'ORFS_PATCHES = [\n    Label("//patches:0047.patch"),\n]\n',
+            "patches/0047.patch": self.EXPORT_PATCH,
+        }
+        with self.assertRaises(bump_impl.BumpError) as ctx:
+            bump_impl.verify_orfs_patch_pairing(
+                "a71b115b9b7b95fc843e715bdebd557147ef98fc",
+                bazel_orfs.get,
+                {}.get,
+                "bazel-orfs a668099ef676",
+            )
+        msg = str(ctx.exception)
+        self.assertIn("bazel-orfs a668099ef676", msg)
+        self.assertIn("ORFS a71b115b9b7b", msg)
+        self.assertIn("patches/0047.patch: flow/BUILD does not exist", msg)
+        self.assertIn("--ignore", msg)
+        problems = bump_impl.verify_orfs_patch_pairing(
+            "a71b115b9b7b95fc843e715bdebd557147ef98fc",
+            bazel_orfs.get,
+            {}.get,
+            "bazel-orfs a668099ef676",
+            ignore_errors=True,
+        )
+        self.assertEqual(problems, ["patches/0047.patch: flow/BUILD does not exist"])
+        self.assertEqual(
+            bump_impl.verify_orfs_patch_pairing(
+                "a71b115b9b7b95fc843e715bdebd557147ef98fc",
+                bazel_orfs.get,
+                {"flow/BUILD": self.FLOW_BUILD}.get,
+                "bazel-orfs a668099ef676",
+            ),
+            [],
+        )

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,1 +1,12 @@
+load("//:orfs_source.bzl", "ORFS_PATCHES")
+
 exports_files(glob(["*.patch"]))
+
+# The carried ORFS patches as one target, taken from ORFS_PATCHES itself so
+# it cannot drift from the list that is actually applied. //test/bump reads
+# them to build a fake ORFS tree the real patches apply to.
+filegroup(
+    name = "orfs_patches",
+    srcs = ORFS_PATCHES,
+    visibility = ["//test/bump:__pkg__"],
+)

--- a/test/bump/BUILD.bazel
+++ b/test/bump/BUILD.bazel
@@ -11,6 +11,11 @@ py_test(
         "fixtures/downstream.MODULE.bazel",
         "fixtures/openroad.MODULE.bazel",
         "fixtures/self.MODULE.bazel",
+        # The pairing check runs against the real carried patches: the test
+        # parses ORFS_PATCHES out of orfs_source.bzl and synthesizes an ORFS
+        # tree from the patches themselves.
+        "//:orfs_source.bzl",
+        "//patches:orfs_patches",
     ],
     main = "bump_test.py",
 )

--- a/test/bump/bump_test.py
+++ b/test/bump/bump_test.py
@@ -82,6 +82,88 @@ def mock_fetch_submodule_sha(_parent_repo, _parent_commit, path):
     return OPENROAD_SUBMODULE_SHAS[path]
 
 
+# --- Fake ORFS tree for the ORFS_PATCHES pairing check -------------------
+#
+# The pairing check reads every ORFS file that ORFS_PATCHES touches at the
+# target commit and looks for each hunk's pre-image. The tree it reads is
+# synthesized from the patches themselves rather than vendored from ORFS:
+# a patched path gets a file holding that patch's pre-image lines, so every
+# hunk finds its context by construction. The fixture therefore follows
+# whatever ORFS_PATCHES lists instead of going stale at the next ORFS bump,
+# and the check still runs against the real carried patches -- a patch that
+# stops parsing, or is named but missing, fails these tests.
+#
+# Files a patch creates are deliberately left out: the check requires those
+# to be absent.
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def carried_orfs_patches():
+    """{patch path: text} for every patch ORFS_PATCHES names in this repo."""
+    source = bump.read_local_text(REPO_ROOT, bump.ORFS_SOURCE_BZL)
+    assert source is not None, "no orfs_source.bzl at the repo root"
+    paths = bump.parse_orfs_patch_labels(source)
+    assert paths, "ORFS_PATCHES parsed as empty"
+    patches = {}
+    for path in paths:
+        text = bump.read_local_text(REPO_ROOT, path)
+        assert text is not None, f"{path} is named in ORFS_PATCHES but absent"
+        patches[path] = text
+    return patches
+
+
+def fake_orfs_tree(patch_texts):
+    """{ORFS path: text} that every patch in ``patch_texts`` applies to."""
+    tree = {}
+    for text in patch_texts.values():
+        for path, creates, hunks in bump.parse_unified_diff(text):
+            if creates:
+                continue
+            lines = tree.setdefault(path, [])
+            for _header, pre in hunks:
+                lines.extend(pre)
+    return {path: "\n".join(lines) + "\n" for path, lines in tree.items()}
+
+
+CARRIED_ORFS_PATCHES = carried_orfs_patches()
+FAKE_ORFS_TREE = fake_orfs_tree(CARRIED_ORFS_PATCHES)
+
+
+def mock_fetch_raw_text(repo, _ref, path):
+    """Raw file reads, served locally.
+
+    bazel-orfs files come from this checkout -- the real orfs_source.bzl and
+    the real patches -- and ORFS files from the synthesized tree. Any other
+    repo is a network access these mocks do not cover, and raising here is
+    how a new one gets noticed before CI reaches for GitHub.
+    """
+    if repo == bump.BAZEL_ORFS_REPO:
+        return bump.read_local_text(REPO_ROOT, path)
+    if repo == bump.ORFS_REPO:
+        return FAKE_ORFS_TREE.get(path)
+    raise AssertionError(f"unmocked raw fetch: {repo}/{path}")
+
+
+def setUpModule():
+    """Make the temp dir the fixtures land in look like a bazel-orfs checkout.
+
+    For a bazel-orfs project the pairing check reads orfs_source.bzl and the
+    patches it names from the directory holding MODULE.bazel, not over the
+    network. Every fixture here is copied to tempfile.gettempdir(), so the
+    real files are copied in beside them.
+    """
+    tmp = tempfile.gettempdir()
+    shutil.copy2(
+        os.path.join(REPO_ROOT, bump.ORFS_SOURCE_BZL),
+        os.path.join(tmp, bump.ORFS_SOURCE_BZL),
+    )
+    for path in CARRIED_ORFS_PATCHES:
+        dest = os.path.join(tmp, path)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copy2(os.path.join(REPO_ROOT, path), dest)
+
+
 def apply_bump(
     fixture_name,
     workspace_dir=None,
@@ -104,12 +186,83 @@ def apply_bump(
         fetch_submodule_sha_fn=mock_fetch_submodule_sha,
         workspace_dir=workspace_dir,
         head_tools=head_tools,
+        fetch_raw_text_fn=mock_fetch_raw_text,
     )
 
     with open(tmp.name) as f:
         content = f.read()
     os.unlink(tmp.name)
     return content
+
+
+class TestOrfsPatchPairingThroughBump(unittest.TestCase):
+    """The pairing check reached through a real bump.
+
+    bump_impl_test covers the checker itself on synthetic diffs. What is
+    covered here is the wiring plus the real carried set: the patches
+    ORFS_PATCHES names today, parsed for real, against an ORFS tree that
+    either fits them or does not.
+    """
+
+    def test_the_synthesized_tree_holds_every_patched_path(self):
+        """Guards against a vacuous fixture.
+
+        If parse_unified_diff stopped finding files, the tree would come out
+        empty, every patch would report a missing file, and the pairing check
+        would be doing nothing while the rest of this suite still passed.
+        """
+        self.assertTrue(CARRIED_ORFS_PATCHES, "no carried ORFS patches found")
+        for text in CARRIED_ORFS_PATCHES.values():
+            for path, creates, _hunks in bump.parse_unified_diff(text):
+                if not creates:
+                    self.assertIn(path, FAKE_ORFS_TREE)
+
+    def test_carried_patches_fit_the_synthesized_tree(self):
+        problems = bump.check_orfs_patches(
+            lambda path: bump.read_local_text(REPO_ROOT, path),
+            FAKE_ORFS_TREE.get,
+        )
+        self.assertEqual(problems, [])
+
+    def test_a_drifted_orfs_tree_makes_the_bump_refuse(self):
+        """The failure this check exists for: ORFS moved out from under a patch."""
+        victim = sorted(FAKE_ORFS_TREE)[0]
+        drifted = dict(FAKE_ORFS_TREE, **{victim: "not what the patch expects\n"})
+
+        def drifted_raw_text(repo, ref, path):
+            if repo == bump.ORFS_REPO:
+                return drifted.get(path)
+            return mock_fetch_raw_text(repo, ref, path)
+
+        src = os.path.join(FIXTURES_DIR, "downstream.MODULE.bazel")
+        tmp = tempfile.NamedTemporaryFile(suffix=".MODULE.bazel", delete=False)
+        tmp.close()
+        shutil.copy2(src, tmp.name)
+        try:
+            with open(tmp.name) as f:
+                before = f.read()
+            with self.assertRaises(bump.BumpError) as cm:
+                bump.bump(
+                    tmp.name,
+                    fetch_commit_fn=mock_fetch_commit,
+                    fetch_integrity_fn=mock_fetch_integrity,
+                    fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
+                    fetch_yosys_makefile_version_fn=mock_fetch_yosys_makefile_version,
+                    fetch_bcr_versions_fn=mock_fetch_bcr_versions,
+                    fetch_sha256_hex_fn=mock_fetch_sha256_hex,
+                    fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+                    fetch_raw_text_fn=drifted_raw_text,
+                )
+            message = str(cm.exception)
+            self.assertIn(victim, message)
+            self.assertIn(ORFS_COMMIT[:12], message)
+            self.assertRegex(message, r"patches/\d+-orfs-")
+            # A refusal writes nothing: MODULE.bazel is read once and
+            # written once at the end.
+            with open(tmp.name) as f:
+                self.assertEqual(f.read(), before)
+        finally:
+            os.unlink(tmp.name)
 
 
 class TestBazelOrfsProject(unittest.TestCase):
@@ -392,6 +545,7 @@ class TestOpenroadDoubleBumpIdempotent(unittest.TestCase):
             fetch_bcr_versions_fn=mock_fetch_bcr_versions,
             fetch_sha256_hex_fn=mock_fetch_sha256_hex,
             fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+            fetch_raw_text_fn=mock_fetch_raw_text,
         )
         bump.bump(tmp.name, **kwargs)
         with open(tmp.name) as f:
@@ -439,6 +593,7 @@ class TestUnchangedPinSkipsRehash(unittest.TestCase):
             fetch_bcr_versions_fn=mock_fetch_bcr_versions,
             fetch_sha256_hex_fn=counting_sha256,
             fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+            fetch_raw_text_fn=mock_fetch_raw_text,
         )
         try:
             bump.bump(tmp.name, **kwargs)
@@ -494,6 +649,7 @@ class TestNetworkErrorHandling(unittest.TestCase):
                     fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
                     fetch_yosys_makefile_version_fn=mock_fetch_yosys_makefile_version,
                     fetch_bcr_versions_fn=mock_fetch_bcr_versions,
+                    fetch_raw_text_fn=mock_fetch_raw_text,
                 )
             finally:
                 os.unlink(tmp.name)
@@ -565,6 +721,7 @@ class TestArchiveOverrideDoubleBumpIdempotent(unittest.TestCase):
             fetch_bcr_versions_fn=mock_fetch_bcr_versions,
             fetch_sha256_hex_fn=mock_fetch_sha256_hex,
             fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+            fetch_raw_text_fn=mock_fetch_raw_text,
         )
         bump.bump(tmp.name, **kwargs)
         with open(tmp.name) as f:
@@ -1079,6 +1236,7 @@ class TestStrictModeFailures(unittest.TestCase):
                 fetch_orfs_tool_sha_fn=mock_fetch_orfs_tool_sha,
                 fetch_yosys_makefile_version_fn=mock_fetch_yosys_makefile_version,
                 fetch_bcr_versions_fn=mock_fetch_bcr_versions,
+                fetch_raw_text_fn=mock_fetch_raw_text,
             )
             with open(tmp.name) as f:
                 return f.read()
@@ -1182,6 +1340,7 @@ class TestLegacyShapesRejected(unittest.TestCase):
                 fetch_bcr_versions_fn=mock_fetch_bcr_versions,
                 fetch_sha256_hex_fn=mock_fetch_sha256_hex,
                 fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+                fetch_raw_text_fn=mock_fetch_raw_text,
             )
             with open(tmp.name) as f:
                 return f.read()
@@ -1242,6 +1401,7 @@ class TestLegacyShapesRejected(unittest.TestCase):
                 fetch_sha256_hex_fn=mock_fetch_sha256_hex,
                 fetch_submodule_sha_fn=mock_fetch_submodule_sha,
                 ignore_errors=True,
+                fetch_raw_text_fn=mock_fetch_raw_text,
             )
             with open(tmp.name) as f:
                 result = f.read()
@@ -1282,6 +1442,7 @@ class TestLegacyShapesRejected(unittest.TestCase):
                     fetch_bcr_versions_fn=mock_fetch_bcr_versions,
                     fetch_sha256_hex_fn=mock_fetch_sha256_hex,
                     fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+                    fetch_raw_text_fn=mock_fetch_raw_text,
                 )
             with open(tmp.name) as f:
                 self.assertEqual(f.read(), content)
@@ -1331,6 +1492,7 @@ class TestYosysAlreadyPinnedWithExtraAttrs(unittest.TestCase):
                 fetch_bcr_versions_fn=mock_fetch_bcr_versions,
                 fetch_sha256_hex_fn=mock_fetch_sha256_hex,
                 fetch_submodule_sha_fn=mock_fetch_submodule_sha,
+                fetch_raw_text_fn=mock_fetch_raw_text,
             )
             with open(tmp.name) as f:
                 result = f.read()
@@ -1372,6 +1534,7 @@ class TestIgnoreModeWarnsAndContinues(unittest.TestCase):
                 fetch_yosys_makefile_version_fn=mock_fetch_yosys_makefile_version,
                 fetch_bcr_versions_fn=mock_fetch_bcr_versions,
                 ignore_errors=True,
+                fetch_raw_text_fn=mock_fetch_raw_text,
             )
             with open(tmp.name) as f:
                 result = f.read()


### PR DESCRIPTION
The bump follows ORFS master while bazel-orfs main may still pin an older ORFS, and bazel-orfs's own `ORFS_PATCHES` apply below any consumer patches. A consumer can therefore be moved onto an ORFS commit those patches no longer fit, and the first sign is `ctx.patch` failing inside bazel-orfs's patch dir during `mod tidy`, after `MODULE.bazel` was already rewritten. That is what happened when ORFS #4501 deleted `flow/BUILD` while main still carried 0047 and 0049 against it (fixed in #953).

This makes the bump check first: read `ORFS_PATCHES` from `orfs_source.bzl` at the bazel-orfs commit being pinned (the checkout itself when bumping bazel-orfs), verify each hunk's pre-image against the touched files of the ORFS tree at the target commit (one raw file fetch per touched file, no tarball, no `patch(1)`), and stop naming the patch, the file or hunk, and both commits. `--ignore` turns it into a warning like the other precondition checks.

Checked against the real pair: bazel-orfs a668099 vs ORFS a71b115 reports 0047 and 0049; main after #953 is clean. Unit tests cover the label parser, the diff parser (old-side counts, creations), the tree check, and the raise/warn behaviour.
