### PR TITLE
fix(dsl): BLOCKS is make-only, so resolve what it decides here

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -301,11 +301,12 @@ Interpretation:
 - **Any DIFFER in the `bazel+make-netlist` column** → real
   bazel-vs-make OpenROAD divergence on this design. Worth filing
   the per-stage SHA matrix as an issue.
-- **Wrapper refuses with "design uses BLOCKS=…"** → bazel-orfs's
-  `BLOCKS=` handling for hierarchical designs diverges from make's
-  (sub-block `.lef`/`.lib` abstracts aren't staged into the parent
-  synth action). Known gap; not a yosys-false-positive question.
-  See `asap7/aes-block` for the canonical example.
+- **Wrapper refuses with "design uses BLOCKS=…"** → the wrappers do
+  not compare hierarchical designs, because each sub-block is a flow
+  of its own and the per-stage `.odb` comparison would not be
+  apples-to-apples. Not a yosys-false-positive question. See
+  `asap7/aes-block` for the canonical example, and the "BLOCKS=
+  caveat" below for what does and does not match make.
 
 ### Reverse-direction sanity check
 
@@ -343,9 +344,37 @@ do-yosys-canonicalize) fail with "Permission denied".
 ### BLOCKS= caveat
 
 For designs that set `BLOCKS=` (hierarchical synthesis with sub-block
-abstracts — e.g. `asap7/aes-block`), bazel-orfs and make currently
-disagree on how the parent's synth_odb action sees the sub-block
-`.lef`/`.lib` abstracts. Both wrappers refuse to run on these
-designs because the per-stage `.odb` comparison wouldn't be
-apples-to-apples. This is a bazel-orfs gap independent of OpenROAD
-determinism.
+abstracts — e.g. `asap7/aes-block`), each sub-block is a flow of its
+own, so both wrappers refuse to run: the per-stage `.odb` comparison
+wouldn't be apples-to-apples. That is a property of the comparison,
+not a bazel-orfs gap.
+
+What does match make: the sub-block `.lef` and `.lib` do reach the
+parent (`ADDITIONAL_LEFS` / `ADDITIONAL_LIBS` in the parent's
+generated `1_synth.mk` and every later stage's, the pre-layout `.lib`
+variant for synth/floorplan/place); the abstract is taken from
+`6_final`, as ORFS's `generate_abstract` does; and a platform
+`config.mk` that branches on `BLOCKS` — asap7 selects `PDN_TCL` that
+way — is resolved by the config.mk parser, since `BLOCKS` itself is a
+make-only concept that never reaches a bazel action.
+
+What still does not match make: `ADDITIONAL_GDS`. make hands the
+parent every block's `6_final.gds`, so the top-level GDS contains the
+macro layout. In bazel a GDS is produced by a separate `orfs_gds`
+target that `orfs_flow()` never instantiates, so a block macro has no
+`.gds` to forward and the parent's `ADDITIONAL_GDS` is empty. Wiring
+it needs `orfs_gds` + `orfs_macro` per block (and a klayout binary),
+not a change to the abstract stage. Nothing gated on GDS today
+notices — `rules-base.json` has no GDS-derived rule, and
+`orfs_flow()` emits no top-level GDS either — but a consumer that
+does put an `orfs_gds` over a hierarchical parent gets a stream with
+hollow macro cells.
+
+Also not derived from a macro dependency:
+`ADDITIONAL_FAST_LIBS` / `ADDITIONAL_SLOW_LIBS`. ORFS's
+`generate_abstract.tcl` writes one `.lib` per corner and make appends
+the block's fast/slow libs to those variables;
+`orfs_abstract_rule` declares only `_typ.lib`, and
+`orfs_additional_arguments` emits only GDS/LEFS/LIBS. A design that
+sets the variables itself in `config.mk` is unaffected. No effect on
+single-corner asap7; it matters for a multi-corner consumer.

--- a/config_mk_parser.py
+++ b/config_mk_parser.py
@@ -291,6 +291,12 @@ class ConfigMkParser:
             elif var_name not in NON_ARGUMENT_VARS:
                 result.arguments[var_name] = resolved
 
+        # A hierarchical parent's platform config.mk may branch on
+        # BLOCKS.  Adopt what that branch changes; see
+        # _apply_platform_blocks_vars.
+        if result.blocks:
+            self._apply_platform_blocks_vars(result, config_path, raw_vars, ctx)
+
         # Process BLOCKS — discover and parse sub-macro configs.
         if result.blocks:
             config_dir = os.path.dirname(config_path)
@@ -321,6 +327,88 @@ class ConfigMkParser:
 
         return result
 
