### PR TITLE
study: the unit-RC calibration's memory is the ODB Tcl read-back, not the extraction

### DIFF
--- a/test/rc_readback/object_probe.tcl
+++ b/test/rc_readback/object_probe.tcl
@@ -1,0 +1,28 @@
+proc rss {} {
+  set f [open /proc/self/status r]; set d [read $f]; close $f
+  regexp {VmRSS:\s+(\d+) kB} $d -> cur
+  return [expr { $cur / 1048576.0 }]
+}
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 6_final.odb 6_final.sdc
+puts "DISTINCT baseline rss=[format %.2f [rss]] GB"
+
+# Distinct objects: one dbWire per net, each surfaced to Tcl exactly once.
+set before [rss]
+set n 0
+foreach db_net [[ord::get_db_block] getNets] {
+  set w [$db_net getWire]
+  incr n
+}
+set after [rss]
+puts [format "DISTINCT getWire over %d distinct nets: rss=%.2f GB delta=%.2f GB per_object=%.1f B" \
+  $n $after [expr {$after-$before}] [expr {($after-$before)*1048576.0*1024.0/$n}]]
+
+# Same count of calls, but all on ONE net -- the control.
+set one [lindex [[ord::get_db_block] getNets] 0]
+set before [rss]
+for { set i 0 } { $i < $n } { incr i } { set w [$one getWire] }
+set after [rss]
+puts [format "DISTINCT getWire %d times on ONE net: delta=%.2f GB per_call=%.1f B" \
+  $n [expr {$after-$before}] [expr {($after-$before)*1048576.0*1024.0/$n}]]
+puts "DISTINCT done"

--- a/test/rc_readback/walk_probe.tcl
+++ b/test/rc_readback/walk_probe.tcl
@@ -1,0 +1,113 @@
+# Where the unit-RC calibration's memory goes.
+#
+# `make write_rc` (docs/tutorials/SetRC.md) extracts per-segment parasitics and
+# then reads them back through the ODB Tcl API to write the CSV the fit
+# consumes. This probe separates the three costs -- loading the design,
+# extracting, and reading back -- and reports RSS as the read-back proceeds, so
+# growth that is proportional to segments visited is visible as it happens
+# rather than inferred from a final number.
+#
+# WALK_MODE selects how much of the read-back loop runs, so the growth can be
+# attributed to one accessor by difference:
+#
+#   full     what write_segments_rc_csv does
+#   nocap    drops getTotalCapacitance
+#   noshape  drops getShape / getTechLayer
+#   rsegs    getRSegs only, no accessors
+#
+# Rows go to /dev/null: this measures the read-back, not the file write.
+#
+# It deliberately does not run estimate_parasitics or read_spef. Neither feeds
+# the segment walk; write_rc.tcl performs them for its net-level comparison
+# CSV, and skipping them takes both time and memory off every iteration here.
+
+proc rss { label } {
+  set f [open /proc/self/status r]
+  set d [read $f]
+  close $f
+  regexp {VmRSS:\s+(\d+) kB} $d -> cur
+  regexp {VmHWM:\s+(\d+) kB} $d -> hwm
+  puts [format "RCPROBE %-34s rss=%7.2f GB  hwm=%7.2f GB" \
+    $label [expr { $cur / 1048576.0 }] [expr { $hwm / 1048576.0 }]]
+  flush stdout
+}
+
+set mode [expr { [info exists ::env(WALK_MODE)] ? $::env(WALK_MODE) : "full" }]
+set report_every [expr { [info exists ::env(WALK_REPORT_NETS)]
+                         ? $::env(WALK_REPORT_NETS) : 10000 }]
+
+rss "start"
+
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 6_final.odb 6_final.sdc
+rss "after load_design"
+
+extract_parasitics -ext_model_file $::env(RCX_RULES) -max_res 0 -no_merge_via_res
+rss "after extract_parasitics"
+
+puts "RCPROBE walk mode=$mode report_every=$report_every"
+
+set stream [open /dev/null "w"]
+set net_i 0
+set seg_i 0
+
+foreach db_net [[ord::get_db_block] getNets] {
+  set type [$db_net getSigType]
+
+  if { !([string equal $type "CLOCK"] || [string equal $type "SIGNAL"]) } {
+    continue
+  }
+
+  set wire [$db_net getWire]
+
+  if { $wire eq "NULL" } {
+    continue
+  }
+
+  set net_name [$db_net getName]
+  set net_type [expr { $type eq "CLOCK" ? "clock" : "signal" }]
+
+  foreach rseg [$db_net getRSegs] {
+    incr seg_i
+
+    if { $mode eq "rsegs" } {
+      continue
+    }
+
+    if { $mode ne "noshape" } {
+      set shape [$wire getShape [$rseg getShapeId]]
+
+      if { ![$shape isSegment] } {
+        continue
+      }
+
+      set layer [[$shape getTechLayer] getName]
+      set width [$shape getDX]
+      set height [$shape getDY]
+      set length_um [ord::dbu_to_microns [expr { max($width, $height) }]]
+    } else {
+      set layer "-"
+      set length_um 1.0
+    }
+
+    set resistance [$rseg getResistance 0]
+
+    if { $mode ne "nocap" } {
+      set capacitance [$rseg getTotalCapacitance 0]
+    } else {
+      set capacitance 0.0
+    }
+
+    puts $stream [format "%s,%s,%s,%.3e,%.3e,%.3e" \
+      $net_name $net_type $layer $length_um $resistance $capacitance]
+  }
+
+  incr net_i
+
+  if { $net_i % $report_every == 0 } {
+    rss "walked nets=$net_i segs=$seg_i"
+  }
+}
+
+close $stream
+rss "walk done nets=$net_i segs=$seg_i"


