### PR TITLE
fix(deps): //:deps could never find its tarball, and could not say so

### DIFF
--- a/deps_wrapper.sh
+++ b/deps_wrapper.sh
@@ -30,18 +30,25 @@ TARGET="$1"; shift
 # bazel run executes from bazel-bin/; nested bazelisk calls need the workspace.
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
-# Derive the _deps companion target name.
+# Derive the _deps companion target names. The tarball is an output of
+# the pkg_tar companion, {name}_deps_tar, not of {name}_deps itself.
 DEPS_TARGET="${TARGET}_deps"
+TAR_TARGET="${DEPS_TARGET}_tar"
 
 # Build the pkg_tar companion target.
-bazelisk build "$DEPS_TARGET"
+if ! bazelisk build "$TAR_TARGET"; then
+    echo "Error: failed to build $TAR_TARGET"
+    echo "Does the target have a _deps companion (is it an ORFS stage target)?"
+    exit 1
+fi
 
-# Locate the tarball.
-TARBALL="$(bazelisk cquery --output=files "$DEPS_TARGET" 2>/dev/null \
-    | grep '\.tar\.gz$')"
+# Locate the tarball. grep exits non-zero when nothing matches, which with
+# 'set -e -o pipefail' would abort here, before the diagnostic below.
+TARBALL="$(bazelisk cquery --output=files "$TAR_TARGET" 2>/dev/null \
+    | grep '\.tar\.gz$' || true)"
 
 if [ -z "$TARBALL" ]; then
-    echo "Error: deps tarball not found for $DEPS_TARGET"
+    echo "Error: deps tarball not found for $TAR_TARGET"
     echo "Does the target have a _deps companion (is it an ORFS stage target)?"
     exit 1
 fi

--- a/test/BUILD
+++ b/test/BUILD
@@ -1891,6 +1891,19 @@ py_test(
     deps = ["//:host_tools_lib"],
 )
 
+# //:deps locates the reproducer tarball through the {name}_deps_tar
+# companion, never through {name}_deps, which owns no tarball. Driven
+# with a stub 'bazelisk' on PATH so no ORFS stage has to be built; also
+# pins that a missing tarball prints a diagnostic instead of the bare
+# 'set -e' abort it used to die of.
+sh_test(
+    name = "deps_wrapper_test",
+    size = "small",
+    srcs = ["deps_wrapper_test.sh"],
+    args = ["$(rootpath //:deps)"],
+    data = ["//:deps"],
+)
+
 sh_test(
     name = "klayout_wrapper_test",
     srcs = ["tool_wrapper_test.sh"],

--- a/test/deps_wrapper_test.sh
+++ b/test/deps_wrapper_test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Regression test for deps_wrapper.sh (//:deps).
+#
+# The tarball is an output of {target}_deps_tar, not of {target}_deps, and
+# 'set -euo pipefail' used to abort the script on the non-matching grep
+# before the "deps tarball not found" diagnostic could print. Both are
+# exercised here with a stub 'bazelisk' placed first on PATH, so no ORFS
+# stage has to be built.
+
+set -uo pipefail
+
+WRAPPER="$(readlink -f "$1")"
+
+ROOT="${TEST_TMPDIR}/ws"
+STUB="${TEST_TMPDIR}/stub"
+mkdir -p "$ROOT" "$STUB"
+echo "tmp/" >"$ROOT/.gitignore"
+echo "tmp" >"$ROOT/.bazelignore"
+
+# A minimal deploy payload: what the wrapper expects to find after untar.
+PAYLOAD="${TEST_TMPDIR}/payload"
+mkdir -p "$PAYLOAD/_main"
+echo '#!/bin/sh' >"$PAYLOAD/make_mock"
+echo "export FOO=bar" >"$PAYLOAD/mock.short.mk"
+mkdir -p "$ROOT/bazel-bin/pkg"
+tar -czf "$ROOT/bazel-bin/pkg/mock_floorplan_deps_tar.tar.gz" -C "$PAYLOAD" .
+
+# Stub bazelisk. MODE selects what 'cquery --output=files' reports:
+#   ok      - the _deps_tar target owns the tarball (the real layout)
+#   notar   - no target owns a tarball
+#   nobuild - 'build' fails, as for a non-ORFS target
+cat >"$STUB/bazelisk" <<'STUBEOF'
+#!/usr/bin/env bash
+case "$1" in
+build)
+    if [ "$MODE" = nobuild ]; then
+        echo "no such target" >&2
+        exit 1
+    fi
+    exit 0
+    ;;
+cquery)
+    label="${!#}"
+    case "$label" in
+    *_deps_tar)
+        if [ "$MODE" = ok ]; then
+            echo "bazel-bin/pkg/mock_floorplan_deps_tar.tar.gz"
+        fi
+        ;;
+    *_deps)
+        # The _deps target's own files: never the tarball.
+        echo "bazel-bin/pkg/2_floorplan.short.mk"
+        echo "bazel-bin/pkg/mock_floorplan_deps.sh"
+        ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+STUBEOF
+chmod +x "$STUB/bazelisk"
+
+export BUILD_WORKSPACE_DIRECTORY="$ROOT"
+export PATH="$STUB:$PATH"
+
+fail=0
+check() {
+    if ! eval "$2"; then
+        echo "FAIL: $1"
+        fail=1
+    fi
+}
+
+# (a) The tarball is located and extracted via the _deps_tar companion.
+export MODE=ok
+out="$("$WRAPPER" //pkg:mock_floorplan 2>&1)"
+rc=$?
+echo "--- MODE=ok (rc=$rc) ---"
+echo "$out"
+check "wrapper should succeed when the _deps_tar target has a tarball" \
+    '[ "$rc" -eq 0 ]'
+check "wrapper should report the deploy directory" \
+    'grep -q "Deployed to: .*/tmp/pkg/mock_floorplan_deps" <<<"$out"'
+check "payload should be extracted" \
+    '[ -f "$ROOT/tmp/pkg/mock_floorplan_deps/make_mock" ]'
+check "make wrapper should be generated" \
+    '[ -x "$ROOT/tmp/pkg/mock_floorplan_deps/make" ]'
+
+# (b) No tarball anywhere: the diagnostic must print, and the exit non-zero.
+export MODE=notar
+out="$("$WRAPPER" //pkg:mock_floorplan 2>&1)"
+rc=$?
+echo "--- MODE=notar (rc=$rc) ---"
+echo "$out"
+check "wrapper should fail when no tarball is produced" '[ "$rc" -ne 0 ]'
+check "wrapper should print the not-found diagnostic" \
+    'grep -q "deps tarball not found" <<<"$out"'
+check "wrapper should name the _deps_tar target" \
+    'grep -q "_deps_tar" <<<"$out"'
+
+# (c) Not an ORFS stage target: the build fails, with a helpful message.
+export MODE=nobuild
+out="$("$WRAPPER" //pkg:not_a_stage 2>&1)"
+rc=$?
+echo "--- MODE=nobuild (rc=$rc) ---"
+echo "$out"
+check "wrapper should fail when the companion does not build" \
+    '[ "$rc" -ne 0 ]'
+check "wrapper should explain the missing _deps companion" \
+    'grep -q "is it an ORFS stage target" <<<"$out"'
+
+exit "$fail"