+    def _apply_platform_blocks_vars(self, result, config_path, raw_vars, ctx):
+        """Adopt platform config.mk variables that branch on BLOCKS.
+
+        BLOCKS is a make-only concept: flow/Makefile turns it into the
+        per-block abstract rules, so it is not a flow variable and
+        bazel-orfs never exports it.  A platform config.mk can still
+        branch on it, and asap7 does:
+
+            ifeq ($(BLOCKS),)
+               export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/grid_strategy-M1-M2-M5-M6.tcl
+            else
+               export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl
+            endif
+
+        make includes the platform config.mk after the design's, with
+        BLOCKS set, so a hierarchical parent gets the BLOCKS grid -- a
+        core ring, an ElementGrid over the macros and M5-M6 macro
+        connects.  Inside a bazel action BLOCKS is empty, so the same
+        include silently picks the flat grid instead.
+
+        Resolved here rather than by exporting BLOCKS: exporting it
+        would also wake flow/Makefile's own BLOCKS machinery
+        (BLOCK_LEFS/BLOCK_TYP_LIBS appended to ADDITIONAL_LEFS/LIBS as
+        make-relative results/ paths that do not exist in the sandbox),
+        and BLOCKS has no `stages:` entry in variables.yaml.
+
+        The platform file is parsed twice, once with BLOCKS empty and
+        once with it set, and only the variables whose value actually
+        differs are adopted -- and only where the design has not set
+        them itself, matching the platform's `?=`.
+
+        Args:
+            result: ParsedDesign being built; mutated in place.
+            config_path: path of the design's config.mk.
+            raw_vars: the design's own assignments, var -> (value, op, line).
+            ctx: variable-resolution context for this design.
+        """
+        platform_config = self._platform_config_path(config_path, result.platform)
+        if not platform_config or not os.path.exists(platform_config):
+            return
+
+        base_dir = os.path.dirname(platform_config)
+        without = {}
+        with_blocks = {"BLOCKS": (" ".join(result.blocks), "=", 0)}
+        for seed in (without, with_blocks):
+            # A throwaway ParsedDesign: the platform file's warnings
+            # belong to the platform, not to this design.
+            self._parse_file(
+                platform_config, base_dir, seed, ParsedDesign(config_path=""), set()
+            )
+
+        for var_name in sorted(with_blocks):
+            if var_name == "BLOCKS" or var_name in NON_ARGUMENT_VARS:
+                continue
+            if var_name in raw_vars:
+                # The design set it: the platform's `?=` never fires.
+                continue
+            new_value = with_blocks[var_name][0]
+            if var_name in without and without[var_name][0] == new_value:
+                continue
+
+            resolved = self._resolve_refs(new_value.strip(), ctx, result, 0)
+            if var_name in SOURCE_VARS:
+                labels = self._map_source_file(var_name, resolved, ctx, result, 0)
+                if labels:
+                    result.sources[var_name] = labels
+            else:
+                result.arguments[var_name] = resolved
+
+    @staticmethod
+    def _platform_config_path(config_path, platform):
+        """flow/platforms/<platform>/config.mk next to flow/designs/..."""
+        if not platform:
+            return None
+        parts = Path(config_path).parts
+        try:
+            designs_idx = len(parts) - 1 - parts[::-1].index("designs")
+        except ValueError:
+            return None
+        flow_dir = Path(*parts[:designs_idx]) if designs_idx else Path(".")
+        return str(flow_dir / "platforms" / platform / "config.mk")
+
     def _parse_file(self, filepath, base_dir, raw_vars, result, visited):
         """Parse a single file, handling includes recursively."""
         filepath = os.path.abspath(filepath)
@@ -342,13 +430,14 @@ class ConfigMkParser:
             lines = f.readlines()
 
         joined = _join_continuation_lines(lines)
-        in_conditional = 0  # nesting depth
-        # Track whether current branch at depth 1 is the "default" branch.
-        # The else branch is the default for ifeq/ifneq.
-        # For ifeq ($VAR,) (test-for-empty), the if-branch is default
-        # since Make variables are empty by default.
-        in_default_branch = False
-        cond_test_empty = False  # True when ifeq tests for empty value
+
+        # One frame per open conditional, innermost last.  A frame is
+        # either DECIDED -- make's outcome is knowable from the values
+        # parsed so far, so the taken branch is known exactly -- or
+        # UNDECIDED, where the historical heuristic applies: the
+        # if-branch of `ifeq ($(VAR),)` is the default (Make variables
+        # are empty unless set) and nothing else is.
+        frames = []
 
         for line_num, line in joined:
             stripped = line.strip()
@@ -359,43 +448,40 @@ class ConfigMkParser:
 
             # Handle conditionals
             if re.match(r"^(ifeq|ifneq|ifdef|ifndef)\b", stripped):
-                if in_conditional == 0:
+                if not frames:
                     result.has_conditionals = True
                     self._warn_conditional(stripped, line_num + 1, result)
-                    # ifeq ($(VAR),) tests for empty — if-branch is default
-                    cond_test_empty = bool(
-                        re.match(r"^ifeq\s+\(\$[\({].*[\)}]\s*,\s*\)", stripped)
-                    )
-                    in_default_branch = cond_test_empty
-                in_conditional += 1
+                frames.append(self._open_frame(stripped, raw_vars, len(frames)))
                 continue
 
             if stripped.startswith("else"):
-                # else/else ifeq — stay in conditional
-                if re.match(r"^else\s+(ifeq|ifneq|ifdef|ifndef)\b", stripped):
-                    self._warn_conditional(stripped, line_num + 1, result)
-                    in_default_branch = False
-                elif in_conditional == 1:
-                    # Plain else at depth 1: this is the default branch
-                    # (unless the if-branch was already the default)
-                    in_default_branch = not cond_test_empty
+                if frames:
+                    self._else_frame(stripped, raw_vars, frames)
+                    if re.match(r"^else\s+(ifeq|ifneq|ifdef|ifndef)\b", stripped):
+                        self._warn_conditional(stripped, line_num + 1, result)
                 continue
 
             if stripped == "endif":
-                if in_conditional == 1:
-                    in_default_branch = False
-                    cond_test_empty = False
-                in_conditional = max(0, in_conditional - 1)
+                if frames:
+                    frames.pop()
                 continue
 