### PR DESCRIPTION
**This is a documentation PR: it is here to be read, then closed.** The two
probes are the evidence; the finding is below.

ORFS's unit-RC calibration (`docs/tutorials/SetRC.md`, reachable from bazel via
`//:rc.bzl`) is unusable on a large design — not because the extraction is
expensive, but because reading the results back through the ODB Tcl API is.

## The finding

**Every distinct ODB object surfaced to Tcl retains about a kilobyte for the
life of the interpreter. Touching the same object again is free.**

```
getWire over 2,015,167 DISTINCT nets   ->  +2.29 GB   1222.6 B per object
getWire 2,015,167 times on ONE net     ->  +0.00 GB      0.0 B per call
```

That is `object_probe.tcl`. It needs a loaded design and nothing else — no
extraction, no flow run — so it reproduces in seconds on any routed design.

## Why it matters for write_rc

`write_segments_rc_csv` walks every routed segment and, per segment, surfaces a
`dbRSeg`, a `dbShape` and a `dbTechLayer`. On a large routed design that is tens
of millions of distinct objects, and the retention is what the calibration dies
of.

Measured with `walk_probe.tcl` on a routed ASAP7 design of roughly 2M nets and
50M extracted segments, with rows written to `/dev/null` so this is read-back
cost only:

| step | RSS |
| --- | --- |
| after `load_design` | 9 GB |
| after `extract_parasitics -max_res 0 -no_merge_via_res` | 20 GB |
| after the read-back walk | **85 GB** |

The extraction — 55M rsegs, 55M capnodes, 40M coupling segments — costs about
11 GB. Reading it back costs about 65 GB.

## Which accessors

`WALK_MODE` drops parts of the loop body, so the growth attributes by
difference:

| mode | accessors per segment | growth over the 20 GB baseline | per segment |
| --- | --- | --- | --- |
| `full` | `getRSegs`, `getShape`, `getTechLayer`, `getResistance`, `getTotalCapacitance` | 65 GB | 1.23 KB |
| `noshape` | `getRSegs`, `getResistance`, `getTotalCapacitance` | 30 GB | 0.56 KB |
| `rsegs` | `getRSegs` only | 30 GB | 0.56 KB |

`rsegs` and `noshape` are identical: dropping `getResistance` and
`getTotalCapacitance` changes nothing, and those are exactly the two that return
plain doubles rather than objects. All of the growth is object-returning calls —
`getRSegs` at ~0.56 KB per segment and `getShape` at ~0.67 KB. The per-object
cost tracks object size (`dbRSeg` < `dbShape` < `dbWire`), which is what a
retained heap copy per object would look like.

## Three things this rules out

Each of these looked plausible and cost a measurement to eliminate. They are
recorded so nobody re-treads them:

- **RCX extraction is not the problem.** It completes in about 11 GB, below what
  global routing needs on the same design.
- **Coupling capacitance is not the problem.** `getTotalCapacitance` traverses
  ~40M coupling segments and costs nothing measurable; raising
  `-coupling_threshold` would not have helped. (It would also have been
  unsound: below-threshold coupling is re-added via
  `addFringe(nullptr, rseg2, ...)`, one side only, per an upstream FIXME.)
- **The Tcl accumulation is not the problem.** `fetch_segments_rc` collected
  four Tcl objects per segment before writing anything, which looks like the
  obvious culprit; removing it does not move the slope. That change is
  worth having on its own terms and is
  https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4523, but it
  is not a memory fix.

## Where this goes

The cost is incurred by surfacing objects across the boundary at all, so no
Tcl-side change avoids it — the data is only reachable through those objects.
The fix belongs in ODB: a bulk accessor returning a net's segment parasitics as
plain values in one crossing, instead of three objects per segment. Filed as
an OpenROAD issue with a proposed shape.

Once that exists, the ORFS side is a small change to
`write_segments_rc_csv` to consume it, which is what would follow here after an
ORFS bump onto an OpenROAD carrying the accessor.

## Running the probes

They load a `final` ODB, so they run against a design that has been through the
flow. Invoke them through a deployed `_deps` tree rather than as bazel targets:
`RESULTS_DIR` derives from the package declaring a run, not the one that built
the design, so a target declared elsewhere looks for the ODB in the wrong place
and fails with `ORD-0007 ... does not exist`, which reads as a missing input.

```bash
bazelisk run //flow/designs/asap7/<design>:<design>_final_deps -- --install "$PWD/tmp/rc"
cd tmp/rc/_main
mkdir -p bazel-out/k8-opt && ln -sfn "$PWD" bazel-out/k8-opt/bin
WALK_MODE=full ./flow/designs/asap7/<design>/make_<...>_run \
  run RUN_SCRIPT="$PWD/../../../test/rc_readback/walk_probe.tcl"
```

Two things that otherwise cost an afternoon: a deployed `_deps` tree needs that
`bazel-out/k8-opt/bin` symlink before make will run, because `config.mk`
includes the stage `.mk` by its `bazel-out/` path; and OpenROAD's Tcl has no
`clock format`, so probe scripts stick to `clock seconds`.
