### PR TITLE
feat(auto-memories): make ORFS AUTO_MEMORIES work under bazel

### DIFF
--- a/config.bzl
+++ b/config.bzl
@@ -16,6 +16,7 @@ CONFIG_KLAYOUT = "{klayout}"
 CONFIG_MAKE = "{make}"
 CONFIG_MAKEFILE = "{makefile}"
 CONFIG_MAKEFILE_YOSYS = "{makefile_yosys}"
+CONFIG_FAKERAM = "{fakeram}"
 CONFIG_OPENROAD = "{openroad}"
 CONFIG_OPENROAD_QT = "{openroad_qt}"
 CONFIG_OPENSTA = "{opensta}"
@@ -30,6 +31,7 @@ NUM_CPUS = {num_cpus}
             make = repository_ctx.attr.make,
             makefile = repository_ctx.attr.makefile,
             makefile_yosys = repository_ctx.attr.makefile_yosys,
+            fakeram = repository_ctx.attr.fakeram,
             openroad = repository_ctx.attr.openroad,
             openroad_qt = repository_ctx.attr.openroad_qt,
             opensta = repository_ctx.attr.opensta,
@@ -57,6 +59,7 @@ global_config = repository_rule(
         ),
         "makefile": attr.label(mandatory = True),
         "makefile_yosys": attr.label(mandatory = True),
