### PR TITLE
orfs: carry SET_RC_TCL as the per-design RC file (patches 0050-0055)

### DIFF
--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -57,6 +57,18 @@ ORFS_PATCHES = [
     # RUN_CMD, so an override reaches every logged target except the
     # stage logs. --@bazel-orfs//:log_timestamps overrides RUN_CMD.
     Label("//patches:0048-orfs-flow-sh-honor-run-cmd.patch"),
+    # SET_RC_TCL as the per-design RC file: read it (after
+    # LAYER_PARASITICS_FILE, before the platform setRC.tcl) in load.tcl,
+    # open.tcl and detail_place.tcl -- the last of which read neither and
+    # dropped any override during 3_5 -- scope it to the stages that load
+    # parasitics, and let a design's value survive the asap7 include.
+    # Six patches, one file each; they go together.
+    Label("//patches:0050-orfs-set-rc-tcl-load.patch"),
+    Label("//patches:0051-orfs-set-rc-tcl-open.patch"),
+    Label("//patches:0052-orfs-set-rc-tcl-detail-place.patch"),
+    Label("//patches:0053-orfs-set-rc-tcl-stages-yaml.patch"),
+    Label("//patches:0054-orfs-set-rc-tcl-stages-json.patch"),
+    Label("//patches:0055-orfs-asap7-set-rc-tcl-conditional.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/patches/0050-orfs-set-rc-tcl-load.patch
+++ b/patches/0050-orfs-set-rc-tcl-load.patch
@@ -1,0 +1,34 @@
+Read SET_RC_TCL as the per-design RC file in load.tcl
+
+ORFS registers SET_RC_TCL and every platform config.mk exports it, yet no
+script reads it: load.tcl and open.tcl read LAYER_PARASITICS_FILE for the
+same purpose, and detail_place.tcl reads neither -- it re-sources the
+platform setRC.tcl after load_design, so an RC override set through
+LAYER_PARASITICS_FILE is silently dropped during 3_5_place_dp. A design
+that calibrates set_wire_rc against its own routed parasitics has no
+variable that reaches every stage.
+
+Read SET_RC_TCL as the per-design RC file, with LAYER_PARASITICS_FILE
+keeping its precedence when set and the platform setRC.tcl as the
+fallback, in all three places that load parasitics. With 0055 letting a
+design's SET_RC_TCL survive the asap7 platform include, and 0053/0054
+scoping the variable to the stages that use it (so a calibration tweak
+re-runs from floorplan, not from synth), the variable means what its name
+says everywhere.
+
+Not upstreamed. Retires at the //:bump onto an ORFS whose scripts read
+SET_RC_TCL themselves (or that drops one of the two variables); the
+companion patches 0050-0055 carry the rest of the change and go together.
+
+diff --git a/flow/scripts/load.tcl b/flow/scripts/load.tcl
+--- a/flow/scripts/load.tcl
++++ b/flow/scripts/load.tcl
+@@ -47,6 +47,8 @@
+ 
+   if { [env_var_exists_and_non_empty LAYER_PARASITICS_FILE] } {
+     log_cmd source $::env(LAYER_PARASITICS_FILE)
++  } elseif { [env_var_exists_and_non_empty SET_RC_TCL] } {
++    log_cmd source $::env(SET_RC_TCL)
+   } else {
+     log_cmd source $::env(PLATFORM_DIR)/setRC.tcl
+   }

--- a/patches/0051-orfs-set-rc-tcl-open.patch
+++ b/patches/0051-orfs-set-rc-tcl-open.patch
@@ -1,0 +1,34 @@
+Read SET_RC_TCL as the per-design RC file in open.tcl
+
+ORFS registers SET_RC_TCL and every platform config.mk exports it, yet no
+script reads it: load.tcl and open.tcl read LAYER_PARASITICS_FILE for the
+same purpose, and detail_place.tcl reads neither -- it re-sources the
+platform setRC.tcl after load_design, so an RC override set through
+LAYER_PARASITICS_FILE is silently dropped during 3_5_place_dp. A design
+that calibrates set_wire_rc against its own routed parasitics has no
+variable that reaches every stage.
+
+Read SET_RC_TCL as the per-design RC file, with LAYER_PARASITICS_FILE
+keeping its precedence when set and the platform setRC.tcl as the
+fallback, in all three places that load parasitics. With 0055 letting a
+design's SET_RC_TCL survive the asap7 platform include, and 0053/0054
+scoping the variable to the stages that use it (so a calibration tweak
+re-runs from floorplan, not from synth), the variable means what its name
+says everywhere.
+
+Not upstreamed. Retires at the //:bump onto an ORFS whose scripts read
+SET_RC_TCL themselves (or that drops one of the two variables); the
+companion patches 0050-0055 carry the rest of the change and go together.
+
+diff --git a/flow/scripts/open.tcl b/flow/scripts/open.tcl
+--- a/flow/scripts/open.tcl
++++ b/flow/scripts/open.tcl
+@@ -47,6 +47,8 @@
+ 
+   if { [env_var_exists_and_non_empty LAYER_PARASITICS_FILE] } {
+     log_cmd source $::env(LAYER_PARASITICS_FILE)
++  } elseif { [env_var_exists_and_non_empty SET_RC_TCL] } {
++    log_cmd source $::env(SET_RC_TCL)
+   } else {
+     log_cmd source $::env(PLATFORM_DIR)/setRC.tcl
+   }

--- a/patches/0052-orfs-set-rc-tcl-detail-place.patch
+++ b/patches/0052-orfs-set-rc-tcl-detail-place.patch
@@ -1,0 +1,40 @@
+Read SET_RC_TCL as the per-design RC file in detail_place.tcl
+
+ORFS registers SET_RC_TCL and every platform config.mk exports it, yet no
+script reads it: load.tcl and open.tcl read LAYER_PARASITICS_FILE for the
+same purpose, and detail_place.tcl reads neither -- it re-sources the
+platform setRC.tcl after load_design, so an RC override set through
+LAYER_PARASITICS_FILE is silently dropped during 3_5_place_dp. A design
+that calibrates set_wire_rc against its own routed parasitics has no
+variable that reaches every stage.
+
+Read SET_RC_TCL as the per-design RC file, with LAYER_PARASITICS_FILE
+keeping its precedence when set and the platform setRC.tcl as the
+fallback, in all three places that load parasitics. With 0055 letting a
+design's SET_RC_TCL survive the asap7 platform include, and 0053/0054
+scoping the variable to the stages that use it (so a calibration tweak
+re-runs from floorplan, not from synth), the variable means what its name
+says everywhere.
+
+Not upstreamed. Retires at the //:bump onto an ORFS whose scripts read
+SET_RC_TCL themselves (or that drops one of the two variables); the
+companion patches 0050-0055 carry the rest of the change and go together.
+
+diff --git a/flow/scripts/detail_place.tcl b/flow/scripts/detail_place.tcl
+--- a/flow/scripts/detail_place.tcl
++++ b/flow/scripts/detail_place.tcl
+@@ -4,7 +4,13 @@
+ load_design 3_4_place_resized.odb 2_floorplan.sdc
+ source_step_tcl PRE DETAIL_PLACE
+ 
+-source $::env(PLATFORM_DIR)/setRC.tcl
++if { [env_var_exists_and_non_empty LAYER_PARASITICS_FILE] } {
++  source $::env(LAYER_PARASITICS_FILE)
++} elseif { [env_var_exists_and_non_empty SET_RC_TCL] } {
++  source $::env(SET_RC_TCL)
++} else {
++  source $::env(PLATFORM_DIR)/setRC.tcl
++}
+ 
+ proc do_dpl { } {
+   # Only for use with hybrid rows

--- a/patches/0053-orfs-set-rc-tcl-stages-yaml.patch
+++ b/patches/0053-orfs-set-rc-tcl-stages-yaml.patch
@@ -1,0 +1,40 @@
+Scope SET_RC_TCL to the stages that load parasitics (variables.yaml)
+
+ORFS registers SET_RC_TCL and every platform config.mk exports it, yet no
+script reads it: load.tcl and open.tcl read LAYER_PARASITICS_FILE for the
+same purpose, and detail_place.tcl reads neither -- it re-sources the
+platform setRC.tcl after load_design, so an RC override set through
+LAYER_PARASITICS_FILE is silently dropped during 3_5_place_dp. A design
+that calibrates set_wire_rc against its own routed parasitics has no
+variable that reaches every stage.
+
+Read SET_RC_TCL as the per-design RC file, with LAYER_PARASITICS_FILE
+keeping its precedence when set and the platform setRC.tcl as the
+fallback, in all three places that load parasitics. With 0055 letting a
+design's SET_RC_TCL survive the asap7 platform include, and 0053/0054
+scoping the variable to the stages that use it (so a calibration tweak
+re-runs from floorplan, not from synth), the variable means what its name
+says everywhere.
+
+Not upstreamed. Retires at the //:bump onto an ORFS whose scripts read
+SET_RC_TCL themselves (or that drops one of the two variables); the
+companion patches 0050-0055 carry the rest of the change and go together.
+
+diff --git a/flow/scripts/variables.yaml b/flow/scripts/variables.yaml
+--- a/flow/scripts/variables.yaml
++++ b/flow/scripts/variables.yaml
+@@ -948,6 +948,14 @@
+ SET_RC_TCL:
+   description: |
+     Metal & Via RC definition file path.
++  stages:
++    - floorplan
++    - place
++    - cts
++    - grt
++    - route
++    - final
++    - generate_abstract
+ FILL_CONFIG:
+   description: |
+     JSON rule file for metal fill during chip finishing.

--- a/patches/0054-orfs-set-rc-tcl-stages-json.patch
+++ b/patches/0054-orfs-set-rc-tcl-stages-json.patch
@@ -1,0 +1,43 @@
+Scope SET_RC_TCL to the stages that load parasitics (variables.json)
+
+ORFS registers SET_RC_TCL and every platform config.mk exports it, yet no
+script reads it: load.tcl and open.tcl read LAYER_PARASITICS_FILE for the
+same purpose, and detail_place.tcl reads neither -- it re-sources the
+platform setRC.tcl after load_design, so an RC override set through
+LAYER_PARASITICS_FILE is silently dropped during 3_5_place_dp. A design
+that calibrates set_wire_rc against its own routed parasitics has no
+variable that reaches every stage.
+
+Read SET_RC_TCL as the per-design RC file, with LAYER_PARASITICS_FILE
+keeping its precedence when set and the platform setRC.tcl as the
+fallback, in all three places that load parasitics. With 0055 letting a
+design's SET_RC_TCL survive the asap7 platform include, and 0053/0054
+scoping the variable to the stages that use it (so a calibration tweak
+re-runs from floorplan, not from synth), the variable means what its name
+says everywhere.
+
+Not upstreamed. Retires at the //:bump onto an ORFS whose scripts read
+SET_RC_TCL themselves (or that drops one of the two variables); the
+companion patches 0050-0055 carry the rest of the change and go together.
+
+diff --git a/flow/scripts/variables.json b/flow/scripts/variables.json
+--- a/flow/scripts/variables.json
++++ b/flow/scripts/variables.json
+@@ -1150,7 +1150,16 @@
+     "tunable": 1
+   },
+   "SET_RC_TCL": {
+-    "description": "Metal & Via RC definition file path.\n"
++    "description": "Metal & Via RC definition file path.\n",
++    "stages": [
++      "floorplan",
++      "place",
++      "cts",
++      "grt",
++      "route",
++      "final",
++      "generate_abstract"
++    ]
+   },
+   "SKIP_ANTENNA_REPAIR": {
+     "default": 0,

--- a/patches/0055-orfs-asap7-set-rc-tcl-conditional.patch
+++ b/patches/0055-orfs-asap7-set-rc-tcl-conditional.patch
@@ -1,0 +1,34 @@
+Let a design's SET_RC_TCL survive the asap7 platform include
+
+ORFS registers SET_RC_TCL and every platform config.mk exports it, yet no
+script reads it: load.tcl and open.tcl read LAYER_PARASITICS_FILE for the
+same purpose, and detail_place.tcl reads neither -- it re-sources the
+platform setRC.tcl after load_design, so an RC override set through
+LAYER_PARASITICS_FILE is silently dropped during 3_5_place_dp. A design
+that calibrates set_wire_rc against its own routed parasitics has no
+variable that reaches every stage.
+
+Read SET_RC_TCL as the per-design RC file, with LAYER_PARASITICS_FILE
+keeping its precedence when set and the platform setRC.tcl as the
+fallback, in all three places that load parasitics. With 0055 letting a
+design's SET_RC_TCL survive the asap7 platform include, and 0053/0054
+scoping the variable to the stages that use it (so a calibration tweak
+re-runs from floorplan, not from synth), the variable means what its name
+says everywhere.
+
+Not upstreamed. Retires at the //:bump onto an ORFS whose scripts read
+SET_RC_TCL themselves (or that drops one of the two variables); the
+companion patches 0050-0055 carry the rest of the change and go together.
+
+diff --git a/flow/platforms/asap7/config.mk b/flow/platforms/asap7/config.mk
+--- a/flow/platforms/asap7/config.mk
++++ b/flow/platforms/asap7/config.mk
+@@ -60,7 +60,7 @@
+ # Endcap and Welltie cells
+ export TAPCELL_TCL             ?= $(PLATFORM_DIR)/openRoad/tapcell.tcl
+ 
+-export SET_RC_TCL              = $(PLATFORM_DIR)/setRC.tcl
++export SET_RC_TCL             ?= $(PLATFORM_DIR)/setRC.tcl
+ 
+ # Route options
+ export MIN_ROUTING_LAYER        ?= M2


### PR DESCRIPTION
Carries `SET_RC_TCL` as the per-design RC file, as six one-file patches in `ORFS_PATCHES`.

ORFS registers `SET_RC_TCL` and every platform `config.mk` exports it, but no script reads it: `load.tcl` and `open.tcl` read `LAYER_PARASITICS_FILE`, and `detail_place.tcl` reads neither, re-sourcing the platform `setRC.tcl` after `load_design` so any override is silently dropped during `3_5_place_dp`. A design that calibrates `set_wire_rc` against its own routed parasitics has no variable that reaches every stage.

The patches read `SET_RC_TCL` in all three places as a ladder (`LAYER_PARASITICS_FILE` when set, then `SET_RC_TCL`, then the platform file), so nobody's current setup changes; scope the variable to the stages that load parasitics in `variables.yaml`/`variables.json`, so a calibration tweak re-runs from floorplan not synth; and make the asap7 export `?=` so a design value survives the platform include.

Each patch header says what it fixes and how it retires (an ORFS whose scripts read `SET_RC_TCL`, or that drops one of the two variables). Carried downstream since July. Verified: the patched ORFS fetches clean, `//test:lb_32x128_1_floorplan` builds on asap7, and the set applies in either order relative to #957, so the two PRs are independent.