### PR DESCRIPTION
## The bug

`bazelisk run //:deps -- //pkg:target` fails for **every** target, with a bare `exit 1` and no message at all.

It is the documented entry point for deploying a stage reproducer — `docs/reference.md:29,126,132`, `examples/README.md:38`, `docs/performance.md:107`.

```
$ bazelisk run //:deps -- //test:lb_32x128_cts
... INFO: Build completed successfully, 1 total action
$ echo $?
1
```

## Two defects, stacked

**1. It queries the wrong companion.** `create_deps_tar()` emits two targets: `{name}_deps`, the runnable deploy wrapper, and `{name}_deps_tar`, the `pkg_tar`. The wrapper asked `{name}_deps` for a `*.tar.gz`, which that target never produces:

```
$ bazelisk cquery --output=files //test:lb_32x128_cts_deps
bazel-out/.../4_cts.short.mk
bazel-out/.../lb_32x128_cts_deps.sh
bazel-out/.../lb_32x128_cts_deps_run.sh      # no tarball

$ bazelisk cquery --output=files //test:lb_32x128_cts_deps_tar
bazel-out/.../lb_32x128_cts_deps_tar.tar.gz  # here it is
```

**2. The diagnostic is unreachable dead code.** With no match the `grep` exits non-zero, and under the script's `set -euo pipefail` the command substitution aborts the script *before* the guard below it:

```sh
TARBALL="$(bazelisk cquery --output=files "$DEPS_TARGET" 2>/dev/null \
    | grep '\.tar\.gz$')"          # <- script dies here

if [ -z "$TARBALL" ]; then
    echo "Error: deps tarball not found for $DEPS_TARGET"   # never runs
```

So the one failure mode the script anticipated was the one it could not report.

## The fix

Query `{name}_deps_tar`, and tolerate the empty `grep` so the guard is reached. A failing `bazelisk build` is tolerated the same way, so a target with no `_deps` companion is told what is wrong instead of dying on the raw build error. `set -euo pipefail` is kept.

## The test

`//test:deps_wrapper_test` drives the wrapper with a stub `bazelisk` first on `PATH`, so no ORFS stage is built and it runs in 0.1s. Three cases:

| case | asserts |
| --- | --- |
| tarball on `_deps_tar` (the real layout) | exits 0, extracts the payload, generates the `make` wrapper |
| no tarball anywhere | prints `deps tarball not found`, names `_deps_tar`, exits non-zero |
| companion does not build | still prints `is it an ORFS stage target`, exits non-zero |

Reverting either half of the fix fails it: 7 of 9 assertions, including the no-tarball case reproducing the silent `rc=1` with no output.

## Checks

`//:fix_lint`, `//:host_tools` and `//:public_surface` all pass. No other caller confuses the pair — `test/BUILD` and `deps_output_group_rule.bzl` already target `_deps_tar` correctly.

## Note

Building `_deps_tar` packs the runfiles that the rest of the script then extracts, which is what it always assumed. The comment above `//:deps` in `BUILD` still says "Only builds the deps output group (cheap)"; that was already stale relative to the old `bazelisk build "$DEPS_TARGET"` and is left alone here to keep this one concern.

Found while building the `-threads` idempotency harness for #970, which had to call `<target>_<stage>_deps` directly to work around this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
