### PR TITLE
orfs: carry a pre-placement wire-load hook (patches 0056-0058)

### DIFF
--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -69,6 +69,14 @@ ORFS_PATCHES = [
     Label("//patches:0053-orfs-set-rc-tcl-stages-yaml.patch"),
     Label("//patches:0054-orfs-set-rc-tcl-stages-json.patch"),
     Label("//patches:0055-orfs-asap7-set-rc-tcl-conditional.patch"),
+    # Pre-placement wire-load hook: open.tcl sources WIRE_LOAD_TCL after
+    # the design is read, so synth-stage timing charges a statistical wire
+    # delay instead of none; inert once real parasitics exist. open.tcl
+    # also scopes its inherited environment to the opened file's stage so
+    # the synth-scoped hook fires only there. Three patches, one file each.
+    Label("//patches:0056-orfs-wire-load-open.patch"),
+    Label("//patches:0057-orfs-wire-load-variables-yaml.patch"),
+    Label("//patches:0058-orfs-wire-load-variables-json.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/patches/0056-orfs-wire-load-open.patch
+++ b/patches/0056-orfs-wire-load-open.patch
@@ -1,0 +1,86 @@
+Source WIRE_LOAD_TCL after opening a design (open.tcl)
+
+Synth-stage timing charges no wire delay: the synth stage estimates no
+parasitics, and open.tcl's estimate_parasitics ladder has no rung below
+placement, so every report and GUI session on a synth ODB reads
+optimistic paths that disagree with what placement will show. A Liberty
+wire_load group is the standard answer, and OpenSTA only applies it to
+nets that have no parasitics, so it is inert once real ones exist.
+
+WIRE_LOAD_TCL is a hook sourced by open.tcl right after the design is
+read, meant for a script that picks the wire_load group
+(set_wire_load_model) from WIRE_LOAD_LIB; both are synth-scoped in
+variables.yaml (bazel-orfs stage scoping) and variables.json (ORFS
+erase_non_stage_variables). A set-but-missing file is a staging bug, so
+source errors out rather than silently reading wire-load-free timing.
+
+For the scoping to hold, open.tcl also scopes the environment it
+inherits to the stage of the file it opens, mirroring the
+erase_non_stage_variables call at the top of every stage script; SDC_FILE
+is preserved across it because read_timing falls back to it when no
+per-stage SDC sits next to the ODB. Inputs whose name does not follow the
+<N>[_<step>]_<stage> numbering leave the environment untouched, and
+KEEP_VARS=1 skips the erase, as in the stage scripts.
+
+Not upstreamed. Retires at the //:bump onto an ORFS that carries a
+pre-placement wire-load hook of its own; the companion patches 0056-0058
+go together.
+
+diff --git a/flow/scripts/open.tcl b/flow/scripts/open.tcl
+--- a/flow/scripts/open.tcl
++++ b/flow/scripts/open.tcl
+@@ -1,5 +1,38 @@
+ source $::env(SCRIPTS_DIR)/util.tcl
+ 
++# Scope the inherited environment to the stage of the design file being
++# opened (variables.yaml stages:), mirroring the erase_non_stage_variables
++# call at the top of every stage script. Consumers of open.tcl (gui_*,
++# report helpers) otherwise see variables scoped to other stages, and
++# stage-scoped hooks (WIRE_LOAD_TCL below) would fire on the wrong stage.
++# Inputs whose name does not follow the <N>[_<step>]_<stage> numbering
++# leave the environment untouched; KEEP_VARS=1 skips erasing, same as in
++# the stage scripts.
++if { ![info exists ::env(KEEP_VARS)] } {
++  set ::env(KEEP_VARS) 0
++}
++set _open_input ""
++foreach _open_var {DEF_FILE V_FILE ODB_FILE} {
++  if { [env_var_exists_and_non_empty $_open_var] } {
++    set _open_input $::env($_open_var)
++    break
++  }
++}
++set _open_stage [lindex [split [file rootname [file tail $_open_input]] _] end]
++if { $_open_stage eq "grt" } {
++  set _open_stage route
++}
++if { [lsearch -exact {synth floorplan place cts route final} $_open_stage] != -1 } {
++  # read_timing (below) falls back to SDC_FILE when no per-stage SDC is
++  # staged next to the ODB; SDC_FILE is synth-scoped in variables.yaml, so
++  # preserve it here.
++  set _open_sdc [expr {[info exists ::env(SDC_FILE)] ? $::env(SDC_FILE) : ""}]
++  erase_non_stage_variables $_open_stage
++  if { $_open_sdc ne "" } {
++    set ::env(SDC_FILE) $_open_sdc
++  }
++}
++
+ source_env_var_if_exists PLATFORM_TCL
+ 
+ if { [env_var_equals GUI_TIMING 1] } {
+@@ -32,6 +65,15 @@
+   log_cmd read_db {*}[hier_options] $input_file
+ }
+ 
++# Apply a statistical wire-load model on nets lacking parasitics (pre-
++# placement); inert once real parasitics exist. Opt out by setting
++# WIRE_LOAD_TCL to the empty string. A set-but-missing file is a staging
++# bug: source errors out, where a silent skip would read WLM-free
++# (optimistic) timing that disagrees with reports on the same ODB.
++if { [env_var_exists_and_non_empty WIRE_LOAD_TCL] } {
++  log_cmd source $::env(WIRE_LOAD_TCL)
++}
++
+ proc read_timing { input_file } {
+   set result [find_sdc_file $input_file]
+   set design_stage [lindex $result 0]

--- a/patches/0057-orfs-wire-load-variables-yaml.patch
+++ b/patches/0057-orfs-wire-load-variables-yaml.patch
@@ -1,0 +1,53 @@
+Register WIRE_LOAD_TCL and WIRE_LOAD_LIB, synth-scoped (variables.yaml)
+
+Synth-stage timing charges no wire delay: the synth stage estimates no
+parasitics, and open.tcl's estimate_parasitics ladder has no rung below
+placement, so every report and GUI session on a synth ODB reads
+optimistic paths that disagree with what placement will show. A Liberty
+wire_load group is the standard answer, and OpenSTA only applies it to
+nets that have no parasitics, so it is inert once real ones exist.
+
+WIRE_LOAD_TCL is a hook sourced by open.tcl right after the design is
+read, meant for a script that picks the wire_load group
+(set_wire_load_model) from WIRE_LOAD_LIB; both are synth-scoped in
+variables.yaml (bazel-orfs stage scoping) and variables.json (ORFS
+erase_non_stage_variables). A set-but-missing file is a staging bug, so
+source errors out rather than silently reading wire-load-free timing.
+
+For the scoping to hold, open.tcl also scopes the environment it
+inherits to the stage of the file it opens, mirroring the
+erase_non_stage_variables call at the top of every stage script; SDC_FILE
+is preserved across it because read_timing falls back to it when no
+per-stage SDC sits next to the ODB. Inputs whose name does not follow the
+<N>[_<step>]_<stage> numbering leave the environment untouched, and
+KEEP_VARS=1 skips the erase, as in the stage scripts.
+
+Not upstreamed. Retires at the //:bump onto an ORFS that carries a
+pre-placement wire-load hook of its own; the companion patches 0056-0058
+go together.
+
+diff --git a/flow/scripts/variables.yaml b/flow/scripts/variables.yaml
+--- a/flow/scripts/variables.yaml
++++ b/flow/scripts/variables.yaml
+@@ -945,6 +945,21 @@
+ RCX_RULES:
+   description: |
+     RC Extraction rules file path.
++WIRE_LOAD_TCL:
++  description: |
++    Path to a Tcl script sourced after the design is opened to apply a
++    statistical wire-load model (a Liberty wire_load group selected with
++    set_wire_load_model) on nets that have no parasitics yet, i.e. before
++    placement. Inert once real parasitics exist (wire-load models are not
++    applied to nets that already carry parasitics).
++  stages:
++    - synth
++WIRE_LOAD_LIB:
++  description: |
++    Path to the Liberty file defining the wire_load group applied by
++    WIRE_LOAD_TCL.
++  stages:
++    - synth
+ SET_RC_TCL:
+   description: |
+     Metal & Via RC definition file path.

--- a/patches/0058-orfs-wire-load-variables-json.patch
+++ b/patches/0058-orfs-wire-load-variables-json.patch
@@ -1,0 +1,46 @@
+Register WIRE_LOAD_TCL and WIRE_LOAD_LIB, synth-scoped (variables.json)
+
+Synth-stage timing charges no wire delay: the synth stage estimates no
+parasitics, and open.tcl's estimate_parasitics ladder has no rung below
+placement, so every report and GUI session on a synth ODB reads
+optimistic paths that disagree with what placement will show. A Liberty
+wire_load group is the standard answer, and OpenSTA only applies it to
+nets that have no parasitics, so it is inert once real ones exist.
+
+WIRE_LOAD_TCL is a hook sourced by open.tcl right after the design is
+read, meant for a script that picks the wire_load group
+(set_wire_load_model) from WIRE_LOAD_LIB; both are synth-scoped in
+variables.yaml (bazel-orfs stage scoping) and variables.json (ORFS
+erase_non_stage_variables). A set-but-missing file is a staging bug, so
+source errors out rather than silently reading wire-load-free timing.
+
+For the scoping to hold, open.tcl also scopes the environment it
+inherits to the stage of the file it opens, mirroring the
+erase_non_stage_variables call at the top of every stage script; SDC_FILE
+is preserved across it because read_timing falls back to it when no
+per-stage SDC sits next to the ODB. Inputs whose name does not follow the
+<N>[_<step>]_<stage> numbering leave the environment untouched, and
+KEEP_VARS=1 skips the erase, as in the stage scripts.
+
+Not upstreamed. Retires at the //:bump onto an ORFS that carries a
+pre-placement wire-load hook of its own; the companion patches 0056-0058
+go together.
+
+diff --git a/flow/scripts/variables.json b/flow/scripts/variables.json
+--- a/flow/scripts/variables.json
++++ b/flow/scripts/variables.json
+@@ -1151,2 +1151,14 @@
+   },
++  "WIRE_LOAD_TCL": {
++    "description": "Path to a Tcl script sourced after the design is opened to apply a statistical wire-load model (a Liberty wire_load group selected with set_wire_load_model) on nets that have no parasitics yet, i.e. before placement. Inert once real parasitics exist.\n",
++    "stages": [
++      "synth"
++    ]
++  },
++  "WIRE_LOAD_LIB": {
++    "description": "Path to the Liberty file defining the wire_load group applied by WIRE_LOAD_TCL.\n",
++    "stages": [
++      "synth"
++    ]
++  },
+   "SET_RC_TCL": {


### PR DESCRIPTION
Carries a pre-placement wire-load hook, as three one-file patches in `ORFS_PATCHES`.

Synth-stage timing charges no wire delay: the synth stage estimates no parasitics and `open.tcl`'s `estimate_parasitics` ladder has no rung below placement, so reports and GUI sessions on a synth ODB read optimistic paths that placement contradicts. A Liberty `wire_load` group is the standard answer, and OpenSTA applies it only to nets without parasitics, so it is inert once real ones exist.

`open.tcl` sources `WIRE_LOAD_TCL` right after the design is read (the script picks the `wire_load` group from `WIRE_LOAD_LIB` with `set_wire_load_model`); both variables are synth-scoped in `variables.yaml`/`variables.json`. A set-but-missing file errors out rather than silently reading wire-load-free timing. For the scoping to hold, `open.tcl` also scopes its inherited environment to the opened file's stage, mirroring the `erase_non_stage_variables` call at the top of every stage script (`SDC_FILE` preserved for `read_timing`'s fallback, `KEEP_VARS=1` and non-stage-named inputs skip it).

Each patch header says what it fixes and how it retires (an ORFS with a pre-placement wire-load hook of its own). Carried downstream since July. Verified: the patched ORFS fetches clean, `//test:lb_32x128_1_floorplan` builds on asap7, and the set applies in either order relative to #956, so the two PRs are independent.