### PR TITLE
feat(run): orfs_run validates its variables, and takes the same two hatches as orfs_flow

### DIFF
--- a/docs/orfs_run.md
+++ b/docs/orfs_run.md
@@ -36,7 +36,11 @@ orfs_run(
     name = "extract_ground_truth",
     src = ":design_grt",
     outs = ["ground_truth.json"],
-    arguments = {"OUTPUT_JSON": "$(location ground_truth.json)"},
+    # Read by extract.tcl, not by ORFS, so it goes in user_arguments:
+    # `arguments` is spell-checked against variables.yaml, the same as
+    # orfs_flow's, and an unknown name there is a typo far more often
+    # than a deliberate hook.
+    user_arguments = {"OUTPUT_JSON": "$(location ground_truth.json)"},
     script = "extract.tcl",
     src_logs = True,
 )

--- a/power.bzl
+++ b/power.bzl
@@ -110,7 +110,7 @@ def power_data(
       visibility: forwarded.
     """
     outs = [out_template.format(power = power) for power in POWER_TYPES]
-    arguments = {
+    user_arguments = {
         "SAIF_STIMULI": "$(location {})".format(saif),
         "POWER_STAGE": _POWER_STAGE_STEM[stage],
         "POWER_BASE_TCL": "$(location {})".format(_POWER_BASE_TCL),
@@ -132,13 +132,13 @@ def power_data(
         _POWER_BASE_TCL,
     ]
     if spef_paths_tcl != None:
-        arguments["SPEF_PATHS_TCL"] = "$(location {})".format(spef_paths_tcl)
+        user_arguments["SPEF_PATHS_TCL"] = "$(location {})".format(spef_paths_tcl)
         data.append(spef_paths_tcl)
     orfs_run(
         name = name,
         src = flow_target,
         outs = outs,
-        arguments = arguments,
+        user_arguments = user_arguments,
         data = data,
         script = _POWER_TCL,
         tags = ["manual"],
@@ -173,7 +173,7 @@ def power_per_module(
       spef_paths_tcl: optional per-instance SPEF-scoping Tcl (see power_data).
       visibility: forwarded.
     """
-    arguments = {
+    user_arguments = {
         "SAIF_STIMULI": "$(location {})".format(saif),
         "POWER_STAGE": _POWER_STAGE_STEM[stage],
         "SAIF_SCOPE": saif_scope,
@@ -193,13 +193,13 @@ def power_per_module(
         _POWER_BASE_TCL,
     ]
     if spef_paths_tcl != None:
-        arguments["SPEF_PATHS_TCL"] = "$(location {})".format(spef_paths_tcl)
+        user_arguments["SPEF_PATHS_TCL"] = "$(location {})".format(spef_paths_tcl)
         data.append(spef_paths_tcl)
     orfs_run(
         name = name,
         src = flow_target,
         outs = [out],
-        arguments = arguments,
+        user_arguments = user_arguments,
         data = data,
         script = _POWER_PER_MODULE_TCL,
         tags = ["manual"],

--- a/private/design_dsl.bzl
+++ b/private/design_dsl.bzl
@@ -21,6 +21,7 @@ already does for orfs_design().
 
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//private:rules.bzl", "orfs_run")
+load("//private:stages.bzl", "split_user_variables")
 
 # Per filegroup target: extensions included in the filegroup.
 # config_mk_parser produces these target names from VERILOG_FILES
@@ -141,11 +142,20 @@ def _auto_floorplan(designs, config):
         return
     name = entry["name"]
 
+    # DESIGNS carries one merged argument dict, so a design with its own
+    # config.mk variables -- the user_arguments list design() takes -- has
+    # them mixed in here. orfs_run validates the two apart, so split on
+    # the same predicate the guard uses.
+    _af_known, _af_user = split_user_variables(entry["arguments"])
+
     orfs_run(
         name = name + "_auto_floorplan_data",
         src = ":" + name + "_synth",
         outs = ["auto_floorplan.json"],
-        arguments = entry["arguments"] | {
+        arguments = _af_known,
+        # AF_* are read by auto_floorplan.tcl and its siblings, never by
+        # ORFS, so they take the hatch rather than the spell-checked dict.
+        user_arguments = _af_user | {
             "AF_EVIDENCE": "$(location auto_floorplan.json)",
             # The three scripts ship from here while SCRIPTS_DIR points at
             # ORFS's flow/scripts, so the driver cannot find its siblings

--- a/private/flow.bzl
+++ b/private/flow.bzl
@@ -144,11 +144,13 @@ def _orfs_estimate_report(name, src, arguments = {}, sources = {}, variant = Non
         name = name,
         src = src,
         outs = [name + ".json"],
-        arguments = arguments | {
-            "OUTPUT": name + ".json",
-        },
+        arguments = arguments,
         script = "@bazel-orfs//:estimate.tcl",
         sources = sources,
+        # Read by estimate.tcl, not by ORFS.
+        user_arguments = {
+            "OUTPUT": name + ".json",
+        },
         stages = [
             "synth",
             "floorplan",
@@ -160,11 +162,13 @@ def _orfs_estimate_report(name, src, arguments = {}, sources = {}, variant = Non
     orfs_run_executable(
         name = name + "_run",
         src = src,
-        arguments = arguments | {
-            "OUTPUT": name + ".json",
-        },
+        arguments = arguments,
         script = "@bazel-orfs//:estimate.tcl",
         sources = sources,
+        # Read by estimate.tcl, not by ORFS.
+        user_arguments = {
+            "OUTPUT": name + ".json",
+        },
         stages = [
             "synth",
             "floorplan",
@@ -197,9 +201,12 @@ def _orfs_html_report(name, src, variant = None, openroad = None, visibility = N
         outs = [gen_name + ".html"],
         arguments = {
             "GUI_TIMING": "1",
-            "OUTPUT": gen_name + ".html",
         },
         script = "@bazel-orfs//:html_timing_report.tcl",
+        # Read by html_timing_report.tcl, not by ORFS.
+        user_arguments = {
+            "OUTPUT": gen_name + ".html",
+        },
         variant = variant or "base",
         tags = ["manual"],
         **run_kwargs
@@ -447,6 +454,10 @@ def orfs_flow(
 
     orfs_variables(
         name = _step_name(name, variant, "variables"),
+        # Same tags as the flow it describes. Without this a manual flow
+        # still emits a non-manual sidecar, so a wildcard build picks up
+        # the one target of a design that was deliberately opted out.
+        tags = kwargs.get("tags", []),
         arguments = arguments | user_arguments,
         data = depset(
             [v for vs in (sources | user_sources).values() for v in vs] +

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -72,6 +72,7 @@ load(
     "ALL_STAGES",
     "ALL_STAGE_TO_VARIABLES",
     "STAGE_SUBSTEPS",
+    "check_stage_variables",
     "get_sources",
     "get_stage_args",
     "keep_modules",
@@ -631,6 +632,21 @@ def _expand_sources(kwargs):
         EXECUTION time by merge_and_filter_arguments (more code under test).
         Do NOT route them through get_stage_args.
     """
+
+    # The same two escape hatches orfs_flow takes, so a caller writing an
+    # orfs_run does not have to discover that the attribute it just used
+    # on orfs_flow does not exist here.
+    #
+    # Merging only. The spell-check is deliberately NOT here: this
+    # function is downstream of both entry points, and one of them has
+    # already merged. See _check_run_variables.
+    user_arguments = kwargs.pop("user_arguments", {})
+    user_sources = kwargs.pop("user_sources", {})
+    if user_arguments:
+        kwargs["arguments"] = kwargs.get("arguments", {}) | user_arguments
+    if user_sources:
+        kwargs["sources"] = kwargs.get("sources", {}) | user_sources
+
     sources = kwargs.pop("sources", {})
     if sources:
         # Normalize scalar source values to lists; the helpers expect lists.
@@ -661,6 +677,41 @@ def _expand_sources(kwargs):
         kwargs["arguments"] = arguments
     return kwargs
 
+def _check_run_variables(kwargs):
+    """Spell-check a directly-authored run target's variable dicts.
+
+    MORATORIUM(validate-where-the-dicts-are-apart): the guard belongs at
+    the boundary where the caller's `arguments` and `user_arguments` are
+    still two dicts, and nowhere downstream of it. There are two such
+    boundaries and they are not the same place:
+
+      * a hand-written orfs_run / orfs_run_executable / orfs_test -- here;
+      * orfs_flow's stage path -- _filter_stage_args, which already does
+        it, and then merges the hatches before get_stage_args flattens
+        everything into one stage-filtered dict.
+
+    Do not move this into _expand_sources, which both paths share. By the
+    time the stage path arrives there the dicts are one, and "the author
+    wrote this in user_arguments" is unrecoverable -- so the guard fires a
+    second time on merged data and rejects legitimate designs, e.g.
+    mock-alu's MOCK_ALU_WIDTH reaching the test stage.
+
+    Nor re-derive the split there with split_user_variables(). Its
+    predicate is "not a known ORFS variable", which is exactly what this
+    guard tests, so a typo would be silently reclassified as a hatch
+    entry -- the failure this guard exists to catch, wearing its fix's
+    clothes.
+
+    Args:
+        kwargs: the macro's keyword arguments, read but not modified.
+    """
+    check_stage_variables(
+        kwargs.get("arguments", {}),
+        kwargs.get("sources", {}),
+        kwargs.get("user_arguments", {}),
+        kwargs.get("user_sources", {}),
+    )
+
 def orfs_run(deps = False, **kwargs):
     """Rule wrapper for orfs_run to populate data dependencies and CLI arguments from explicitly specified sources.
 
@@ -671,8 +722,12 @@ def orfs_run(deps = False, **kwargs):
             the companions would be dead targets in every package. Turn it
             on for a run whose failures get debugged interactively or filed
             upstream.
-        **kwargs: The keyword arguments to pass to the underlying _orfs_run_rule.
+        **kwargs: The keyword arguments to pass to the underlying
+            _orfs_run_rule. `user_arguments` and `user_sources` name
+            variables read only by this run's own script rather than by
+            ORFS, matching orfs_flow's attributes of the same name.
     """
+    _check_run_variables(kwargs)
     _orfs_run_rule(**_expand_sources(kwargs))
     if deps:
         create_deps_tar(kwargs.get("name"), kwargs.get("visibility", None))
@@ -906,7 +961,28 @@ def orfs_test(**kwargs):
     """Rule wrapper for orfs_test to populate data dependencies and CLI arguments from explicitly specified sources.
 
     Args:
-        **kwargs: The keyword arguments to pass to the underlying _orfs_rule_test.
+        **kwargs: The keyword arguments to pass to the underlying
+            _orfs_rule_test. `user_arguments` and `user_sources` name
+            variables read only by this target's own script, matching
+            orfs_flow's attributes of the same name; `arguments` and
+            `sources` are spell-checked against ORFS's variables.yaml.
+    """
+    _check_run_variables(kwargs)
+    _orfs_rule_test(**_expand_sources(kwargs))
+
+def _orfs_test_stage(**kwargs):
+    """orfs_test for orfs_flow's stage path, without the spell-check.
+
+    Every other stage in STAGE_IMPLS instantiates its rule directly; the
+    test stage alone went through the public macro, which is why it was
+    the only thing the guard broke. _filter_stage_args has already
+    validated these dicts and then merged them, so re-checking here would
+    reject a design for a variable its author declared correctly. See
+    MORATORIUM(validate-where-the-dicts-are-apart) on
+    _check_run_variables.
+
+    Args:
+        **kwargs: stage-filtered keyword arguments from _filter_stage_args.
     """
     _orfs_rule_test(**_expand_sources(kwargs))
 
@@ -1177,6 +1253,7 @@ def orfs_run_executable(deps = False, **kwargs):
             companions. Opt-in for the same reason as orfs_run's.
         **kwargs: The keyword arguments to pass to the underlying _orfs_rule_run_executable.
     """
+    _check_run_variables(kwargs)
     _orfs_rule_run_executable(**_expand_sources(kwargs))
     if deps:
         create_deps_tar(kwargs.get("name"), kwargs.get("visibility", None))
@@ -3364,7 +3441,7 @@ GENERATE_METADATA_STAGE_IMPL = struct(
 )
 UPDATE_RULES_IMPL = struct(stage = "update_rules", impl = orfs_update_rules)
 
-TEST_STAGE_IMPL = struct(stage = "test", impl = orfs_test)
+TEST_STAGE_IMPL = struct(stage = "test", impl = _orfs_test_stage)
 
 STAGE_IMPLS = [
     struct(stage = "synth", impl = orfs_synth_rule),

--- a/private/stages.bzl
+++ b/private/stages.bzl
@@ -195,9 +195,12 @@ def check_variables(variables, label):
                 label = label,
                 unknown = ", ".join(unknown),
             ) +
-            "Check spelling against ORFS flow/scripts/variables.yaml. " +
-            "If the variable is correct but missing from variables.yaml, " +
-            "add it to your project's ORFS patch or file a PR against ORFS.",
+            ("Check spelling against ORFS flow/scripts/variables.yaml. " +
+             "If it is read only by your own .tcl/.mk rather than by " +
+             "ORFS, move it to user_{label} -- the escape hatch exempt " +
+             "from this check. If it is a real ORFS variable missing " +
+             "from variables.yaml, add it to your project's ORFS patch " +
+             "or file a PR against ORFS.").format(label = label),
         )
 
 def _check_user_hatch(user_dict, label, use_instead):
@@ -215,6 +218,24 @@ def _check_user_hatch(user_dict, label, use_instead):
             ) +
             "project-specific values.",
         )
+
+def split_user_variables(variables):
+    """Split a variable dict into ORFS-known and project-specific halves.
+
+    For callers that receive one merged dict -- a parsed config.mk, say --
+    and have to hand the two halves to a macro that validates them apart.
+    The predicate is the same membership test check_variables() uses, so
+    the split cannot disagree with the guard it feeds.
+
+    Args:
+        variables: a variable dict, possibly mixing both kinds.
+
+    Returns:
+        (known, user): two dicts whose union is `variables`.
+    """
+    known = {k: v for k, v in variables.items() if k in ALL_VARIABLE_TO_STAGES}
+    user = {k: v for k, v in variables.items() if k not in ALL_VARIABLE_TO_STAGES}
+    return known, user
 
 def check_stage_variables(arguments, sources, user_arguments, user_sources):
     """Validates a stage target's variable dicts and their escape hatches.

--- a/sram/BUILD
+++ b/sram/BUILD
@@ -95,11 +95,11 @@ orfs_run(
     outs = [
         ":macro_placement.tcl",
     ],
-    arguments = {
-        "MESSAGE": "Hello world!",
-    },
     cmd = "run",
     script = ":write_macros.tcl",
+    user_arguments = {
+        "MESSAGE": "Hello world!",
+    },
 )
 
 orfs_run(

--- a/test/BUILD
+++ b/test/BUILD
@@ -161,11 +161,11 @@ orfs_run(
     outs = [
         "tag_array_64x184_io-placement.tcl",
     ],
-    arguments = {
-        "OUTPUT": "tag_array_64x184_io-placement.tcl",
-    },
     script = ":write_pin_placement.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "tag_array_64x184_io-placement.tcl",
+    },
 )
 
 sh_binary(
@@ -303,11 +303,11 @@ orfs_run(
     outs = [
         "lb_32x128_top_io-placement.tcl",
     ],
-    arguments = {
-        "OUTPUT": "lb_32x128_top_io-placement.tcl",
-    },
     script = ":write_pin_placement.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "lb_32x128_top_io-placement.tcl",
+    },
 )
 
 sh_binary(
@@ -376,11 +376,11 @@ orfs_run(
     outs = [
         "lb_32x128_io-placement.tcl",
     ],
-    arguments = {
-        "OUTPUT": "lb_32x128_io-placement.tcl",
-    },
     script = ":write_pin_placement.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "lb_32x128_io-placement.tcl",
+    },
 )
 
 sh_binary(
@@ -528,11 +528,11 @@ orfs_run(
     outs = [
         "L1MetadataArray_io-placement.tcl",
     ],
-    arguments = {
-        "OUTPUT": "L1MetadataArray_io-placement.tcl",
-    },
     script = ":write_pin_placement.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "L1MetadataArray_io-placement.tcl",
+    },
 )
 
 sh_binary(
@@ -1093,11 +1093,11 @@ orfs_run(
     outs = [
         "regfile_128x65_io-placement.tcl",
     ],
-    arguments = {
-        "OUTPUT": "regfile_128x65_io-placement.tcl",
-    },
     script = ":write_pin_placement.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "regfile_128x65_io-placement.tcl",
+    },
 )
 
 sh_binary(
@@ -1164,11 +1164,11 @@ orfs_run(
     outs = [
         "lb_32x128_sweep_io-placement.tcl",
     ],
-    arguments = {
-        "OUTPUT": "lb_32x128_sweep_io-placement.tcl",
-    },
     script = ":write_pin_placement.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "lb_32x128_sweep_io-placement.tcl",
+    },
 )
 
 sh_binary(
@@ -1241,12 +1241,12 @@ orfs_run(
     outs = [
         "units.txt",
     ],
-    arguments = {
-        "OUTPUT": "$(location units.txt)",
-    },
     openroad = "@openroad//src/sta:opensta",
     script = ":units.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "$(location units.txt)",
+    },
 )
 
 build_test(
@@ -1331,12 +1331,12 @@ orfs_run(
     name = "log_dir_probe_mock",
     src = ":lb_32x128_squashed_cts",
     outs = ["log_dir_probe.txt"],
-    arguments = {
-        "OUTPUT": "$(location log_dir_probe.txt)",
-    },
     openroad = "//mock/openroad/src/bin:openroad",
     script = ":log_dir_probe.tcl",
     src_logs = True,
+    user_arguments = {
+        "OUTPUT": "$(location log_dir_probe.txt)",
+    },
     variant = "log_dir_probe",
 )
 
@@ -1952,11 +1952,11 @@ orfs_run(
     name = "lb_32x128_mock_run_with_deps",
     src = ":lb_32x128_mock_floorplan",
     outs = ["lb_32x128_mock_run_with_deps.yaml"],
-    arguments = {
-        "OUTPUT": "lb_32x128_mock_run_with_deps.yaml",
-    },
     script = ":report_named.tcl",
     tags = ["manual"],
+    user_arguments = {
+        "OUTPUT": "lb_32x128_mock_run_with_deps.yaml",
+    },
     deps = True,
 )
 
@@ -2182,11 +2182,11 @@ orfs_run(
     name = "my_run_test",
     src = ":lb_32x128_synth",
     outs = ["my_run_test.txt"],
-    arguments = {
-        "OUTPUT": "$(location :my_run_test.txt)",
-    },
     extra_arguments = [":my_variables"],
     script = "write_my_var.tcl",
+    user_arguments = {
+        "OUTPUT": "$(location :my_run_test.txt)",
+    },
 )
 
 sh_test(
@@ -2217,10 +2217,11 @@ orfs_run(
     name = "verify_synth_propagated_vars",
     src = ":lb_32x128_shared_synth_floorplan",
     outs = ["propagated_vars.txt"],
-    arguments = {
+    script = ":dump_floorplan_vars_tcl",
+    # Read by dump_floorplan_vars_tcl, not by ORFS.
+    user_arguments = {
         "OUT_vars_txt": "$(location :propagated_vars.txt)",
     },
-    script = ":dump_floorplan_vars_tcl",
 )
 
 sh_test(
@@ -2322,11 +2323,12 @@ orfs_run(
     name = "test_orfs_run_sources",
     src = ":lb_32x128_synth",
     outs = ["test_orfs_run_sources.txt"],
-    arguments = {
+    script = ":dump_sources_tcl",
+    # Read by dump_sources_tcl, not by ORFS.
+    user_arguments = {
         "OUT_vars_txt": "$(location :test_orfs_run_sources.txt)",
     },
-    script = ":dump_sources_tcl",
-    sources = {
+    user_sources = {
         "TEST_SOURCE_1": ":test_source_1",
         "TEST_SOURCES": [
             ":test_source_1",
@@ -2345,13 +2347,13 @@ sh_test(
 orfs_test(
     name = "test_orfs_test_sources",
     src = ":lb_32x128_mock_openroad_floorplan",
-    arguments = {
-        "SCRIPT": "$(location :verify_orfs_test_sources.tcl)",
-    },
     cmd = "run",
     data = [":verify_orfs_test_sources.tcl"],
     openroad = "//mock/openroad/src/bin:openroad",
-    sources = {
+    user_arguments = {
+        "SCRIPT": "$(location :verify_orfs_test_sources.tcl)",
+    },
+    user_sources = {
         "TEST_SOURCE_1": ":test_source_1",
         "TEST_SOURCES": [
             ":test_source_1",

--- a/test/estimation_ladder/BUILD.bazel
+++ b/test/estimation_ladder/BUILD.bazel
@@ -41,11 +41,19 @@ orfs_flow(
 )
 
 # Common configuration shared across the estimator
+# Split because the two halves take different attributes: IO_CONSTRAINTS
+# is a real ORFS variable and belongs in sources=, while the three
+# ESTIMATOR_* hooks are this study's own and belong in user_sources=.
+# Putting a known ORFS variable in the hatch is a hard failure -- two
+# dicts with different precedence naming one variable is a split brain.
 ESTIMATOR_SOURCES = {
+    "IO_CONSTRAINTS": ["io_constraints.tcl"],
+}
+
+ESTIMATOR_USER_SOURCES = {
     "ESTIMATOR_BATCH_TCL": ["estimator_batch.tcl"],
     "ESTIMATOR_LIB_TCL": ["estimator_lib.tcl"],
     "ESTIMATOR_TCL": ["estimator.tcl"],
-    "IO_CONSTRAINTS": ["io_constraints.tcl"],
 }
 
 # Ground Truth measurement using actual grt output from orfs_flow
@@ -56,15 +64,17 @@ orfs_run(
         "ground_truth.json",
     ],
     arguments = MULTIPLIER_ARGS | {
-        "OUTPUT_JSON": "$(location ground_truth.json)",
     },
     cmd = "run",
     script = "extract.tcl",
-    sources = {
+    src_logs = True,
+    user_arguments = {
+        "OUTPUT_JSON": "$(location ground_truth.json)",
+    },
+    user_sources = {
         "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
         "EXTRACT_TCL": ["extract.tcl"],
     },
-    src_logs = True,
 )
 
 # Standalone fast estimator executable target for Optuna hyperparameter exploration
@@ -75,6 +85,7 @@ orfs_run_executable(
     cmd = "run",
     script = "estimator.tcl",
     sources = ESTIMATOR_SOURCES,
+    user_sources = ESTIMATOR_USER_SOURCES,
 )
 
 py_binary(
@@ -183,15 +194,17 @@ orfs_run(
         "ground_truth_top.json",
     ],
     arguments = MULTIPLIER_TOP_ARGS | {
-        "OUTPUT_JSON": "$(location ground_truth_top.json)",
     },
     cmd = "run",
     script = "extract.tcl",
-    sources = {
+    src_logs = True,
+    user_arguments = {
+        "OUTPUT_JSON": "$(location ground_truth_top.json)",
+    },
+    user_sources = {
         "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
         "EXTRACT_TCL": ["extract.tcl"],
     },
-    src_logs = True,
 )
 
 orfs_run_executable(
@@ -201,6 +214,7 @@ orfs_run_executable(
     cmd = "run",
     script = "estimator.tcl",
     sources = ESTIMATOR_SOURCES,
+    user_sources = ESTIMATOR_USER_SOURCES,
 )
 
 py_binary(
@@ -331,8 +345,10 @@ orfs_run_executable(
     cmd = "run",
     script = "macro_probe.tcl",
     sources = {
-        "MACRO_PROBE_TCL": ["macro_probe.tcl"],
         "IO_CONSTRAINTS": ["io_constraints.tcl"],
+    },
+    user_sources = {
+        "MACRO_PROBE_TCL": ["macro_probe.tcl"],
     },
 )
 
@@ -342,7 +358,7 @@ orfs_run_executable(
     arguments = MULTIPLIER_TOP_ARGS,
     cmd = "run",
     script = "nameprobe.tcl",
-    sources = {"NAMEPROBE_TCL": ["nameprobe.tcl"]},
+    user_sources = {"NAMEPROBE_TCL": ["nameprobe.tcl"]},
 )
 
 # C2: can a per-path feature fix the ordering, which no correction
@@ -421,7 +437,7 @@ orfs_run_executable(
     arguments = MULTIPLIER_TOP_ARGS,
     cmd = "run",
     script = "layer_probe.tcl",
-    sources = {"LAYER_PROBE_TCL": ["layer_probe.tcl"]},
+    user_sources = {"LAYER_PROBE_TCL": ["layer_probe.tcl"]},
 )
 
 # B4: which routing layer should stand in for "an average wire"? One
@@ -507,15 +523,17 @@ AB_PERIODS = [
         src = ":ab_asap7_p%s_grt" % period,
         outs = ["ab_%s_truth.json" % period],
         arguments = MULTIPLIER_ARGS | {
-            "OUTPUT_JSON": "$(location ab_%s_truth.json)" % period,
         },
         cmd = "run",
         script = "extract.tcl",
-        sources = {
+        src_logs = True,
+        user_arguments = {
+            "OUTPUT_JSON": "$(location ab_%s_truth.json)" % period,
+        },
+        user_sources = {
             "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
             "EXTRACT_TCL": ["extract.tcl"],
         },
-        src_logs = True,
     )
     for period in AB_PERIODS
 ]
@@ -528,6 +546,7 @@ AB_PERIODS = [
         cmd = "run",
         script = "estimator.tcl",
         sources = ESTIMATOR_SOURCES,
+        user_sources = ESTIMATOR_USER_SOURCES,
     )
     for period in AB_PERIODS
 ]
@@ -554,7 +573,7 @@ orfs_run_executable(
     arguments = MULTIPLIER_ARGS,
     cmd = "run",
     script = "unit_probe.tcl",
-    sources = {"UNIT_PROBE_TCL": ["unit_probe.tcl"]},
+    user_sources = {"UNIT_PROBE_TCL": ["unit_probe.tcl"]},
 )
 
 # The site grid, for expressing the seed-sensitivity study's geometric
@@ -568,7 +587,7 @@ orfs_run_executable(
     arguments = MULTIPLIER_ARGS,
     cmd = "run",
     script = "site_probe.tcl",
-    sources = {"SITE_PROBE_TCL": ["site_probe.tcl"]},
+    user_sources = {"SITE_PROBE_TCL": ["site_probe.tcl"]},
 )
 
 # One knob at a time, everything else fixed. The Optuna archive cannot
@@ -809,18 +828,20 @@ FUZZ_CORE_AREA = {
         )],
         arguments = FUZZ_ARGS | {
             "CORE_AREA": FUZZ_CORE_AREA[eps],
+        },
+        cmd = "run",
+        script = "extract.tcl",
+        src_logs = True,
+        user_arguments = {
             "OUTPUT_JSON": "$(location fuzz_truth_%s_%s.json)" % (
                 name,
                 FUZZ_EPS_TAG[eps],
             ),
         },
-        cmd = "run",
-        script = "extract.tcl",
-        sources = {
+        user_sources = {
             "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
             "EXTRACT_TCL": ["extract.tcl"],
         },
-        src_logs = True,
     )
     for name in FUZZ_VARIANTS
     for eps in FUZZ_EPS
@@ -840,6 +861,7 @@ FUZZ_CORE_AREA = {
         cmd = "run",
         script = "estimator.tcl",
         sources = ESTIMATOR_SOURCES,
+        user_sources = ESTIMATOR_USER_SOURCES,
     )
     for name in FUZZ_VARIANTS
 ]
@@ -999,18 +1021,20 @@ FUZZ_TOP_ARGS = MULTIPLIER_TOP_ARGS | {"DESIGN_NAME": "multiplier_top_fuzz"}
         )],
         arguments = FUZZ_TOP_ARGS | {
             "CORE_AREA": FUZZ_TOP_CORE_AREA[eps],
+        },
+        cmd = "run",
+        script = "extract.tcl",
+        src_logs = True,
+        user_arguments = {
             "OUTPUT_JSON": "$(location fuzz_top_truth_%s_%s.json)" % (
                 name,
                 FUZZ_EPS_TAG[eps],
             ),
         },
-        cmd = "run",
-        script = "extract.tcl",
-        sources = {
+        user_sources = {
             "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
             "EXTRACT_TCL": ["extract.tcl"],
         },
-        src_logs = True,
     )
     for name in FUZZ_TOP_VARIANTS
     for eps in FUZZ_EPS
@@ -1027,6 +1051,7 @@ FUZZ_TOP_ARGS = MULTIPLIER_TOP_ARGS | {"DESIGN_NAME": "multiplier_top_fuzz"}
         cmd = "run",
         script = "estimator.tcl",
         sources = ESTIMATOR_SOURCES,
+        user_sources = ESTIMATOR_USER_SOURCES,
     )
     for name in FUZZ_TOP_VARIANTS
 ]
@@ -1168,18 +1193,20 @@ WIDE_VARIANTS = [
         )],
         arguments = FUZZ_ARGS | {
             "CORE_AREA": WIDE_CORE_AREA[eps],
+        },
+        cmd = "run",
+        script = "extract.tcl",
+        src_logs = True,
+        user_arguments = {
             "OUTPUT_JSON": "$(location wide_truth_%s_%s.json)" % (
                 name,
                 WIDE_EPS_TAG[eps],
             ),
         },
-        cmd = "run",
-        script = "extract.tcl",
-        sources = {
+        user_sources = {
             "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
             "EXTRACT_TCL": ["extract.tcl"],
         },
-        src_logs = True,
     )
     for name in WIDE_VARIANTS
     for eps in WIDE_EPS
@@ -1410,18 +1437,20 @@ TOP_REF_VARIANTS = [
         )],
         arguments = FUZZ_TOP_ARGS | {
             "CORE_AREA": TOP_CORE_AREA[eps],
+        },
+        cmd = "run",
+        script = "extract.tcl",
+        src_logs = True,
+        user_arguments = {
             "OUTPUT_JSON": "$(location topref_truth_%s_%s.json)" % (
                 name,
                 TOP_EPS_TAG[eps],
             ),
         },
-        cmd = "run",
-        script = "extract.tcl",
-        sources = {
+        user_sources = {
             "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
             "EXTRACT_TCL": ["extract.tcl"],
         },
-        src_logs = True,
     )
     for name in TOP_REF_VARIANTS
     for eps in TOP_EPS
@@ -1508,7 +1537,6 @@ orfs_run_executable(
     cmd = "run",
     script = "stage_variance.tcl",
     sources = {
-        "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
         "IO_CONSTRAINTS": ["io_constraints.tcl"],
     },
     stages = [
@@ -1517,6 +1545,9 @@ orfs_run_executable(
         "cts",
         "grt",
     ],
+    user_sources = {
+        "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
+    },
 )
 
 py_binary(
@@ -1561,7 +1592,6 @@ orfs_run_executable(
     cmd = "run",
     script = "stage_variance.tcl",
     sources = {
-        "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
         "IO_CONSTRAINTS": ["io_constraints.tcl"],
     },
     stages = [
@@ -1570,6 +1600,9 @@ orfs_run_executable(
         "cts",
         "grt",
     ],
+    user_sources = {
+        "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
+    },
 )
 
 py_binary(
@@ -1608,7 +1641,6 @@ orfs_run_executable(
     cmd = "run",
     script = "macro_score.tcl",
     sources = {
-        "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
         "IO_CONSTRAINTS": ["io_constraints.tcl"],
     },
     stages = [
@@ -1617,6 +1649,9 @@ orfs_run_executable(
         "cts",
         "grt",
     ],
+    user_sources = {
+        "EXTRACT_LIB_TCL": ["extract_lib.tcl"],
+    },
 )
 
 py_binary(

--- a/test/log_dir_probe/BUILD.bazel
+++ b/test/log_dir_probe/BUILD.bazel
@@ -8,12 +8,12 @@ orfs_run(
     name = "log_dir_probe_mock",
     src = "//test:log_dir_probe_src",
     outs = ["log_dir_probe.txt"],
-    arguments = {
-        "OUTPUT": "$(location log_dir_probe.txt)",
-    },
     openroad = "//mock/openroad/src/bin:openroad",
     script = "//test:log_dir_probe.tcl",
     src_logs = True,
+    user_arguments = {
+        "OUTPUT": "$(location log_dir_probe.txt)",
+    },
 )
 
 sh_test(

--- a/test/stages_filter_test.bzl
+++ b/test/stages_filter_test.bzl
@@ -13,6 +13,9 @@ and the invariants documented by the MORATORIUM blocks in private/stages.bzl:
   * check_stage_variables() accepts the one legitimate combination — known
     arguments/sources plus unmapped user_arguments/user_sources — and the
     unmapped hatch variables then survive the filter on every stage;
+  * split_user_variables() partitions a merged dict on exactly the
+    predicate check_variables() applies, so a caller that splits and then
+    validates can never be rejected for a variable it classified itself;
   * output is sorted/deterministic;
   * list union — a variable in ANY requested stage is kept.
 
@@ -29,6 +32,7 @@ load(
     "dropped_variables",
     "get_sources",
     "get_stage_args",
+    "split_user_variables",
 )
 
 # A name guaranteed not to be a known ORFS variable (the unmapped escape hatch).
@@ -221,7 +225,55 @@ denylist_is_the_complement_of_keep_test = unittest.make(_denylist_is_the_complem
 denylist_union_over_stages_test = unittest.make(_denylist_union_over_stages_test)
 user_hatch_survives_the_filter_test = unittest.make(_user_hatch_survives_the_filter_test)
 user_stages_sidecar_scopes_test = unittest.make(_user_stages_sidecar_scopes_test)
+
+def _split_user_variables_partitions_test(ctx):
+    """The split is a partition, not a filter: nothing is lost or doubled."""
+    env = unittest.begin(ctx)
+    known_name = sorted(ALL_VARIABLE_TO_STAGES.keys())[0]
+    merged = {known_name: "1", _UNMAPPED: "2"}
+
+    known, user = split_user_variables(merged)
+
+    asserts.equals(env, {known_name: "1"}, known)
+    asserts.equals(env, {_UNMAPPED: "2"}, user)
+
+    # Union restores the input, and the halves are disjoint.
+    asserts.equals(env, merged, known | user)
+    asserts.equals(env, [], [k for k in known if k in user])
+    return unittest.end(env)
+
+def _split_matches_the_guards_predicate_test(ctx):
+    """The helper and the guard have to agree, or the split is a bug factory.
+
+    split_user_variables() exists so a caller holding one merged dict --
+    a parsed config.mk -- can hand the halves to a macro that validates
+    them apart. If its predicate were merely similar to
+    check_variables()'s rather than identical, the split would hand the
+    guard something the guard rejects. Asserting the two agree is what
+    makes MORATORIUM(validate-where-the-dicts-are-apart) safe to rely on:
+    splitting is legitimate upstream of the merge, and never a substitute
+    for validating.
+    """
+    env = unittest.begin(ctx)
+    known_names = sorted(ALL_VARIABLE_TO_STAGES.keys())[:3]
+    merged = {name: "1" for name in known_names} | {_UNMAPPED: "2"}
+
+    known, user = split_user_variables(merged)
+
+    # Every key the split calls known is one the guard knows, and every
+    # key it calls user is one the guard would reject in a validated dict.
+    for name in known:
+        asserts.true(env, name in ALL_VARIABLE_TO_STAGES, name + " not known")
+    for name in user:
+        asserts.false(env, name in ALL_VARIABLE_TO_STAGES, name + " is known")
+
+    # And the round trip passes the guard, which would fail() otherwise.
+    check_stage_variables(known, {}, user, {})
+    return unittest.end(env)
+
 sorted_output_test = unittest.make(_sorted_output_test)
+split_user_variables_partitions_test = unittest.make(_split_user_variables_partitions_test)
+split_matches_the_guards_predicate_test = unittest.make(_split_matches_the_guards_predicate_test)
 
 def stages_filter_test_suite(name):
     unittest.suite(
@@ -235,4 +287,6 @@ def stages_filter_test_suite(name):
         user_hatch_survives_the_filter_test,
         user_stages_sidecar_scopes_test,
         sorted_output_test,
+        split_user_variables_partitions_test,
+        split_matches_the_guards_predicate_test,
     )


### PR DESCRIPTION
`orfs_flow` sets the expectation: a variable read by your own `.tcl` rather than
by ORFS goes in `user_arguments`, a path hook in `user_sources`, and a misspelled
ORFS variable fails loudly. `orfs_run`, `orfs_run_executable` and `orfs_test` had
none of it — so the rule whose whole purpose is running your own script was the
one rule with no way to declare that, and a typo in an ORFS variable name there
was accepted in silence and simply never reached the tool.

An omission rather than a decision: `eeffe61` set out to give *"every public
stage macro the same spell-check and the same two hatches"*, wired the guard into
`_filter_stage_args`, and `orfs_run` is not a stage macro.

## Breaking, and loud

A misspelled ORFS variable in an `orfs_run` now fails, naming `user_arguments` as
the remedy. Every in-tree caller is moved, and each move was a latent bug:

| caller | variables that were silently unvalidated |
| --- | --- |
| `power.bzl` | `SAIF_STIMULI`, `POWER_STAGE`, `SAIF_SCOPE`, `SPEFS_AND_NETLISTS`, `OUT_JSON`, `MODULE_INSTANCE_MAP`, `POWER_BASE_TCL`, `SPEF_PATHS_TCL` |
| `private/flow.bzl` | `OUTPUT`, in the framework's own estimate and html-report runs |
| `test/BUILD` | `OUTPUT`, `OUT_vars_txt`, `SCRIPT`, `TEST_SOURCE_1`, `TEST_SOURCES` |
| `test/estimation_ladder` | the `ESTIMATOR_*`, `EXTRACT_*` and probe hooks |

`estimation_ladder`'s `ESTIMATOR_SOURCES` also mixed `IO_CONSTRAINTS` — a real
ORFS variable — with three of its own hooks, which the shadow check rightly
refuses in one dict: two dicts with different precedence naming one variable is a
split brain.

## Where the guard sits, and why it cannot move

`_check_run_variables`, called from the three public macros, at the boundary
where the caller's two dicts are still two. It carries
`MORATORIUM(validate-where-the-dicts-are-apart)`.

It must not move downstream into `_expand_sources`, which both entry points share
and one of them has already merged — `orfs_flow` reaches the test stage through
`_filter_stage_args`, which validates and then folds the hatches in before
`get_stage_args` flattens everything. A guard there fires a second time on merged
data and rejects designs whose authors declared everything correctly
(`mock-alu`'s `MOCK_ALU_WIDTH` at the test stage).

Nor may the split be re-derived there with `split_user_variables()`: its predicate
is "not a known ORFS variable", which is exactly what the guard tests — so a typo
would be silently reclassified as a hatch entry, which is the failure this guard
exists to catch wearing its fix's clothes.

The test stage was the only stage reaching a public macro; every other
`STAGE_IMPLS` entry instantiates its rule directly, which is why it was the only
thing that broke. It gets `_orfs_test_stage`, an unguarded seam, while public
`orfs_test` keeps the guard.

## Also

`tags` now reach the `<name>_variables` sidecar `orfs_flow` emits. Without it a
`manual` flow still produced one non-`manual` target, so a wildcard build picked
up part of a design that had deliberately opted out.

## Verification

`fix_lint`, `public_surface`, `bazelisk build --nobuild --keep_going //...`
clean, and `//test:stages_filter_test` gains two cases locking that
`split_user_variables()` is a partition and that its predicate is the guard's.