-            # Inside conditionals: only accept assignments from the default branch
-            if in_conditional > 0:
+            # Inside conditionals: accept an assignment only from the
+            # branch make would take (decided frames), or from the
+            # heuristic default branch (undecided frames).
+            if frames:
+                accept = all(f["accepts"] for f in frames)
+                known_dead = any(f["decided"] and not f["taken"] for f in frames)
                 self._parse_assignment(
                     stripped,
                     line_num,
                     raw_vars,
                     result,
-                    conditional=not in_default_branch,
+                    conditional=not accept,
+                    # A branch make provably skips is not a variable that
+                    # "will be missing in Bazel" -- it is missing in make
+                    # too, so there is nothing to warn about.
+                    record_conditional_only=not known_dead,
                 )
                 continue
 
@@ -442,7 +528,187 @@ class ConfigMkParser:
                 stripped, line_num, raw_vars, result, conditional=False
             )
 
-    def _parse_assignment(self, line, line_num, raw_vars, result, conditional=False):
+    # ------------------------------------------------------------------
+    # Make conditionals
+    #
+    # The parser evaluates a conditional whenever the outcome is
+    # knowable: every variable the test references has already been
+    # assigned in this parse (the file itself or a file that included
+    # it).  That is not a cosmetic improvement.  asap7/riscv32i-mock-sram
+    # sets BLOCKS= and then includes asap7/riscv32i/config.mk, whose
+    #
+    #     ifeq ($(BLOCKS),)
+    #         export ADDITIONAL_LEFS = $(PLATFORM_DIR)/lef/fakeram7_256x32.lef
+    #         export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_256x32.lib
+    #     endif
+    #
+    # branch is exactly the branch make skips -- the platform's canned
+    # fakeram abstract is for the NON-hierarchical build; the
+    # hierarchical one builds its own.  Assuming the if-branch handed
+    # the parent both.
+    #
+    # When a referenced variable is unknown -- set by the platform
+    # config.mk, variables.mk, the environment or the command line, none
+    # of which this parser reads -- the historical heuristic stands: the
+    # if-branch of `ifeq ($(VAR),)` is the default, because an unset Make
+    # variable is empty, and no other branch is.
+    # ------------------------------------------------------------------
+
+    def _open_frame(self, directive, raw_vars, depth):
+        """Build the frame for a newly opened conditional."""
+        # `ifeq ($(VAR),)` tests for empty: its if-branch is the
+        # heuristic default, since an unset Make variable is empty.
+        test_empty = bool(
+            re.match(r"^ifeq\s+\(\$[\({].*[\)}]\s*,\s*\)", directive)
+        )
+        outcome = self._eval_conditional(directive, raw_vars)
+        frame = {
+            "test_empty": test_empty,
+            "decided": outcome is not None,
+            "taken": bool(outcome),
+            "seen_taken": bool(outcome),
+            # Only the outermost conditional ever had a "default branch";
+            # assignments nested deeper were never adopted on a guess.
+            "heur_default": test_empty and depth == 0,
+            "depth": depth,
+        }
+        self._set_accepts(frame)
+        return frame
+
+    def _else_frame(self, directive, raw_vars, frames):
+        """Advance the innermost frame onto its `else` / `else ifeq` arm."""
+        frame = frames[-1]
+        chained = re.match(r"^else\s+(ifeq|ifneq|ifdef|ifndef)\b", directive)
+        if chained:
+            outcome = None
+            if not frame["seen_taken"]:
+                outcome = self._eval_conditional(
+                    directive[len("else") :].strip(), raw_vars
+                )
+            if frame["seen_taken"]:
+                # An earlier arm already matched: make skips this one.
+                frame["decided"] = True
+                frame["taken"] = False
+            elif outcome is None:
+                frame["decided"] = False
+                frame["taken"] = False
+            else:
+                frame["decided"] = True
+                frame["taken"] = bool(outcome)
+                frame["seen_taken"] = frame["seen_taken"] or bool(outcome)
+            # A chained arm is never the heuristic default.
+            frame["heur_default"] = False
+        elif frame["decided"]:
+            # Plain else on a decided frame: taken iff nothing matched.
+            frame["taken"] = not frame["seen_taken"]
+            frame["seen_taken"] = True
+        else:
+            # Plain else on an undecided frame: the historical default,
+            # unless the if-branch already claimed it.
+            frame["heur_default"] = not frame["test_empty"] and frame["depth"] == 0
+        self._set_accepts(frame)
+
+    @staticmethod
+    def _set_accepts(frame):
+        frame["accepts"] = (
+            frame["taken"] if frame["decided"] else frame["heur_default"]
+        )
+
+    def _eval_conditional(self, directive, raw_vars):
+        """Evaluate a Make conditional; None when the outcome is unknown.
+
+        Args:
+            directive: the conditional text, e.g. `ifeq ($(BLOCKS),)`.
+            raw_vars: var -> (value, op, line) parsed so far.
+
+        Returns:
+            True if make would take this branch, False if it would skip
+            it, None if any variable the test references is unknown here.
+        """
+        match = re.match(r"^(ifeq|ifneq|ifdef|ifndef)\s+(.*)$", directive.strip())
+        if not match:
+            return None
+        kind, rest = match.group(1), match.group(2).strip()
+
+        if kind in ("ifdef", "ifndef"):
+            name = rest.split()[0] if rest.split() else ""
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+                return None
+            if name not in raw_vars:
+                # Could be set anywhere this parser does not read.
+                return None
+            defined = bool(raw_vars[name][0].strip())
+            return defined if kind == "ifdef" else not defined
+
+        args = self._split_condition_args(rest)
+        if args is None:
+            return None
+        left, right = (self._expand_known(a, raw_vars) for a in args)
+        if left is None or right is None:
+            return None
+        equal = left.strip() == right.strip()
+        return equal if kind == "ifeq" else not equal
+
+    @staticmethod
+    def _split_condition_args(rest):
+        """Split an ifeq/ifneq argument list into its two sides.
+
+        Handles both `(a,b)` and `"a" "b"` spellings; returns None for
+        anything else, including a comma nested inside a $(...) call.
+        """
+        if rest.startswith("(") and rest.endswith(")"):
+            inner = rest[1:-1]
+            depth = 0
+            for i, ch in enumerate(inner):
+                if ch in "({":
+                    depth += 1
+                elif ch in ")}":
+                    depth -= 1
+                elif ch == "," and depth == 0:
+                    return inner[:i], inner[i + 1 :]
+            return None
+        quoted = re.findall(r'"([^"]*)"|\'([^\']*)\'', rest)
+        if len(quoted) == 2:
+            return tuple(a or b for a, b in quoted)
+        return None
+
+    def _expand_known(self, text, raw_vars):
+        """Expand $(VAR)/${VAR} from raw_vars; None if anything is left.
+
+        Deliberately strict: a reference this parser cannot resolve, or
+        any Make function call, makes the whole conditional unknown
+        rather than silently comparing against a literal `$(...)`.
+        """
+        seen = set()
+        value = text
+        for _ in range(8):
+            refs = re.findall(
+                r"\$\(([A-Za-z_][A-Za-z0-9_]*)\)|\$\{([A-Za-z_][A-Za-z0-9_]*)\}",
+                value,
+            )
+            names = [a or b for a, b in refs]
+            if not names:
+                break
+            if any(n not in raw_vars for n in names):
+                return None
+            if any(n in seen for n in names):
+                return None
+            seen.update(names)
+            ctx = {n: raw_vars[n][0].strip() for n in names}
+            value = self._resolve_simple_refs(value, ctx)
+        if "$" in value:
+            return None
+        return value
+
+    def _parse_assignment(
+        self,
+        line,
+        line_num,
+        raw_vars,
+        result,
+        conditional=False,
+        record_conditional_only=True,
+    ):
         """Parse an export VAR = value line."""
         # Match: export VAR = value, export VAR ?= value, export VAR := value
         # Also: VAR = value (without export), and export VAR=value (no spaces)