+        "fakeram": attr.label(mandatory = True),
         "openroad": attr.label(
             mandatory = True,
             cfg = "exec",

--- a/config_mk_parser.py
+++ b/config_mk_parser.py
@@ -57,6 +57,11 @@ SOURCE_VARS = {
     "FOOTPRINT_TCL",
     "SDC_FILE_EXTRA",
     "SC_LEF",
+    # AUTO_MEMORIES: user-supplied .memories files merged onto what the
+    # scanner detects. gen_memories.py reads them by path during
+    # canonicalization, so they have to be staged like any other source
+    # rather than passed as a string.
+    "ADDITIONAL_MEMORIES",
 }
 
 # Variables that are purely for path resolution, not passed to orfs_flow()

--- a/config_mk_parser_test.py
+++ b/config_mk_parser_test.py
@@ -551,6 +551,28 @@ class TestVariableClassification(unittest.TestCase):
             self.assertIn(var, result.sources, f"{var} should be in sources")
             self.assertNotIn(var, result.arguments, f"{var} should not be in arguments")
 
+    def test_additional_memories_is_source(self):
+        """AUTO_MEMORIES: the .memories file is read by path, so it must
+        be staged rather than passed through as an argument string.
+
+        asap7/tinyRocket is the design that exercises this; before the
+        variable was classified, canonicalization failed on
+        "No rule to make target '.../tag_array.memories'".
+        """
+        config, _ = _write_config(
+            """\
+            export PLATFORM = asap7
+            export DESIGN_NAME = RocketTile
+            export AUTO_MEMORIES = 1
+            export ADDITIONAL_MEMORIES = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/tag_array.memories
+        """
+        )
+        result = self.parser.parse(config)
+        self.assertIn("ADDITIONAL_MEMORIES", result.sources)
+        self.assertNotIn("ADDITIONAL_MEMORIES", result.arguments)
+        # AUTO_MEMORIES itself is a plain flag and stays an argument.
+        self.assertEqual(result.arguments.get("AUTO_MEMORIES"), "1")
+
     def test_core_utilization_is_argument(self):
         config, _ = _write_config(
             """\

--- a/extension.bzl
+++ b/extension.bzl
@@ -78,6 +78,13 @@ _default_tag = tag_class(
             mandatory = False,
             default = Label("@orfs//flow:makefile_yosys"),
         ),
+        # FakeRAM, which AUTO_MEMORIES shells out to for the generated
+        # .lib/.lef views. ORFS vendors it at tools/FakeRAM2.0; the
+        # standalone repository is archived.
+        "fakeram": attr.label(
+            mandatory = False,
+            default = Label("@orfs//tools/FakeRAM2.0:all_files"),
+        ),
         "openroad": attr.label(
             mandatory = False,
             cfg = "exec",
@@ -180,6 +187,7 @@ def _orfs_repositories_impl(module_ctx):
             make = default.make,
             makefile = default.makefile,
             makefile_yosys = default.makefile_yosys,
+            fakeram = default.fakeram,
             openroad = default.openroad,
             openroad_qt = default.openroad_qt,
             opensta = default.opensta,

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -247,10 +247,20 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+# scripts/memories/*.tcl is listed separately from scripts/*.tcl below
+# because a glob wildcard does not cross a directory separator: neither
+# `scripts/*.tcl` (the makefile group) nor `scripts/synth*.tcl` (the
+# yosys group) matches scripts/memories/extract_memories.tcl, which the
+# AUTO_MEMORIES rules in flow/Makefile name as a prerequisite of
+# results/memories_inferred.json. Without it a design with
+# AUTO_MEMORIES=1 fails canonicalization on
+#   make: *** No rule to make target '.../scripts/memories/extract_memories.tcl'
+# Same shape as the flow/util/*.tcl omission noted further down.
 MAKEFILE_SHARED = [
     "scripts/variables.json",
     "scripts/*.py",
     "scripts/memories/*.py",
+    "scripts/memories/*.tcl",
     "scripts/*.sh",
     "scripts/*.yaml",
     "scripts/*.mk",

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -105,6 +105,10 @@ ORFS_PATCHES = [
     # since-archived external repo) is gone, so nothing applies it.
     # ORFS's patch, re-pathed onto the vendored copy.
     Label("//patches:0063-orfs-fakeram-asap7-backend.patch"),
+    # tinyRocket has two memory wrappers around undefined _ext modules,
+    # and ORFS describes only one, so hierarchy -check dies on the other.
+    # Goes with 0062; either is useless without it.
+    Label("//patches:0064-orfs-tinyrocket-data-arrays-memories.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -84,6 +84,16 @@ ORFS_PATCHES = [
     # _GENERATE_FLOW_BUILD below, since ORFS no longer ships that file.
     # Not upstreamed -- retire at the bump onto an ORFS that carries it.
     Label("//patches:0059-orfs-do-write-rc.patch"),
+    # AUTO_MEMORIES detection runs before gen_memories.py writes
+    # results/memories/blackboxes.txt, but reads its sources through a
+    # preamble that hard-errors when that file is absent -- so the step
+    # that must run first cannot run at all. Clears AUTO_MEMORIES for the
+    # detection process only.
+    Label("//patches:0060-orfs-extract-memories-no-blackboxes.patch"),
+    # `proc` in extract_memories.tcl reaches Tcl's procedure-definition
+    # keyword instead of yosys's pass, because yosys -import cannot
+    # shadow a Tcl built-in. Qualifies it as `yosys proc`.
+    Label("//patches:0061-orfs-extract-memories-yosys-proc.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -94,6 +94,11 @@ ORFS_PATCHES = [
     # keyword instead of yosys's pass, because yosys -import cannot
     # shadow a Tcl built-in. Qualifies it as `yosys proc`.
     Label("//patches:0061-orfs-extract-memories-yosys-proc.patch"),
+    # tinyRocket's tag_array override describes a memory detection never
+    # finds (no inferred $mem_v2 in the wrapper), so per the .memories
+    # contract it must carry its own pins and geometry. It carried
+    # neither. Read off the module boundary.
+    Label("//patches:0062-orfs-tinyrocket-tag-array-memories.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -99,6 +99,12 @@ ORFS_PATCHES = [
     # contract it must carry its own pins and geometry. It carried
     # neither. Read off the module boundary.
     Label("//patches:0062-orfs-tinyrocket-tag-array-memories.patch"),
+    # AUTO_MEMORIES calls FakeRAM as `run.py --orfs_asap7_backend`. ORFS
+    # vendors FakeRAM at tools/FakeRAM2.0 and ships the patch that adds
+    # that backend, but the MODULE.bazel that used to apply it (to the
+    # since-archived external repo) is gone, so nothing applies it.
+    # ORFS's patch, re-pathed onto the vendored copy.
+    Label("//patches:0063-orfs-fakeram-asap7-backend.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk
@@ -468,6 +474,38 @@ def _write_recorded_builds():
         )
     return "".join(parts)
 
+# ORFS's .bazelignore ignores tools/ wholesale, and for an external
+# repository bazel turns that into --deleted_packages: no BUILD file
+# under tools/ can define a package at all, however it got there.
+#
+# That collides with AUTO_MEMORIES. ORFS vendors FakeRAM at
+# tools/FakeRAM2.0 (the standalone repository is archived), and
+# gen_memories.py shells out to its run.py, so the tool has to be staged
+# into the canonicalize sandbox -- which needs a label, which needs a
+# package. patches/0063 adds the filegroup that ORFS's own patch
+# provides; this makes it loadable.
+#
+# The tools/ entry is replaced with its subdirectories rather than
+# dropped, so everything else there -- OpenROAD, yosys, AutoTuner, each
+# carrying bazel files of its own -- stays ignored exactly as before.
+# Enumerated from the tree rather than hardcoded: a bump that adds a
+# tools/ entry keeps it ignored by default, which is the safe direction.
+_UNIGNORE_FAKERAM = """
+if [ -e .bazelignore ] && grep -qx 'tools/' .bazelignore; then
+  {
+    grep -vx 'tools/' .bazelignore
+    for d in tools/*/; do
+      [ -d "$d" ] || continue
+      case "$d" in
+        tools/FakeRAM2.0/) continue ;;
+      esac
+      echo "$d"
+    done
+  } > .bazelignore.orfs_new
+  mv .bazelignore.orfs_new .bazelignore
+fi
+"""
+
 ORFS_PATCH_CMDS = [
     _WRITE_DESIGN_BZL,
     _write_recorded_builds(),
@@ -475,6 +513,7 @@ ORFS_PATCH_CMDS = [
         platforms = " ".join(ORFS_BAZEL_PLATFORMS),
     ),
     _GENERATE_FLOW_BUILD,
+    _UNIGNORE_FAKERAM,
 ]
 
 def orfs_archive_args(commit, integrity, urls = [], patches = [], patch_cmds = []):

--- a/patches/0060-orfs-extract-memories-no-blackboxes.patch
+++ b/patches/0060-orfs-extract-memories-no-blackboxes.patch
@@ -1,0 +1,62 @@
+Let AUTO_MEMORIES detection run before the list it produces exists.
+
+AUTO_MEMORIES is a two-step flow, and flow/Makefile orders it that way:
+
+    $(RESULTS_DIR)/memories_inferred.json: ... extract_memories.tcl
+            synth.sh extract_memories.tcl ...
+
+    do-auto-memories: $(RESULTS_DIR)/memories_inferred.json
+            gen_memories.py --yosys-json .../memories_inferred.json \
+                            --out-dir $(RESULTS_DIR)/memories ...
+
+Detection runs first and produces the inventory; gen_memories.py then
+turns it into results/memories/ -- the .lib/.lef views and
+blackboxes.txt, the list of modules synthesis is to blackbox.
+
+But extract_memories.tcl reads its sources through synth_preamble.tcl's
+read_design_sources, and every frontend branch of that proc consults
+auto_memories_blackboxes, which hard-errors when
+results/memories/blackboxes.txt is absent:
+
+    ERROR: AUTO_MEMORIES=1 but .../results/memories/blackboxes.txt is
+    missing; the do-auto-memories step must run before synthesis
+
+So the step whose entire purpose is to run before that file exists fails
+because it does not exist. The guard is right for synthesis and
+canonicalization -- reaching those without a blackbox list means the
+flow skipped a step -- and wrong for the detection pass, which is the
+one caller that must tolerate its absence.
+
+Clearing AUTO_MEMORIES for the extraction process only is what says
+that: there is nothing to blackbox yet, and this pass is what the list
+will be derived from. The guard keeps its full strength everywhere else,
+since nothing else clears it. Blackboxing during detection would also
+be wrong on its own terms -- a blackboxed module has no memory to infer,
+so the pass would inventory nothing.
+
+extract_memories.tcl's later `hierarchy -top` is deliberately unchecked,
+which is what lets detection tolerate a memory wrapper that instantiates
+a module the sources never define (asap7/tinyRocket's tag_array_ext).
+
+Not upstreamed. Retire at the //:bump onto an ORFS whose detection pass
+does not consult the blackbox list.
+
+diff --git a/flow/scripts/memories/extract_memories.tcl b/flow/scripts/memories/extract_memories.tcl
+--- a/flow/scripts/memories/extract_memories.tcl
++++ b/flow/scripts/memories/extract_memories.tcl
+@@ -4,6 +4,15 @@
+ 
+ source $::env(SCRIPTS_DIR)/synth_preamble.tcl
+ 
++# This pass runs before gen_memories.py, so results/memories/blackboxes.txt
++# does not exist yet and there is nothing to blackbox: this is the pass
++# whose output that list is derived from. read_design_sources consults
++# auto_memories_blackboxes in every frontend branch, and that proc errors
++# out when the file is absent, so reading the sources with AUTO_MEMORIES
++# still set fails the step that has to run first. Clear it for this
++# process only; the guard keeps its strength for synthesis.
++set ::env(AUTO_MEMORIES) 0
++
+ # Read all RTL sources using active frontend (all frontends)
+ read_design_sources
+ 

--- a/patches/0061-orfs-extract-memories-yosys-proc.patch
+++ b/patches/0061-orfs-extract-memories-yosys-proc.patch
@@ -1,0 +1,46 @@
+Call yosys's `proc` command, not Tcl's `proc` keyword.
+
+extract_memories.tcl runs under yosys's Tcl shell and asks for the
+process-conversion pass by writing
+
+    proc
+    memory -nomap
+
+`yosys -import` (synth_preamble.tcl:1) imports yosys commands into the
+Tcl namespace, but it cannot shadow a Tcl built-in, and `proc` is the
+one that defines a procedure. So the bare word reaches Tcl instead of
+yosys and the pass dies on
+
+    ERROR: TCL interpreter returned an error:
+    wrong # args: should be "proc name args body"
+
+`memory -nomap` on the next line is unaffected -- `memory` is not a Tcl
+built-in -- which is why only one of the two needs qualifying.
+
+The `yosys` prefix is how the rest of the flow already disambiguates:
+synth_preamble.tcl calls `yosys read_slang` for the same reason.
+
+Because this is the only `proc` in the file, and it is reached on every
+AUTO_MEMORIES run, the detection pass cannot ever have completed as
+shipped. Together with the blackbox-guard ordering fixed in patch 0060,
+this is what stands between AUTO_MEMORIES and running at all.
+
+Not upstreamed. Retire at the //:bump onto an ORFS that qualifies the
+call.
+
+diff --git a/flow/scripts/memories/extract_memories.tcl b/flow/scripts/memories/extract_memories.tcl
+--- a/flow/scripts/memories/extract_memories.tcl
++++ b/flow/scripts/memories/extract_memories.tcl
+@@ -11,8 +11,10 @@ read_design_sources
+ # Elaborate hierarchy
+ hierarchy -top $::env(DESIGN_NAME)
+ 
+-# Run process execution and memory collection
+-proc
++# Run process execution and memory collection. `yosys proc` rather than
++# bare `proc`: yosys -import cannot shadow Tcl's proc keyword, so the
++# bare word would define a procedure instead of running the pass.
++yosys proc
+ memory -nomap
+ 
+ # Write netlist JSON containing inferred $mem_v2 primitives

--- a/patches/0062-orfs-tinyrocket-tag-array-memories.patch
+++ b/patches/0062-orfs-tinyrocket-tag-array-memories.patch
@@ -1,0 +1,109 @@
+Give tinyRocket's tag_array override the geometry it is required to carry.
+
+asap7/tinyRocket sets ADDITIONAL_MEMORIES to a .memories file that
+force-converts tag_array, because the RTL gives that wrapper no
+behavioral body to fall back on -- it instantiates a tag_array_ext the
+sources never define.
+
+The override carries only name/idiomatic/reason, which would be enough
+for a memory detection already found. tag_array is not one:
+detect.py finds memories by scanning the yosys netlist for inferred
+$mem_v2 cells, and tag_array contains none -- its body only wires
+through to the undefined tag_array_ext, so there is nothing to infer.
+
+schema.merge_overrides states the consequence in its own docstring:
+
+    An override naming an unknown memory is taken whole -- it must then
+    carry pins and geometry itself to be emittable.
+
+Taken whole, this override has no pins and no geometry, so
+validate_emittable rejects it:
+
+    schema.SchemaError: memory tag_array: no pins
+
+which is the file failing its own format's contract rather than anything
+about the design. ADDITIONAL_MEMORIES is documented for exactly this
+case -- "or to describe one the scanner cannot find" (variables.yaml).
+
+The values are read off the module boundary in
+designs/src/tinyRocket/freechips.rocketchip.system.TinyConfig.v:
+
+    module tag_array(
+      input  [1:0]  RW0_addr,     -> addr_w 2, rows 4
+      input         RW0_en,
+      input         RW0_clk,
+      input         RW0_wmode,
+      input  [24:0] RW0_wdata_0,  -> bits 25
+      output [24:0] RW0_rdata_0
+    );
+
+One read-write port, and no mask pin on the boundary (the wrapper's
+internal RW0_wmask does not reach it), so mask_lanes stays 0.
+
+Not upstreamed. Retire at the //:bump onto an ORFS whose tag_array
+override is emittable -- either by carrying this geometry or by
+detecting memories at the module boundary, which the AUTO_MEMORIES
+description in variables.yaml already claims and detect.py does not
+implement.
+
+diff --git a/flow/designs/asap7/tinyRocket/tag_array.memories b/flow/designs/asap7/tinyRocket/tag_array.memories
+--- a/flow/designs/asap7/tinyRocket/tag_array.memories
++++ b/flow/designs/asap7/tinyRocket/tag_array.memories
+@@ -3,6 +3,57 @@
+   "memories": [
+     {
+       "name": "tag_array",
++      "rows": 4,
++      "bits": 25,
++      "addr_w": 2,
++      "read_ports": 0,
++      "write_ports": 0,
++      "rw_ports": 1,
++      "mask_lanes": 0,
++      "pins": [
++        {
++          "name": "RW0_addr",
++          "direction": "input",
++          "width": 2,
++          "port_id": "RW0",
++          "function": "addr"
++        },
++        {
++          "name": "RW0_en",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "en"
++        },
++        {
++          "name": "RW0_clk",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "clk"
++        },
++        {
++          "name": "RW0_wmode",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "wmode"
++        },
++        {
++          "name": "RW0_wdata_0",
++          "direction": "input",
++          "width": 25,
++          "port_id": "RW0",
++          "function": "data_in"
++        },
++        {
++          "name": "RW0_rdata_0",
++          "direction": "output",
++          "width": 25,
++          "port_id": "RW0",
++          "function": "data_out"
++        }
++      ],
+       "idiomatic": true,
+       "reason": "forced: the RTL provides no behavioral fallback for this wrapper"
+     }

--- a/patches/0063-orfs-fakeram-asap7-backend.patch
+++ b/patches/0063-orfs-fakeram-asap7-backend.patch
@@ -1,0 +1,217 @@
+Apply ORFS's own ASAP7 FakeRAM backend to the copy ORFS vendors.
+
+AUTO_MEMORIES generates its .lib/.lef views by calling FakeRAM:
+
+    subprocess.check_call([sys.executable, fakeram_run,
+                           "--orfs_asap7_backend", ...])   # gen_memories.py
+
+FakeRAM used to be a separate repository, and ORFS's MODULE.bazel
+declared it as a bazel module with this patch applied on top:
+
+    bazel_dep(name = "fakeram", dev_dependency = True)
+    git_override(
+        module_name = "fakeram",
+        patches = ["//patches/fakeram:0001-Add-ORFS-ASAP7-backend.patch"],
+        remote = "https://github.com/The-OpenROAD-Project/FakeRAM2.0.git",
+    )
+
+Two things have since changed. FakeRAM was rolled into ORFS -- the
+upstream repository is archived and its README points at
+OpenROAD-flow-scripts/tree/master/tools/FakeRAM2.0 -- and ORFS deleted
+its MODULE.bazel. So the source is now vendored at tools/FakeRAM2.0 and
+nothing applies the backend patch to it. ORFS still ships the patch at
+patches/fakeram/0001-Add-ORFS-ASAP7-backend.patch; it simply has no
+consumer. Verified against the pinned commit and against ORFS master:
+no tools/FakeRAM2.0/orfs_asap7/ directory, and no --orfs_asap7_backend
+in tools/FakeRAM2.0/run.py. Without it AUTO_MEMORIES stops at
+
+    gen_memories: FAKERAM_RUN_PY not set and FakeRAM run.py not found
+
+or, once found, at an unrecognized argument.
+
+Note also that bzlmod honours `patches` on git_override only from the
+root module, and dev_dependency only when the declaring module is root.
+So even before MODULE.bazel was deleted this declaration could not have
+worked for bazel-orfs -- the same rule that made bazel-orfs patch ORFS
+through a module extension in the first place (see orfs_source.bzl's
+docstring).
+
+This is ORFS's patch, re-pathed onto tools/FakeRAM2.0 rather than
+rewritten, so it stays comparable to the file ORFS ships. Two
+deliberate differences:
+
+  * The MODULE.bazel hunk is dropped. It declared FakeRAM as a bazel
+    module, which it no longer is here; keeping it would assert
+    something false about how ORFS is consumed.
+
+  * The BUILD.bazel hunk is kept. It is a single
+    filegroup(name = "all_files", srcs = glob(["**/*"])), which is
+    exactly the label needed to stage the tool into the canonicalize
+    sandbox -- so bazel-orfs does not have to generate a third BUILD
+    file of its own, and orfs_source.bzl's "these two packages are the
+    whole non-design coupling surface" stays true.
+
+Not upstreamed, and the upstream fix is not this patch: ORFS should
+vendor tools/FakeRAM2.0 with its own backend already applied, or apply
+patches/fakeram itself. Retire at the //:bump onto an ORFS where
+tools/FakeRAM2.0/run.py accepts --orfs_asap7_backend.
+
+diff --git a/tools/FakeRAM2.0/BUILD.bazel b/tools/FakeRAM2.0/BUILD.bazel
+new file mode 100644
+index 0000000..16e9be4
+--- /dev/null
++++ b/tools/FakeRAM2.0/BUILD.bazel
+@@ -0,0 +1,5 @@
++filegroup(
++    name = "all_files",
++    srcs = glob(["**/*"]),
++    visibility = ["//visibility:public"],
++)
+diff --git a/tools/FakeRAM2.0/orfs_asap7/__init__.py b/tools/FakeRAM2.0/orfs_asap7/__init__.py
+new file mode 100644
+index 0000000..edcf578
+--- /dev/null
++++ b/tools/FakeRAM2.0/orfs_asap7/__init__.py
+@@ -0,0 +1 @@
++# ORFS ASAP7 package
+diff --git a/tools/FakeRAM2.0/orfs_asap7/generate.py b/tools/FakeRAM2.0/orfs_asap7/generate.py
+new file mode 100644
+index 0000000..58fef20
+--- /dev/null
++++ b/tools/FakeRAM2.0/orfs_asap7/generate.py
+@@ -0,0 +1,83 @@
++import json
++import sys
++from pathlib import Path
++
++from utils.class_process import Process
++from utils.memory_config import MemoryConfig
++from utils.memory_factory import MemoryFactory
++from utils.timing_data import TimingData
++from utils.ram_liberty_exporter import RAMLibertyExporter
++from utils.lef_exporter import LefExporter
++
++ASAP7_PROCESS_CONFIG = {
++    "tech_nm": 7,
++    "voltage": 0.7,
++    "metal_prefix": "M",
++    "metal_layer": "M4",
++    "pin_width_nm": 24,
++    "pin_pitch_nm": 48,
++    "metal_track_pitch_nm": 48,
++    "manufacturing_grid_nm": 1,
++    "contacted_poly_pitch_nm": 54,
++    "fin_pitch_nm": 27,
++    "column_mux_factor": 1,
++    "snap_width_nm": 190,
++    "snap_height_nm": 1400,
++}
++
++ASAP7_TIMING_CONFIG = {
++    "cycle_time": 1.0,
++    "access_time": 0.5,
++    "setup_time": 0.1,
++    "hold_time": 0.05,
++    "leakage": 0.001,
++}
++
++def run_orfs_asap7(platform: str, out_dir: Path, json_path: Path):
++    if platform != "asap7":
++        sys.stderr.write(f"FakeRAM2.0 orfs_asap7: unsupported platform {platform}\n")
++        return 1
++
++    try:
++        data = json.loads(json_path.read_text())
++        memories = data.get("memories", [])
++    except Exception as e:
++        sys.stderr.write(f"FakeRAM2.0 orfs_asap7: failed to read {json_path}: {e}\n")
++        return 1
++
++    out_dir.mkdir(parents=True, exist_ok=True)
++    converted = sorted((m for m in memories if m.get("idiomatic")), key=lambda m: m["name"])
++
++    process = Process(ASAP7_PROCESS_CONFIG)
++    timing_data = TimingData(ASAP7_TIMING_CONFIG)
++
++    for m in converted:
++        name = m["name"]
++        bits = m.get("bits", 32)
++        rows = m.get("rows", 128)
++
++        sram_dict = {
++            "name": name,
++            "width": bits,
++            "depth": rows,
++            "banks": 1,
++        }
++        mem_config = MemoryConfig.from_json(sram_dict)
++        ram = MemoryFactory.create(mem_config, "RAM", "SP", process, timing_data)
++
++        # Export Liberty
++        lib_path = out_dir / f"{name}.lib"
++        with open(lib_path, "w") as f:
++            RAMLibertyExporter(ram).export(f)
++
++        pre_lib_path = out_dir / f"{name}_pre_layout.lib"
++        with open(pre_lib_path, "w") as f:
++            RAMLibertyExporter(ram).export(f)
++
++        # Export LEF
++        lef_path = out_dir / f"{name}.lef"
++        with open(lef_path, "w") as f:
++            LefExporter(ram).export(f)
++
++    (out_dir / "blackboxes.txt").write_text("".join(f"{m['name']}\n" for m in converted))
++    return 0
+diff --git a/tools/FakeRAM2.0/run.py b/tools/FakeRAM2.0/run.py
+index f525c5f..06ae626 100755
+--- a/tools/FakeRAM2.0/run.py
++++ b/tools/FakeRAM2.0/run.py
+@@ -8,6 +8,7 @@ from utils.class_process import Process
+ from utils.memory_config import MemoryConfig
+ from utils.memory_factory import MemoryFactory
+ from utils.timing_data import TimingData
++from orfs_asap7.generate import run_orfs_asap7
+ 
+ 
+ def get_args() -> argparse.Namespace:
+@@ -28,10 +29,19 @@ def get_args() -> argparse.Namespace:
+         required=False,
+         default="results",
+     )
++    parser.add_argument(
++        "--orfs_asap7_backend",
++        action="store_true",
++        help="Use ORFS ASAP7 backend (expects JSON in memories.json format)",
++    )
+     return parser.parse_args()
+ 
+ 
+ def main(args: argparse.Namespace):
++    if args.orfs_asap7_backend:
++        from pathlib import Path
++        return run_orfs_asap7(platform="asap7", out_dir=Path(args.output_dir), json_path=Path(args.config))
++
+     json_data = RunUtils.get_config(args.config)
+     # Create a process object (shared by all srams)
+     process = Process(json_data)
+@@ -52,4 +62,4 @@ def main(args: argparse.Namespace):
+ ### Entry point
+ if __name__ == "__main__":
+     args = get_args()
+-    main(args)
++    sys.exit(main(args))
+diff --git a/tools/FakeRAM2.0/utils/class_process.py b/tools/FakeRAM2.0/utils/class_process.py
+index e1cfac3..745285c 100644
+--- a/tools/FakeRAM2.0/utils/class_process.py
++++ b/tools/FakeRAM2.0/utils/class_process.py
+@@ -119,6 +119,9 @@ class Process:
+ 
+         total_height += additional_height
+ 
++        min_height = max(3.5, self.snap_height_nm / 1000.0 if self.snap_height_nm else 0)
++        total_height = max(total_height, min_height)
++
+         return (total_width, total_height)
+ 
+     def get_tech_nm(self):

--- a/patches/0064-orfs-tinyrocket-data-arrays-memories.patch
+++ b/patches/0064-orfs-tinyrocket-data-arrays-memories.patch
@@ -1,0 +1,417 @@
+Describe tinyRocket's other three memory wrappers, not just one.
+
+asap7/tinyRocket has four memory wrappers, each instantiating an _ext
+module the sources never define:
+
+    wrapper           undefined submodule       geometry
+    tag_array         tag_array_ext             4 x 25,   1 RW
+    data_arrays_0     data_arrays_0_ext         64 x 32,  1 RW, 4 mask lanes
+    data_arrays_0_0   data_arrays_0_0_ext       64 x 32,  1 RW
+    mem               mem_ext                   1024 x 32, 1 R + 1 W, 4 mask lanes
+
+None carries an inferrable memory -- each only wires through to its
+missing _ext -- so detection finds none of them and every one needs a
+.memories override to be converted. ORFS ships an override for
+tag_array alone, so canonicalization clears that wrapper and dies on
+the next:
+
+    ERROR: Module `\data_arrays_0_ext' referenced in module
+    `\data_arrays_0' in cell `\data_arrays_0_ext' is not part of the
+    design.
+
+then the same for data_arrays_0_0_ext, and mem_ext behind it. That is
+synth_preamble.tcl's `hierarchy -check` finding an undefined module,
+exactly as it would have for tag_array without its override. So the
+demo documented in docs/user/AutoMemories.md --
+
+    make DESIGN_CONFIG=designs/asap7/tinyRocket/config.mk synth floorplan
+
+-- cannot have completed either; nothing here is specific to bazel.
+
+The four wrappers were enumerated by finding every instantiated *_ext
+module with no matching definition, rather than one build failure at a
+time, and each geometry is derived from its module header rather than
+typed by hand: address width gives rows, the data lanes summed give
+bits, and each 1-bit subword mask pin contributes one lane -- the form
+schema.py documents as "Subword-split mask pins (W0_mask_0..3)
+contribute one lane each". `mem` is the one with split R0/W0 ports
+rather than a single RW0, so it is 1 read + 1 write rather than 1
+read-write.
+
+ADDITIONAL_MEMORIES is already a space-separated list, so the three new
+files join the existing one.
+
+Not upstreamed. Retire at the //:bump onto an ORFS that describes all
+four wrappers -- or, better, one whose detection finds memory-shaped
+modules at the module boundary, which is what the AUTO_MEMORIES
+description in variables.yaml claims and detect.py does not do. Either
+fix retires this patch and 0062 together.
+
+diff --git a/flow/designs/asap7/tinyRocket/data_arrays_0.memories b/flow/designs/asap7/tinyRocket/data_arrays_0.memories
+new file mode 100644
+--- /dev/null
++++ b/flow/designs/asap7/tinyRocket/data_arrays_0.memories
+@@ -0,0 +1,131 @@
++{
++  "version": 1,
++  "memories": [
++    {
++      "name": "data_arrays_0",
++      "rows": 64,
++      "bits": 32,
++      "addr_w": 6,
++      "read_ports": 0,
++      "write_ports": 0,
++      "rw_ports": 1,
++      "mask_lanes": 4,
++      "pins": [
++        {
++          "name": "RW0_addr",
++          "direction": "input",
++          "width": 6,
++          "port_id": "RW0",
++          "function": "addr"
++        },
++        {
++          "name": "RW0_en",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "en"
++        },
++        {
++          "name": "RW0_clk",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "clk"
++        },
++        {
++          "name": "RW0_wmode",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "wmode"
++        },
++        {
++          "name": "RW0_wdata_0",
++          "direction": "input",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_in"
++        },
++        {
++          "name": "RW0_wdata_1",
++          "direction": "input",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_in"
++        },
++        {
++          "name": "RW0_wdata_2",
++          "direction": "input",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_in"
++        },
++        {
++          "name": "RW0_wdata_3",
++          "direction": "input",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_in"
++        },
++        {
++          "name": "RW0_rdata_0",
++          "direction": "output",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_out"
++        },
++        {
++          "name": "RW0_rdata_1",
++          "direction": "output",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_out"
++        },
++        {
++          "name": "RW0_rdata_2",
++          "direction": "output",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_out"
++        },
++        {
++          "name": "RW0_rdata_3",
++          "direction": "output",
++          "width": 8,
++          "port_id": "RW0",
++          "function": "data_out"
++        },
++        {
++          "name": "RW0_wmask_0",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "mask"
++        },
++        {
++          "name": "RW0_wmask_1",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "mask"
++        },
++        {
++          "name": "RW0_wmask_2",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "mask"
++        },
++        {
++          "name": "RW0_wmask_3",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "mask"
++        }
++      ],
++      "idiomatic": true,
++      "reason": "forced: the RTL provides no behavioral fallback for this wrapper"
++    }
++  ]
++}
+diff --git a/flow/designs/asap7/tinyRocket/data_arrays_0_0.memories b/flow/designs/asap7/tinyRocket/data_arrays_0_0.memories
+new file mode 100644
+--- /dev/null
++++ b/flow/designs/asap7/tinyRocket/data_arrays_0_0.memories
+@@ -0,0 +1,61 @@
++{
++  "version": 1,
++  "memories": [
++    {
++      "name": "data_arrays_0_0",
++      "rows": 64,
++      "bits": 32,
++      "addr_w": 6,
++      "read_ports": 0,
++      "write_ports": 0,
++      "rw_ports": 1,
++      "mask_lanes": 0,
++      "pins": [
++        {
++          "name": "RW0_addr",
++          "direction": "input",
++          "width": 6,
++          "port_id": "RW0",
++          "function": "addr"
++        },
++        {
++          "name": "RW0_en",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "en"
++        },
++        {
++          "name": "RW0_clk",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "clk"
++        },
++        {
++          "name": "RW0_wmode",
++          "direction": "input",
++          "width": 1,
++          "port_id": "RW0",
++          "function": "wmode"
++        },
++        {
++          "name": "RW0_wdata_0",
++          "direction": "input",
++          "width": 32,
++          "port_id": "RW0",
++          "function": "data_in"
++        },
++        {
++          "name": "RW0_rdata_0",
++          "direction": "output",
++          "width": 32,
++          "port_id": "RW0",
++          "function": "data_out"
++        }
++      ],
++      "idiomatic": true,
++      "reason": "forced: the RTL provides no behavioral fallback for this wrapper"
++    }
++  ]
++}
+diff --git a/flow/designs/asap7/tinyRocket/mem.memories b/flow/designs/asap7/tinyRocket/mem.memories
+new file mode 100644
+--- /dev/null
++++ b/flow/designs/asap7/tinyRocket/mem.memories
+@@ -0,0 +1,145 @@
++{
++  "version": 1,
++  "memories": [
++    {
++      "name": "mem",
++      "rows": 1024,
++      "bits": 32,
++      "addr_w": 10,
++      "read_ports": 1,
++      "write_ports": 1,
++      "rw_ports": 0,
++      "mask_lanes": 4,
++      "pins": [
++        {
++          "name": "R0_addr",
++          "direction": "input",
++          "width": 10,
++          "port_id": "R0",
++          "function": "addr"
++        },
++        {
++          "name": "R0_en",
++          "direction": "input",
++          "width": 1,
++          "port_id": "R0",
++          "function": "en"
++        },
++        {
++          "name": "R0_clk",
++          "direction": "input",
++          "width": 1,
++          "port_id": "R0",
++          "function": "clk"
++        },
++        {
++          "name": "R0_data_0",
++          "direction": "output",
++          "width": 8,
++          "port_id": "R0",
++          "function": "data_out"
++        },
++        {
++          "name": "R0_data_1",
++          "direction": "output",
++          "width": 8,
++          "port_id": "R0",
++          "function": "data_out"
++        },
++        {
++          "name": "R0_data_2",
++          "direction": "output",
++          "width": 8,
++          "port_id": "R0",
++          "function": "data_out"
++        },
++        {
++          "name": "R0_data_3",
++          "direction": "output",
++          "width": 8,
++          "port_id": "R0",
++          "function": "data_out"
++        },
++        {
++          "name": "W0_addr",
++          "direction": "input",
++          "width": 10,
++          "port_id": "W0",
++          "function": "addr"
++        },
++        {
++          "name": "W0_en",
++          "direction": "input",
++          "width": 1,
++          "port_id": "W0",
++          "function": "en"
++        },
++        {
++          "name": "W0_clk",
++          "direction": "input",
++          "width": 1,
++          "port_id": "W0",
++          "function": "clk"
++        },
++        {
++          "name": "W0_data_0",
++          "direction": "input",
++          "width": 8,
++          "port_id": "W0",
++          "function": "data_in"
++        },
++        {
++          "name": "W0_data_1",
++          "direction": "input",
++          "width": 8,
++          "port_id": "W0",
++          "function": "data_in"
++        },
++        {
++          "name": "W0_data_2",
++          "direction": "input",
++          "width": 8,
++          "port_id": "W0",
++          "function": "data_in"
++        },
++        {
++          "name": "W0_data_3",
++          "direction": "input",
++          "width": 8,
++          "port_id": "W0",
++          "function": "data_in"
++        },
++        {
++          "name": "W0_mask_0",
++          "direction": "input",
++          "width": 1,
++          "port_id": "W0",
++          "function": "mask"
++        },
++        {
++          "name": "W0_mask_1",
++          "direction": "input",
++          "width": 1,
++          "port_id": "W0",
++          "function": "mask"
++        },
++        {
++          "name": "W0_mask_2",
++          "direction": "input",
++          "width": 1,
++          "port_id": "W0",
++          "function": "mask"
++        },
++        {
++          "name": "W0_mask_3",
++          "direction": "input",
++          "width": 1,
++          "port_id": "W0",
++          "function": "mask"
++        }
++      ],
++      "idiomatic": true,
++      "reason": "forced: the RTL provides no behavioral fallback for this wrapper"
++    }
++  ]
++}
+diff --git a/flow/designs/asap7/tinyRocket/config.mk b/flow/designs/asap7/tinyRocket/config.mk
+--- a/flow/designs/asap7/tinyRocket/config.mk
++++ b/flow/designs/asap7/tinyRocket/config.mk
+@@ -19,7 +19,11 @@
+ # provides no behavioral fallback (the wrapper instantiates a
+ # tag_array_ext module the sources never define), so its conversion is
+ # forced via a .memories override.
+-export ADDITIONAL_MEMORIES = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/tag_array.memories
++export ADDITIONAL_MEMORIES = \
++    $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/tag_array.memories \
++    $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/data_arrays_0.memories \
++    $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/data_arrays_0_0.memories \
++    $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/mem.memories
+ 
+ export CORE_UTILIZATION = 40
+ export CORE_MARGIN      = 2

--- a/private/attrs.bzl
+++ b/private/attrs.bzl
@@ -2,6 +2,7 @@
 
 load(
     "@config//:global_config.bzl",
+    "CONFIG_FAKERAM",
     "CONFIG_KLAYOUT",
     "CONFIG_MAKE",
     "CONFIG_MAKEFILE",
@@ -166,6 +167,11 @@ def yosys_only_attrs():
             doc = "Top level makefile yosys.",
             allow_single_file = ["Makefile"],
             default = CONFIG_MAKEFILE_YOSYS,
+        ),
+        "_fakeram": attr.label(
+            doc = "FakeRAM tree, staged only when AUTO_MEMORIES=1.",
+            allow_files = True,
+            default = CONFIG_FAKERAM,
         ),
         "yosys": attr.label(
             doc = "Yosys binary. Override to use a custom or locally-built yosys.",

--- a/private/environment.bzl
+++ b/private/environment.bzl
@@ -356,6 +356,13 @@ def source_inputs(ctx, use_pre_layout = None, gds = True, logging = True):
             # stage's same-named log writes (Permission denied).
             ctx.attr.src[OrfsDepInfo].files,
             ctx.attr.src[OrfsInfo].additional_lefs,
+            # AUTO_MEMORIES artifacts (memories.json + the generated
+            # .lib/.lef directory). The flow's Tcl globs these out of
+            # the results dir at run time rather than through a
+            # variable, so nothing else in this depset would carry
+            # them and floorplan would fail to link the blackboxed
+            # memory modules. Empty unless AUTO_MEMORIES=1.
+            ctx.attr.src[OrfsInfo].memories,
             ctx.attr.src[PdkInfo].files,
             ctx.attr.src[PdkInfo].libs,
             # LoggingInfo.jsons/.reports are gated by `logging` above;
@@ -786,6 +793,16 @@ def _artifact_name(ctx, category, name = None):
 
 def declare_artifact(ctx, category, name):
     return ctx.actions.declare_file(_artifact_name(ctx, category, name))
+
+def declare_directory_artifact(ctx, category, name):
+    """A directory artifact, for outputs whose file names are not known.
+
+    AUTO_MEMORIES is the case: gen_memories.py emits one .lib and one
+    .lef per converted memory plus blackboxes.txt, and which memories
+    exist is decided by scanning the RTL at run time. There is no name
+    list to declare, so the directory is the artifact.
+    """
+    return ctx.actions.declare_directory(_artifact_name(ctx, category, name))
 
 def artifact_dir(ctx, category):
     """The directory declare_artifact(ctx, category, ...) files land in.

--- a/private/orfs_design.bzl
+++ b/private/orfs_design.bzl
@@ -126,7 +126,9 @@ def orfs_design(name = None, config = "config.mk", platform = None, design = Non
     # orfs_flow() rules without using exports_files().
     existing_rules = native.existing_rules()
     for fg_name, fg_glob in [
-        ("design_config", ["*.mk", "*.sdc", "*.json", "*.cfg", "*.tcl", "*.def"]),
+        # *.memories: ADDITIONAL_MEMORIES entries (AUTO_MEMORIES), which
+        # live beside config.mk in the design directory.
+        ("design_config", ["*.mk", "*.sdc", "*.json", "*.cfg", "*.tcl", "*.def", "*.memories"]),
         ("lef", ["*.lef"]),
         ("lib", ["*.lib"]),
         ("gds", ["*.gds.gz"]),

--- a/private/providers.bzl
+++ b/private/providers.bzl
@@ -16,6 +16,13 @@ OrfsInfo = provider(
         "additional_lefs",
         "additional_libs",
         "additional_libs_pre_layout",
+        # AUTO_MEMORIES: results/memories.json plus the directory of
+        # generated .lib/.lef macro views. Produced during
+        # canonicalization and read out of the results dir by every
+        # later stage's Tcl, so unlike the other fields here these are
+        # flow *outputs* being carried forward rather than inputs
+        # collected from deps. Empty for the vast majority of designs.
+        "memories",
         "arguments",
     ],
 )

--- a/private/rules.bzl
+++ b/private/rules.bzl
@@ -25,6 +25,7 @@ load(
     "data_inputs_excluding",
     "declare_artifact",
     "declare_artifacts",
+    "declare_directory_artifact",
     "deps_inputs",
     "environment_string",
     "extensionless_basename",
@@ -288,6 +289,7 @@ def _macro_impl(ctx):
             additional_lefs = depset([]),
             additional_libs = depset([]),
             additional_libs_pre_layout = depset([]),
+            memories = depset([]),
             arguments = depset([]),
         ),
         TopInfo(
@@ -804,6 +806,7 @@ def _arguments_impl(ctx):
             additional_lefs = src_info.additional_lefs,
             additional_libs = src_info.additional_libs,
             additional_libs_pre_layout = src_info.additional_libs_pre_layout,
+            memories = src_info.memories,
             arguments = depset(
                 [computed_json],
                 transitive = [src_info.arguments],
@@ -2033,6 +2036,71 @@ def _yosys_impl(ctx):
     # come through arguments/stage_arguments, not extra_arguments .json files.
     use_syn = all_arguments.get("SYNTH_USE_SYN") == "1"
 
+    # AUTO_MEMORIES: canonicalization detects memory-shaped modules in the
+    # RTL and generates .lib/.lef macro views for them; synthesis then
+    # blackboxes those modules and every later stage reads the generated
+    # views. The flow's Tcl globs them out of the results dir at run time
+    # rather than through a variable, so in a sandbox -- where only
+    # declared outputs survive -- they have to be declared here and
+    # carried forward on OrfsInfo.memories (see source_inputs). Without
+    # that, floorplan fails to link the blackboxed memory modules.
+    #
+    # Analysis-time only, like SYNTH_USE_SYN above: the value must come
+    # through arguments/stage_arguments, not an extra_arguments .json.
+    auto_memories = all_arguments.get("AUTO_MEMORIES") == "1"
+    if auto_memories and use_syn:
+        fail("AUTO_MEMORIES=1 needs the yosys canonicalize step that " +
+             "generates the memory views, and SYNTH_USE_SYN=1 does not " +
+             "run one. Both are set in " + str(ctx.label))
+
+    memories_outputs = []
+    memories_inferred = []
+    fakeram_inputs = []
+    fakeram_env = {}
+    if auto_memories:
+        memories_outputs = [
+            declare_artifact(ctx, "results", "memories.json"),
+            # A directory: gen_memories.py emits one .lib and one .lef
+            # per converted memory plus blackboxes.txt, and which
+            # memories exist is only known once the RTL is scanned.
+            declare_directory_artifact(ctx, "results", "memories"),
+        ]
+
+        # The detection pass's output. Not in OrfsInfo.memories -- no
+        # later stage reads it -- but it has to be declared and staged
+        # into the synth action all the same, because make checks the
+        # whole chain there:
+        #
+        #   yosys-dependencies: memories.json
+        #   memories.json: memories_inferred.json ...
+        #   memories_inferred.json: $(VERILOG_FILES) extract_memories.tcl
+        #
+        # With memories.json present but memories_inferred.json missing,
+        # make rebuilds the latter -- re-running detection in the synth
+        # sandbox, where it fails on a design already reduced to the
+        # canonicalized RTLIL ("Module `RocketTile' not found!") -- and
+        # would then try to rewrite memories.json, which is a read-only
+        # input there.
+        memories_inferred = [
+            declare_artifact(ctx, "results", "memories_inferred.json"),
+        ]
+
+        # gen_memories.py shells out to FakeRAM, which ORFS vendors at
+        # tools/FakeRAM2.0. Point it there explicitly rather than relying
+        # on its own discovery: that fallback rglobs RUNFILES_DIR for a
+        # run.py whose parent directory contains "fakeram", and the test
+        # is case-sensitive, so it never matches "FakeRAM2.0".
+        fakeram_inputs = ctx.files._fakeram
+        run_py = [
+            f
+            for f in fakeram_inputs
+            if f.basename == "run.py" and "FakeRAM2.0/run.py" in f.path
+        ]
+        if not run_py:
+            fail("AUTO_MEMORIES=1 but no FakeRAM run.py among the files of " +
+                 str(ctx.attr._fakeram.label) + " in " + str(ctx.label))
+        fakeram_env = {"FAKERAM_RUN_PY": run_py[0].path}
+
     # Clock-period extraction. The yosys side never reads the raw SDC:
     # synth_preamble.tcl consumes only SDC_FILE_CLOCK_PERIOD (the abc -D
     # value), which ORFS's do-sdc-clock-period target derives from the SDC
@@ -2117,17 +2185,20 @@ def _yosys_impl(ctx):
             command = EXPAND_VERILOG_DIRS + " && ".join(commands),
             env = verilog_arguments(ctx.files.verilog_files) |
                   yosys_environment(ctx) |
-                  config_environment(canon_config),
+                  config_environment(canon_config) |
+                  fakeram_env,
             inputs = depset(
                 [canon_config] + ([clock_period] if clock_period else []) +
-                ctx.files.verilog_files + ctx.files.extra_configs,
+                ctx.files.verilog_files + ctx.files.extra_configs +
+                fakeram_inputs,
                 transitive = [
                     synth_data_inputs,
                     pdk_inputs(ctx),
                     canon_deps,
                 ],
             ),
-            outputs = [canon_output] + canon_logs,
+            outputs = [canon_output] + canon_logs + memories_outputs +
+                      memories_inferred,
             tools = yosys_inputs(ctx),
             progress_message = "Canonicalizing RTL for %s" % module_top(ctx),
         )
@@ -2271,7 +2342,13 @@ def _yosys_impl(ctx):
             inputs = depset(
                 [canon_output, config] +
                 ([clock_period] if clock_period else []) +
-                ctx.files.extra_configs,
+                ctx.files.extra_configs +
+                # Synthesis blackboxes the converted memories, which it
+                # reads from results/memories/blackboxes.txt -- written
+                # by the canonicalize action above. memories_inferred
+                # rides along so make sees the chain as up to date rather
+                # than re-running detection here; see its declaration.
+                memories_outputs + memories_inferred,
                 transitive = [
                     synth_data_inputs,
                     pdk_inputs(ctx),
@@ -2298,7 +2375,14 @@ def _yosys_impl(ctx):
                         synth_outputs["1_2_yosys.v"],
                         synth_outputs["1_2_yosys.sdc"],
                         config,
-                    ] + ctx.files.extra_configs,
+                    ] + ctx.files.extra_configs +
+                    # synth_odb.tcl reads the blackboxed memories through
+                    # load.tcl and read_liberty.tcl, which glob
+                    # results/memories for *.lef and *.lib. Without them
+                    # OpenROAD fails with
+                    #   [ERROR ORD-2013] instance ... LEF master
+                    #   data_arrays_0 not found
+                    memories_outputs,
                     transitive = [
                         data_inputs(ctx),
                         pdk_inputs(ctx),
@@ -2359,7 +2443,7 @@ def _yosys_impl(ctx):
         f
         for name, f in synth_outputs.items()
         if name != "1_2_yosys.sdc"
-    ]
+    ] + memories_outputs
 
     # Write synth's data_arguments to a JSON so downstream stages
     # inherit synth-time variables (SDC_FILE, VERILOG_FILES, SYNTH_*)
@@ -2567,6 +2651,10 @@ def _yosys_impl(ctx):
                     if (dep[OrfsInfo].lib_pre_layout or dep[OrfsInfo].lib)
                 ],
             ),
+            # The generated AUTO_MEMORIES views enter the graph here, at
+            # the one stage that produces them; every later stage carries
+            # them forward unchanged.
+            memories = depset(memories_outputs),
             arguments = depset([synth_args_json]),
         ),
         ctx.attr.pdk[PdkInfo],
@@ -3008,6 +3096,10 @@ def _make_impl(
             additional_lefs = ctx.attr.src[OrfsInfo].additional_lefs,
             additional_libs = ctx.attr.src[OrfsInfo].additional_libs,
             additional_libs_pre_layout = ctx.attr.src[OrfsInfo].additional_libs_pre_layout,
+            # Carried, not regenerated: the AUTO_MEMORIES views are made
+            # once during canonicalization and every later stage reads
+            # the same files.
+            memories = ctx.attr.src[OrfsInfo].memories,
             arguments = depset(
                 [analysis_json],
                 transitive = [ctx.attr.src[OrfsInfo].arguments] +

--- a/pythonwrapper/python.py
+++ b/pythonwrapper/python.py
@@ -12,6 +12,20 @@ def main():
     # *own* runfiles tree instead of inheriting the wrapper's tree.
     os.environ.pop("RUNFILES_DIR", None)
     os.environ.pop("RUNFILES_MANIFEST_FILE", None)
+    # Same reasoning, for child *python* scripts. rules_python's venv
+    # runs us with PYTHONSAFEPATH=1, which suppresses the script's own
+    # directory from sys.path -- so a flow script that runs another
+    # python script cannot import that script's siblings, and fails on
+    # something like "No module named 'utils'" that reproduces nowhere
+    # else. ORFS's AUTO_MEMORIES hits this: gen_memories.py spawns
+    # FakeRAM's run.py, which imports its own utils/ package.
+    #
+    # The flow's scripts are written against a plain `python3`, where
+    # the script directory is on sys.path. Dropping the variable gives
+    # children exactly that. It does not affect this interpreter, which
+    # has already started, and runpy.run_path below never put the script
+    # directory on sys.path anyway.
+    os.environ.pop("PYTHONSAFEPATH", None)
     runpy.run_path(script, run_name="__main__")
 
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -2431,3 +2431,19 @@ sh_test(
     args = ["$(rootpath :lb_32x128_estimate.json)"],
     data = [":lb_32x128_estimate.json"],
 )
+
+# ORFS's AUTO_MEMORIES rules name flow/scripts/memories/*.tcl and
+# *.py as prerequisites, and no `scripts/*` glob reaches that
+# subdirectory. Pins the staged set so a design with AUTO_MEMORIES=1
+# cannot regress to "No rule to make target
+# .../memories/extract_memories.tcl" -- a packaging omission that reads
+# like a Makefile bug. See MAKEFILE_SHARED in orfs_source.bzl.
+sh_test(
+    name = "auto_memories_staged_test",
+    size = "small",
+    srcs = ["auto_memories_staged_test.sh"],
+    data = [
+        "@orfs//flow:makefile",
+        "@orfs//flow:makefile_yosys",
+    ],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//:openroad.bzl", "orfs_arguments", "orfs_floorplan", "orfs_flow", "orfs_gds", "orfs_macro", "orfs_place", "orfs_run", "orfs_run_executable", "orfs_synth", "orfs_test", "orfs_variables")
 load("//:orfs_genrule.bzl", "orfs_genrule")
 load("//:sweep.bzl", "orfs_sweep")
+load(":auto_memories_outputs_test.bzl", "auto_memories_outputs_test")
 load(":deps_output_group_rule.bzl", "deps_output_group_test", "output_group_test")
 load(":keep_modules_test.bzl", "keep_modules_test_suite")
 load(":provider_test_rule.bzl", "lib_pre_layout_test")
@@ -621,6 +622,50 @@ source_input_propagation_test(
     name = "src_data_propagation_test",
     expected_basename = "dummy_extra.lef",
     target_under_test = ":src_propagation_place",
+)
+
+# AUTO_MEMORIES: the generated .lib/.lef views only survive the sandbox
+# if canonicalization declares them. asap7/tinyRocket is the design that
+# sets AUTO_MEMORIES=1; gcd is the control, and the absence half is what
+# keeps every other design from paying for outputs nothing produces.
+auto_memories_outputs_test(
+    name = "auto_memories_outputs_test",
+    expected = [
+        "memories.json",
+        "memories",
+        # The detection output. No later stage reads it, but it has to be
+        # declared so make does not re-run detection in the synth sandbox.
+        "memories_inferred.json",
+    ],
+    target_under_test = "@orfs//flow/designs/asap7/tinyRocket:RocketTile_synth",
+)
+
+auto_memories_outputs_test(
+    name = "no_auto_memories_outputs_test",
+    forbidden = [
+        "memories.json",
+        "memories",
+        "memories_inferred.json",
+    ],
+    target_under_test = "@orfs//flow/designs/asap7/gcd:gcd_synth",
+)
+
+# The end-to-end gate for AUTO_MEMORIES: the full flow on the one ORFS
+# design that uses it. Manual -- this is PnR, minutes not seconds, and
+# has no business in a wildcard build.
+#
+# _floorplan is listed alongside _final deliberately. Synth alone would
+# pass even if the generated views never propagated past the stage that
+# made them, so floorplan is the cheapest target that actually proves
+# OrfsInfo.memories works; _final proves the rest of the flow does.
+build_test(
+    name = "auto_memories_flow_test",
+    tags = ["manual"],
+    targets = [
+        "@orfs//flow/designs/asap7/tinyRocket:RocketTile_synth",
+        "@orfs//flow/designs/asap7/tinyRocket:RocketTile_floorplan",
+        "@orfs//flow/designs/asap7/tinyRocket:RocketTile_final",
+    ],
 )
 
 # Unit tests for the stage variable filtering helpers (stages.bzl).
@@ -2445,5 +2490,6 @@ sh_test(
     data = [
         "@orfs//flow:makefile",
         "@orfs//flow:makefile_yosys",
+        "@orfs//tools/FakeRAM2.0:all_files",
     ],
 )

--- a/test/auto_memories_outputs_test.bzl
+++ b/test/auto_memories_outputs_test.bzl
@@ -1,0 +1,60 @@
+"""analysistest: AUTO_MEMORIES declares its generated views as outputs.
+
+ORFS's AUTO_MEMORIES writes results/memories.json and a
+results/memories/ directory of generated .lib/.lef views during
+canonicalization, and every later stage reads them back by globbing the
+results dir (load.tcl, read_liberty.tcl). In a sandbox only declared
+outputs survive, so if the synth rule does not declare them the views
+are discarded the moment canonicalization ends and floorplan fails to
+link the blackboxed memory modules.
+
+The negative half matters as much as the positive one: a design without
+AUTO_MEMORIES must declare neither, or every design in the world pays
+for a directory artifact and a JSON it never produces -- and the action
+would fail for not creating them.
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _output_basenames(env):
+    names = {}
+    for action in analysistest.target_actions(env):
+        for f in action.outputs.to_list():
+            names[f.basename] = action.mnemonic
+    return names
+
+def _auto_memories_outputs_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    declared = _output_basenames(env)
+    label = analysistest.target_under_test(env).label
+
+    for name in ctx.attr.expected:
+        asserts.true(
+            env,
+            name in declared,
+            ("Expected %s among the declared outputs of %s, but it is " +
+             "absent. Declared: %s") % (name, label, sorted(declared)),
+        )
+
+    for name in ctx.attr.forbidden:
+        asserts.true(
+            env,
+            name not in declared,
+            ("%s is declared as an output of %s, which does not set " +
+             "AUTO_MEMORIES=1. Nothing produces it, so the action would " +
+             "fail for not creating it.") % (name, label),
+        )
+
+    return analysistest.end(env)
+
+auto_memories_outputs_test = analysistest.make(
+    _auto_memories_outputs_test_impl,
+    attrs = {
+        "expected": attr.string_list(
+            doc = "Output basenames that must be declared.",
+        ),
+        "forbidden": attr.string_list(
+            doc = "Output basenames that must NOT be declared.",
+        ),
+    },
+)

--- a/test/auto_memories_staged_test.sh
+++ b/test/auto_memories_staged_test.sh
@@ -16,6 +16,19 @@
 #
 # The ORFS-side unit tests in the same directory must stay out, or every
 # stage sandbox carries test code it never runs.
+#
+# The generator then shells out to FakeRAM, which ORFS vendors at
+# tools/FakeRAM2.0 since the standalone repository was archived. Two
+# things have to hold there and neither is self-evident:
+#
+#   * the tree is reachable at all. ORFS's .bazelignore ignores tools/
+#     wholesale, which bazel turns into --deleted_packages, so a BUILD
+#     file under it defines no package until that entry is narrowed.
+#
+#   * run.py accepts --orfs_asap7_backend, the flag gen_memories.py
+#     invokes it with. ORFS ships the patch that adds it but nothing
+#     applied it to the vendored copy, so an unpatched tree looks
+#     perfectly staged and fails only once a flow runs.
 set -eu
 
 # The test runs in runfiles/_main; @orfs files are a sibling subtree
@@ -57,5 +70,30 @@ refuse detect_test.py
 refuse gen_memories_test.py
 refuse idiomatic_test.py
 refuse schema_test.py
+
+# --- FakeRAM, the generator gen_memories.py shells out to ---
+
+fakeram_run=$(find -L "$root" -path "*/tools/FakeRAM2.0/run.py" -print 2>/dev/null | head -1)
+if [ -n "$fakeram_run" ]; then
+    echo "ok: tools/FakeRAM2.0/run.py is staged"
+    if grep -q -- "--orfs_asap7_backend" "$fakeram_run"; then
+        echo "ok: run.py accepts --orfs_asap7_backend"
+    else
+        echo "FAIL: run.py does not accept --orfs_asap7_backend;" \
+             "the ORFS ASAP7 backend patch did not reach the vendored copy"
+        status=1
+    fi
+else
+    echo "FAIL: tools/FakeRAM2.0/run.py is NOT staged"
+    status=1
+fi
+
+# The backend module run.py imports when that flag is given.
+if find -L "$root" -path "*/tools/FakeRAM2.0/orfs_asap7/generate.py" -print 2>/dev/null | grep -q .; then
+    echo "ok: orfs_asap7/generate.py is staged"
+else
+    echo "FAIL: orfs_asap7/generate.py is NOT staged"
+    status=1
+fi
 
 exit $status

--- a/test/auto_memories_staged_test.sh
+++ b/test/auto_memories_staged_test.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# The AUTO_MEMORIES scripts flow/Makefile names must reach the sandbox.
+#
+# ORFS's AUTO_MEMORIES rules (flow/Makefile, guarded by
+# `ifeq ($(AUTO_MEMORIES),1)`) name two scripts as prerequisites:
+#
+#   results/memories_inferred.json: ... $(SCRIPTS_DIR)/memories/extract_memories.tcl
+#   do-auto-memories: ...           $(SCRIPTS_DIR)/memories/gen_memories.py
+#
+# Both live in flow/scripts/memories/, which no `scripts/*` glob reaches
+# -- a glob wildcard does not cross a directory separator. When
+# extract_memories.tcl was missing from the staged set, a design with
+# AUTO_MEMORIES=1 (asap7/tinyRocket) failed canonicalization with
+#   make: *** No rule to make target '.../memories/extract_memories.tcl'
+# which reads as a Makefile bug rather than a packaging one.
+#
+# The ORFS-side unit tests in the same directory must stay out, or every
+# stage sandbox carries test code it never runs.
+set -eu
+
+# The test runs in runfiles/_main; @orfs files are a sibling subtree
+# under the runfiles root, so search from there rather than from cwd.
+# -L because bazel builds the runfiles tree out of symlinks.
+root="${RUNFILES_DIR:-$(dirname "$(pwd)")}"
+
+status=0
+
+require() {
+    if find -L "$root" -path "*/flow/scripts/memories/$1" -print 2>/dev/null | grep -q .; then
+        echo "ok: flow/scripts/memories/$1 is staged"
+    else
+        echo "FAIL: flow/scripts/memories/$1 is NOT staged"
+        status=1
+    fi
+}
+
+refuse() {
+    if find -L "$root" -path "*/flow/scripts/memories/$1" -print 2>/dev/null | grep -q .; then
+        echo "FAIL: flow/scripts/memories/$1 is staged but is ORFS's own test code"
+        status=1
+    else
+        echo "ok: flow/scripts/memories/$1 is excluded"
+    fi
+}
+
+# Named directly by flow/Makefile's AUTO_MEMORIES rules.
+require extract_memories.tcl
+require gen_memories.py
+
+# Imported by gen_memories.py, so they travel with it.
+require detect.py
+require idiomatic.py
+require schema.py
+
+# MAKEFILE_SHARED_EXCLUDE keeps these out.
+refuse detect_test.py
+refuse gen_memories_test.py
+refuse idiomatic_test.py
+refuse schema_test.py
+
+exit $status


### PR DESCRIPTION
## What this is

`asap7/tinyRocket` is the one ORFS design that uses `AUTO_MEMORIES`, and
it did not build under bazel-orfs. This makes it build, synth through
final.

`AUTO_MEMORIES` detects memory-shaped modules in the RTL pre-synthesis,
generates `.lib`/`.lef` macro views for them, blackboxes the modules,
and has every later stage read the generated views — so an existing
design gets macro-based results without a memory compiler. It is
experimental in ORFS and, as shipped, non-functional: several of the
blockers below are fatal on ORFS's own `make` flow too, so its
documented demo cannot have run either.

The PR started as a one-line packaging fix and grew as each blocker
uncovered the next. What follows is the chain, in the order the flow
hits it.

## The chain of blockers

| # | Blocker | Where the fix lives |
|---|---|---|
| 1 | `MAKEFILE_SHARED` staged `scripts/memories/*.py` but no `.tcl`, so `extract_memories.tcl` was missing — a glob wildcard does not cross a directory separator | `orfs_source.bzl` |
| 2 | The detection pass hard-errors on `blackboxes.txt`, the file its own output produces | patch 0060 |
| 3 | Bare `proc` reaches Tcl's keyword, not yosys's pass — `yosys -import` cannot shadow a built-in | patch 0061 |
| 4 | `tag_array`'s override carries none of the pins/geometry its own format requires of an undetected memory | patch 0062 |
| 5 | `ADDITIONAL_MEMORIES` was passed as a string, not staged; `*.memories` was in no filegroup | `config_mk_parser.py`, `private/orfs_design.bzl` |
| 6 | The ASAP7 FakeRAM backend was never applied to the copy ORFS vendors, and `tools/` is `.bazelignore`d so the tree was not even addressable | patch 0063 + a `patch_cmd` |
| 7 | `PYTHONSAFEPATH` (set by rules_python's venv) hid FakeRAM's own `utils/` package from it | `pythonwrapper/python.py` |
| 8 | Three of tinyRocket's four memory wrappers had no override at all | patch 0064 |
| 9 | The generated views were not declared as outputs, not propagated to later stages, and missing from two actions that read them | `private/rules.bzl` and friends |

Each was found by rebuilding and reading the next distinct failure, so
none is speculative.

## Notable details

**ORFS's `MODULE.bazel` is gone, and that is what broke FakeRAM.** ORFS
used to declare FakeRAM as a bazel module with
`patches/fakeram/0001-Add-ORFS-ASAP7-backend.patch` applied via
`git_override`. FakeRAM has since been rolled into ORFS at
`tools/FakeRAM2.0/` (the standalone repo is archived) and ORFS deleted
its `MODULE.bazel`, so nothing applies that patch any more — ORFS still
ships it, with no consumer. Checked against both the pinned commit and
ORFS master.

It could not have worked here regardless: bzlmod honours `patches` on
`git_override` only from the root module, and `dev_dependency` only when
the declaring module is root. That is the same rule that makes
bazel-orfs patch ORFS through a module extension in the first place.

**`.bazelignore` beats a BUILD file.** ORFS ignores `tools/` wholesale,
which bazel turns into `--deleted_packages` for an external repo, so the
filegroup needed to stage FakeRAM defined no package. A `patch_cmd`
replaces the `tools/` entry with its subdirectories minus `FakeRAM2.0`,
enumerated from the tree rather than hardcoded so a bump keeps new
entries ignored by default.

**Four wrappers, not one.** They were enumerated by finding every
instantiated `*_ext` module with no matching definition, rather than one
build failure at a time, and each geometry is derived from its module
header rather than typed by hand:

```
tag_array         4 x 25,    1 RW
data_arrays_0     64 x 32,   1 RW, 4 mask lanes
data_arrays_0_0   64 x 32,   1 RW
mem               1024 x 32, 1 R + 1 W, 4 mask lanes
```

**FakeRAM is staged only when `AUTO_MEMORIES=1`.** 89 files have no
business in every synth sandbox. It rides a new overridable `fakeram`
seam alongside the existing `makefile`/`makefile_yosys` ones.

## Verification

```
gen_memories: data_arrays_0   64x32   RW=1 mask_lanes=4 -> macro (forced: ...)
gen_memories: data_arrays_0_0 64x32   RW=1 mask_lanes=0 -> macro (forced: ...)
gen_memories: mem             1024x32 R=1 W=1           -> macro (forced: ...)
gen_memories: tag_array       4x25    RW=1 mask_lanes=0 -> macro (forced: ...)
```

- `RocketTile_{synth,floorplan,place,cts,grt,route,final}` all build.
  Floorplan is the load-bearing one: synth alone passes even if the
  views never propagate past the stage that made them.
- Regression: `gcd`, `aes`, `jpeg`, `ethmac` still build through route —
  every stage action's input set changed, so this is not a formality.
- New tests: staging (including that `run.py` accepts
  `--orfs_asap7_backend`, so an unpatched vendored tree cannot pass),
  an analysistest on the declared outputs with a negative half on `gcd`,
  a parser test for `ADDITIONAL_MEMORIES`, and a manual end-to-end
  `build_test`.
- Verified the first fix actually catches its regression: with the glob
  removed, the staging test fails on exactly `extract_memories.tcl` and
  passes every other assertion.
- `//:fix_lint`, `//:host_tools`, `//:public_surface` clean.

## Upstream candidates, not acted on

Five carried patches, all on an experimental ORFS feature, each with its
retire condition in its header. Reported here rather than filed:

- 0060, 0061 — `extract_memories.tcl` cannot run as shipped. Fatal on
  ORFS's `make` flow too.
- 0062, 0064 — tinyRocket describes one of its four wrappers. The better
  upstream fix is detection at the module boundary, which
  `variables.yaml` already claims and `detect.py` does not implement;
  that would retire both.
- 0063 — ORFS should vendor `tools/FakeRAM2.0` with its own backend
  applied, or apply `patches/fakeram` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