@@ -467,7 +733,11 @@ class ConfigMkParser:
         # branches produces wrong configs. Warnings are deferred to
         # _check_conditional_warnings() after all branches are processed.
         if conditional:
-            if var_name not in raw_vars and var_name not in NON_ARGUMENT_VARS:
+            if (
+                record_conditional_only
+                and var_name not in raw_vars
+                and var_name not in NON_ARGUMENT_VARS
+            ):
                 result._conditional_only_vars = getattr(
                     result, "_conditional_only_vars", {}
                 )

--- a/config_mk_parser_test.py
+++ b/config_mk_parser_test.py
@@ -796,6 +796,308 @@ class TestConditionalParsing(unittest.TestCase):
         self.assertTrue(len(rel_warnings) > 0)
 
 
+class TestConditionalEvaluation(unittest.TestCase):
+    """Conditionals whose tested variable is known are evaluated.
+
+    The heuristic ("the if-branch of `ifeq ($(VAR),)` is the default,
+    since an unset Make variable is empty") only applies where the
+    parser genuinely cannot know.  Where the value has been assigned in
+    this parse, make's outcome is knowable and is followed exactly.
+    """
+
+    def setUp(self):
+        self.parser = ConfigMkParser()
+
+    def test_ifeq_empty_taken_when_var_unset(self):
+        """Unknown variable keeps the historical default-branch guess."""
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            ifeq ($(BLOCKS),)
+                export ABC_AREA = 1
+            else
+                export ABC_AREA = 0
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "1")
+
+    def test_ifeq_empty_skipped_when_var_set(self):
+        """A set BLOCKS makes the if-branch dead and the else live."""
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export BLOCKS = b1
+            ifeq ($(BLOCKS),)
+                export ABC_AREA = 1
+            else
+                export ABC_AREA = 0
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "0")
+
+    def test_ifeq_dead_branch_emits_no_missing_warning(self):
+        """A branch make also skips is not "missing in Bazel"."""
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export BLOCKS = b1
+            ifeq ($(BLOCKS),)
+                export CORE_UTILIZATION = 30
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertNotIn("CORE_UTILIZATION", result.arguments)
+        missing = [w for w in result.warnings if "only set inside conditional" in w.message]
+        self.assertEqual(missing, [])
+
+    def test_ifneq_evaluated(self):
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export BLOCKS = b1
+            ifneq ($(BLOCKS),)
+                export ABC_AREA = 1
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "1")
+
+    def test_ifeq_literal_compare_evaluated(self):
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export DESIGN_TYPE = CELL
+            ifeq ($(DESIGN_TYPE),CELL)
+                export ABC_AREA = 1
+            else
+                export ABC_AREA = 0
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "1")
+
+    def test_ifdef_evaluated(self):
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export BLOCKS = b1
+            ifdef BLOCKS
+                export ABC_AREA = 1
+            endif
+            ifndef BLOCKS
+                export CORE_UTILIZATION = 30
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "1")
+        self.assertNotIn("CORE_UTILIZATION", result.arguments)
+
+    def test_else_ifeq_chain_evaluated(self):
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export DESIGN_TYPE = RAM
+            ifeq ($(DESIGN_TYPE),CELL)
+                export ABC_AREA = 1
+            else ifeq ($(DESIGN_TYPE),RAM)
+                export ABC_AREA = 2
+            else
+                export ABC_AREA = 3
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "2")
+
+    def test_nested_conditional_both_decided(self):
+        """Nested branches are adopted when every enclosing test is known."""
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export BLOCKS = b1
+            export DESIGN_TYPE = RAM
+            ifneq ($(BLOCKS),)
+                ifeq ($(DESIGN_TYPE),RAM)
+                    export ABC_AREA = 1
+                endif
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.arguments["ABC_AREA"], "1")
+
+    def test_unknown_function_call_stays_undecided(self):
+        """A Make function in the test is not guessed at."""
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = test
+            export CORNER = BC
+            ifeq ($(filter BC,$(CORNER)),)
+                export ABC_AREA = 1
+            endif
+        """
+        )
+        result = self.parser.parse(config)
+        # Undecided: the historical test-for-empty default still applies.
+        self.assertEqual(result.arguments["ABC_AREA"], "1")
+
+    def test_include_sets_variable_for_includee_conditional(self):
+        """The includer's BLOCKS decides a conditional in the included file.
+
+        This is asap7/riscv32i-mock-sram: it sets BLOCKS= and then
+        includes asap7/riscv32i/config.mk, whose `ifeq ($(BLOCKS),)`
+        branch carries the NON-hierarchical fakeram abstract.
+        """
+        tmpdir = tempfile.mkdtemp()
+        base = os.path.join(tmpdir, "flow/designs/asap7")
+        os.makedirs(os.path.join(base, "parent"), exist_ok=True)
+        os.makedirs(os.path.join(base, "child"), exist_ok=True)
+
+        with open(os.path.join(base, "child", "config.mk"), "w") as f:
+            f.write("export PLATFORM = asap7\n")
+            f.write("export DESIGN_NAME = child\n")
+            f.write("ifeq ($(BLOCKS),)\n")
+            f.write("\texport ADDITIONAL_LEFS = $(PLATFORM_DIR)/lef/canned.lef\n")
+            f.write("endif\n")
+
+        config = os.path.join(base, "parent", "config.mk")
+        with open(config, "w") as f:
+            f.write("export DESIGN_NICKNAME = parent\n")
+            f.write("export BLOCKS = b1\n")
+            f.write("include designs/asap7/child/config.mk\n")
+
+        result = self.parser.parse(config)
+        self.assertEqual(result.blocks, ["b1"])
+        self.assertNotIn("ADDITIONAL_LEFS", result.sources)
+        self.assertNotIn("ADDITIONAL_LEFS", result.arguments)
+
+
+class TestPlatformBlocksVars(unittest.TestCase):
+    """A platform config.mk that branches on BLOCKS is resolved here.
+
+    BLOCKS never reaches a bazel action, so the make-time include of
+    flow/platforms/<p>/config.mk would take the non-hierarchical branch
+    for a hierarchical parent.  asap7 selects PDN_TCL that way.
+    """
+
+    def setUp(self):
+        self.parser = ConfigMkParser()
+
+    def _tree(self, design_body, platform_body="", platform="asap7"):
+        tmpdir = tempfile.mkdtemp()
+        design_dir = os.path.join(tmpdir, "flow/designs", platform, "parent")
+        platform_dir = os.path.join(tmpdir, "flow/platforms", platform)
+        os.makedirs(design_dir, exist_ok=True)
+        os.makedirs(platform_dir, exist_ok=True)
+        config = os.path.join(design_dir, "config.mk")
+        with open(config, "w") as f:
+            f.write(textwrap.dedent(design_body))
+        if platform_body:
+            with open(os.path.join(platform_dir, "config.mk"), "w") as f:
+                f.write(textwrap.dedent(platform_body))
+        return config
+
+    _PLATFORM_PDN = """\
+        ifeq ($(BLOCKS),)
+           export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/flat.tcl
+        else
+           export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/BLOCKS.tcl
+        endif
+        export PLACE_DENSITY ?= 0.60
+    """
+
+    def test_blocks_branch_adopted(self):
+        config = self._tree(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = parent
+            export BLOCKS = b1
+            """,
+            self._PLATFORM_PDN,
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(
+            result.sources["PDN_TCL"],
+            ["//flow:platforms/asap7/openRoad/pdn/BLOCKS.tcl"],
+        )
+        # Only what BLOCKS actually changes is adopted.
+        self.assertNotIn("PLACE_DENSITY", result.arguments)
+
+    def test_no_blocks_leaves_platform_alone(self):
+        """Without BLOCKS the make-time default already matches."""
+        config = self._tree(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = parent
+            """,
+            self._PLATFORM_PDN,
+        )
+        result = self.parser.parse(config)
+        self.assertNotIn("PDN_TCL", result.sources)
+
+    def test_design_pdn_wins(self):
+        """The platform uses ?=, so a design's own value stands."""
+        config = self._tree(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = parent
+            export BLOCKS = b1
+            export PDN_TCL = $(PLATFORM_DIR)/openRoad/pdn/mine.tcl
+            """,
+            self._PLATFORM_PDN,
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(
+            result.sources["PDN_TCL"],
+            ["//flow:platforms/asap7/openRoad/pdn/mine.tcl"],
+        )
+
+    def test_platform_without_blocks_conditional_is_noop(self):
+        config = self._tree(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = parent
+            export BLOCKS = b1
+            """,
+            """\
+            export PLACE_DENSITY ?= 0.60
+            export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/flat.tcl
+            """,
+        )
+        result = self.parser.parse(config)
+        self.assertNotIn("PDN_TCL", result.sources)
+        self.assertNotIn("PLACE_DENSITY", result.arguments)
+
+    def test_missing_platform_config_is_tolerated(self):
+        config = self._tree(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = parent
+            export BLOCKS = b1
+            """
+        )
+        result = self.parser.parse(config)
+        self.assertEqual(result.blocks, ["b1"])
+        self.assertNotIn("PDN_TCL", result.sources)
+
+
 class TestBlocksSubMacros(unittest.TestCase):
     """Test BLOCKS variable and sub-macro config discovery."""
 
@@ -1154,6 +1456,15 @@ class TestIntegrationComplex(unittest.TestCase):
         self.assertEqual(result.platform, "asap7")
         self.assertEqual(result.blocks, ["fakeram7_256x32"])
         self.assertTrue(len(result.block_configs) == 1)
+        # BLOCKS= is set here and riscv32i/config.mk, which this file
+        # includes, guards the platform's canned fakeram abstract with
+        # `ifeq ($(BLOCKS),)`.  make skips that branch; so must the
+        # parser, or the parent gets both the canned abstract and the
+        # one its own block build produces.
+        self.assertNotIn("ADDITIONAL_LEFS", result.sources)
+        self.assertNotIn("ADDITIONAL_LIBS", result.sources)
+        self.assertNotIn("ADDITIONAL_LEFS", result.arguments)
+        self.assertNotIn("ADDITIONAL_LIBS", result.arguments)
 
     def test_asap7_aes_block(self):
         """Has BLOCKS for hierarchical synthesis via a shared block.mk."""

--- a/docs/orfs-design-builds.md
+++ b/docs/orfs-design-builds.md
@@ -178,6 +178,87 @@ The test's invariant for `src/` is stated exactly: every canonical
 the rule. Run it against a real tree with `ORFS_DESIGNS_DIR` as described
 in the test file.
 
+## Hierarchical designs: what `BLOCKS=` means under bazel
+
+Four ORFS designs set `BLOCKS=` — `asap7/aes-block`,
+`asap7/riscv32i-mock-sram`, `gf180/uart-blocks`,
+`ihp-sg13g2/i2c-gpio-expander` — and all four are live in ORFS CI (each
+ships `rules-base.json`, and ORFS's metric-rebase commits move their
+numbers). `BLOCKS` itself is a make-only concept: `flow/Makefile` turns
+it into per-block `generate_abstract` rules and appends the resulting
+`.lef`/`.lib` to `ADDITIONAL_LEFS`/`ADDITIONAL_LIBS`. It is not a flow
+variable — it has no `stages:` entry in `variables.yaml` — so
+bazel-orfs never exports it, and `orfs_design()` builds the sub-macro
+flows itself.
+
+Two consequences of that had to be handled explicitly.
+
+**A platform `config.mk` may branch on it.** asap7 does:
+
+```make
+ifeq ($(BLOCKS),)
+   export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/grid_strategy-M1-M2-M5-M6.tcl
+else
+   export PDN_TCL ?= $(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl
+endif
+```
+
+make includes the platform file after the design's, with `BLOCKS` set,
+so a hierarchical parent gets the BLOCKS grid — a M5/M6 core ring, an
+ElementGrid over the macros, M5-M6 macro connects — where the flat grid
+has no ring and connects macros at M4/M5. Inside a bazel action
+`BLOCKS` is empty, so the same include silently picked the flat grid.
+The parser now resolves this: for a design with blocks it parses the
+platform `config.mk` twice, once with `BLOCKS` empty and once with it
+set, and adopts the variables whose value actually differs — and only
+where the design has not set them itself, matching the platform's `?=`.
+Resolving it here rather than exporting `BLOCKS` is deliberate:
+exporting it would also wake `flow/Makefile`'s own BLOCKS machinery
+inside the sandbox, whose `BLOCK_LEFS` are make-relative `results/`
+paths that do not exist there.
+
+**A design `config.mk` may branch on it too.** `riscv32i-mock-sram`
+sets `BLOCKS=fakeram7_256x32` and then includes `riscv32i/config.mk`,
+which guards the platform's canned fakeram abstract with `ifeq
+($(BLOCKS),)` — the branch for the *non*-hierarchical build. The parser
+evaluates a conditional whenever every variable it references has
+already been assigned in that parse, so this branch is now skipped as
+make skips it. Where a referenced variable is genuinely unknown — set
+by the platform file, `variables.mk`, the environment or the command
+line — the old heuristic stands: the if-branch of `ifeq ($(VAR),)` is
+the default, because an unset Make variable is empty.
+
+Sub-block abstracts are taken from `6_final`, as ORFS's
+`generate_abstract` does. `ADDITIONAL_GDS` and the per-corner
+fast/slow libs are still unwired; see the "BLOCKS= caveat" in
+[TESTING.md](../TESTING.md) for exactly what matches make and what
+does not.
+
+### `asap7/aes-block` is knife-edge upstream
+
+Worth knowing before you read a red `aes_cipher_top_test` as a
+bazel-orfs bug. The design has 20 `aes_sbox` macros of 15.87 um side
+plus one `aes_rcon`, `MACRO_PLACE_HALO = 3 3`, and
+`CORE_UTILIZATION = 47`. A halo'd sbox is 21.87 um, so RTL-MP needs
+five columns — a core side of at least 109.33 um — and four columns
+give only 16 slots for 20 macros. The core side is
+`sqrt((macro area + std cell area) / 0.47)`, so it moves with the
+synthesised area, and at 486.7 um² of std cells it comes out 109.14 um:
+0.19 um short, and `macro_place` dies with
+
+```
+[ERROR MPL-0003] There are no valid tilings for mixed cluster: root
+```
+
+Verified by bisecting the utilization on the floorplan `_deps`
+reproducer: 46 gives a 110.32 um core and places, 47 gives 109.14 um
+and does not, with the same 21 macros and the same halo. ORFS CI clears
+the cliff by about half a micron — its `synth__design__instance__area__stdcell`
+golden of 631 is 15% padding over roughly 549 um², which puts the core
+at about 109.8 um. So a *smaller* netlist is what breaks it. Any change
+that shifts synthesis by a fraction of a percent can flip this design,
+in either direction, and none of the `BLOCKS=` handling above moves it.
+
 ## The ORFS cleanup PR
 
 > Superseded in scope by

--- a/private/designs.bzl
+++ b/private/designs.bzl
@@ -72,6 +72,20 @@ def _orfs_designs_impl(repository_ctx):
     # deletions as well as edits.
     repository_ctx.watch_tree(designs_path.dirname)
 
+    # The parser also reads flow/platforms/<p>/config.mk for a design
+    # with BLOCKS=, to resolve the variables that file selects on BLOCKS
+    # (asap7 picks PDN_TCL that way -- see
+    # config_mk_parser._apply_platform_blocks_vars). It sits outside the
+    # designs tree watched above, so watch it here or an edit to it
+    # leaves DESIGNS stale.
+    platforms_dir = str(designs_path.dirname.dirname) + "/platforms"
+    for platform in repository_ctx.attr.platforms:
+        platform_config = repository_ctx.path(
+            platforms_dir + "/" + platform + "/config.mk",
+        )
+        if platform_config.exists:
+            repository_ctx.watch(platform_config)
+
     platforms_arg = ",".join(repository_ctx.attr.platforms)
     result = repository_ctx.execute(
         [python, str(parser_path), "--all", designs_dir, "--platforms", platforms_arg, "--json"],

--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -342,8 +342,8 @@ def _filter_verilog_files(raw_verilog_files, design = None):
         # entry are broken under bazel today, and failing here would stop
         # their package loading outright rather than letting the rest of
         # the repo build.
+        # buildifier: disable=print
         print("%s: dropped %d VERILOG_FILES entr%s that could not be made into labels; the design will elaborate without %s:\n%s\nSpell the path out in config.mk if the file is needed under bazel." % (
-            # buildifier: disable=print
             design or "orfs_design",
             len(dropped),
             "y" if len(dropped) == 1 else "ies",
@@ -362,6 +362,27 @@ def _collect_include_dirs(arguments):
         if inc_dir:
             extra_data.append("//" + inc_dir + ":include")
     return extra_data
+
+# ORFS's flow/Makefile builds a BLOCKS sub-macro all the way to
+# `finish` -- `generate_abstract` depends on 6_final.gds/.def/.v/.sdc --
+# and no ORFS design sets ABSTRACT_SOURCE, so make always abstracts a
+# block from 6_final.  orfs_flow()'s own default is the same ("final"),
+# so blocks simply take it.
+#
+# It used to be pinned to "cts" here, which is a real divergence and not
+# just a speed trade: a post-CTS abstract's .lef carries no
+# detail-route geometry and its .lib no post-route parasitics, so the
+# parent saw macro timing and blockages ORFS CI never measured.
+#
+# It does not fix ADDITIONAL_GDS, which make also derives from a block's
+# 6_final: a .gds comes from a separate orfs_gds target that orfs_flow()
+# does not instantiate, so a block macro has no .gds to forward
+# whatever stage it stops at.  See TESTING.md, "BLOCKS= caveat".
+#
+# A design that wants the cheaper abstract can still say so: BUILD-level
+# orfs_flow(abstract_stage = ...) is unaffected by this default, and
+# ORFS's own ABSTRACT_SOURCE reaches generate_abstract as ever.
+_BLOCK_ABSTRACT_STAGE = "final"
 
 def _create_block_targets(config, designs, platform, design, pkg, tags, mock_openroad, mock_yosys = None):
     """Create sub-macro orfs_flow() targets for BLOCKS.
@@ -389,7 +410,7 @@ def _create_block_targets(config, designs, platform, design, pkg, tags, mock_ope
         # Real flow
         orfs_flow(
             name = block_config["name"],
-            abstract_stage = "cts",
+            abstract_stage = _BLOCK_ABSTRACT_STAGE,
             verilog_files = block_verilog,
             pdk = "//flow:" + platform,
             arguments = block_config["arguments"],
@@ -402,7 +423,7 @@ def _create_block_targets(config, designs, platform, design, pkg, tags, mock_ope
         if mock_openroad:
             lint_kwargs = dict(
                 name = block_config["name"],
-                abstract_stage = "cts",
+                abstract_stage = _BLOCK_ABSTRACT_STAGE,
                 verilog_files = block_verilog,
                 pdk = "//flow:" + platform,
                 arguments = block_config["arguments"],


### PR DESCRIPTION
`asap7/aes-block` is live in ORFS CI, not dead — it ships
`rules-base.json`, and ORFS's metric-rebase commits move its numbers
(`ef2e3afc4` "update metrics asap7", 2026-09-01, changed its cts,
globalroute, detailedroute and finish values). So are the other three
designs that set `BLOCKS=`: `asap7/riscv32i-mock-sram`,
`gf180/uart-blocks`, `ihp-sg13g2/i2c-gpio-expander`.

That makes any bazel-vs-make divergence in the `BLOCKS=` path a
faithfulness bug rather than a dead corner. Three were real.

## 1. The asap7 parent got the wrong PDN grid

`flow/platforms/asap7/config.mk` selects `PDN_TCL` on `$(BLOCKS)`:
the BLOCKS grid adds a M5/M6 core ring and an ElementGrid over the
macros with M5-M6 connects, the flat one has no ring and connects
macros at M4/M5. aes-block's macros stop at M5.

`BLOCKS` is a make concept — `flow/Makefile` turns it into the
per-block `generate_abstract` rules, and it has no `stages:` entry in
`variables.yaml` — so bazel-orfs never exports it, and inside a bazel
action that `ifeq` always took the flat branch. Verified before the
fix: the parent's generated `2_floorplan.mk` had no `PDN_TCL` at all.

The parser now parses the platform `config.mk` twice, once with
`BLOCKS` empty and once with it set, and adopts only the variables
whose value actually differs — and only where the design has not set
them itself, matching the platform's `?=`. For aes-block that is
exactly one variable. Exporting `BLOCKS` instead would also wake the
Makefile's own BLOCKS machinery inside the sandbox, whose `BLOCK_LEFS`
are make-relative `results/` paths that do not exist there.

After: `export PDN_TCL?=.../pdn/BLOCKS_grid_strategy.tcl`, and the
blocks keep their own `BLOCK_grid_strategy.tcl`.

## 2. `ifeq ($(BLOCKS),)` in a design config.mk was never evaluated

The parser assumed the if-branch of `ifeq ($(VAR),)` on the grounds
that Make variables default to empty — without checking whether the
variable had been assigned. `riscv32i-mock-sram` sets
`BLOCKS=fakeram7_256x32` and then includes `riscv32i/config.mk`, whose
guarded branch carries the platform's canned fakeram `.lef`/`.lib` —
the pair for the *non*-hierarchical build. The parent was handed both
that and the abstract its own block build produces.

Conditionals (`ifeq`/`ifneq`/`ifdef`/`ifndef`, including `else if`
chains and nesting) are now evaluated whenever every variable the test
references is already assigned in that parse. Where a value is
genuinely unknown — the platform file, `variables.mk`, the environment,
the command line — the old heuristic stands unchanged. A Make function
in the test is not guessed at.

## 3. Sub-macro abstracts came from cts, make's come from `6_final`

`_create_block_targets` pinned `abstract_stage = "cts"`. ORFS's
`generate_abstract` depends on `6_final.gds/.def/.v/.sdc` and no ORFS
design sets `ABSTRACT_SOURCE`, so make always abstracts a block from
`6_final`; a post-CTS `.lef` carries no detail-route geometry and its
`.lib` no post-route parasitics. Blocks now take `orfs_flow()`'s own
default, which is already `final`.

`ADDITIONAL_GDS` and the per-corner fast/slow libs stay unwired, for
reasons that are *not* the abstract stage — a `.gds` comes from a
separate `orfs_gds` target that `orfs_flow()` does not instantiate.
`TESTING.md` now states what matches make and what does not, instead
of the stale claim that sub-block abstracts never reach the parent
synth action (they do — verified in the parent's `1_synth.mk`).

## What this does not fix: aes-block is knife-edge upstream

`aes_cipher_top_test` is red here and green in ORFS CI, and none of the
above moves it. The design has 20 `aes_sbox` macros of 15.87um side,
`MACRO_PLACE_HALO = 3 3` and `CORE_UTILIZATION = 47`. A halo'd sbox is
21.87um, so RTL-MP needs five columns — a core side of at least
109.33um — and four columns give 16 slots for 20 macros. The core side
is `sqrt((macro area + std cell area) / 0.47)`, so it follows the
synthesised area, and at 486.7um² of std cells it comes out 109.14um:
0.19um short, and `macro_place` dies with

```
[ERROR MPL-0003] There are no valid tilings for mixed cluster: root
```

Verified by bisecting the utilization on the floorplan `_deps`
reproducer, same 21 macros and same halo throughout:

| `CORE_UTILIZATION` | core side | `macro_place` |
| --- | --- | --- |
| 44 | 112.81um | places |
| 46 | 110.32um | places |
| 47 | 109.14um | MPL-0003 |

ORFS CI clears the cliff by about half a micron — its
`synth__design__instance__area__stdcell` golden of 631 is 15% padding
over roughly 549um², putting the core near 109.8um. So a *smaller*
netlist is what breaks it, and any change that shifts synthesis by a
fraction of a percent can flip this design either way. Recorded in
`docs/orfs-design-builds.md` so a future red aes-block is not read as a
DSL bug. Giving it headroom means changing a CI-golden ORFS design, so
it is reported here rather than acted on.

## Verification

- `//:config_mk_parser_test`: 105 tests, 15 new (10 for conditional
  evaluation, 5 for the platform BLOCKS path).
- `bazelisk test ...`: 165 tests pass.
- Load and analyse steps over every `@orfs//flow/designs` package and
  every design's `_route`: clean. All four `BLOCKS=` parents analyse.
- `//:fix_lint`, `//:public_surface`, `//:host_tools`: clean.
- Only PDN_TCL is adopted for aes-block; every non-asap7 platform is a
  no-op (no other platform `config.mk` mentions BLOCKS).
