### PR TITLE
fix(orfs): the log_timestamps flag silently deletes the stage summary block

### DIFF
--- a/orfs_source.bzl
+++ b/orfs_source.bzl
@@ -109,6 +109,13 @@ ORFS_PATCHES = [
     # and ORFS describes only one, so hierarchy -check dies on the other.
     # Goes with 0062; either is useless without it.
     Label("//patches:0064-orfs-tinyrocket-data-arrays-memories.patch"),
+    # genElapsedTime.py read the timing line positionally, so any prefix
+    # on the log line -- the per-line stamp //:log_timestamps.py adds,
+    # which 0048 routes into every stage log -- dropped the whole
+    # per-stage summary block, sha1sum column included, exit status 0.
+    # Matches the format with a regex instead. Prerequisite of 0048:
+    # upstream them together or not at all.
+    Label("//patches:0065-orfs-genelapsedtime-stamped-log.patch"),
 ]
 
 # Generate the BUILD file for any design directory that has a config.mk

--- a/patches/0048-orfs-flow-sh-honor-run-cmd.patch
+++ b/patches/0048-orfs-flow-sh-honor-run-cmd.patch
@@ -15,6 +15,23 @@ Defaulting to the current command keeps the behavior identical when
 RUN_CMD is unset, so this is a no-op for a normal `make` and makes the
 variable mean what its name says everywhere.
 
+Not upstreamable on its own, contrary to the commit that carried it
+here -- 2837a5c, in #900, which closed with "Upstreamable as-is, and
+worth upstreaming". flow.sh writes the stage log through RUN_CMD and
+then, four lines later, parses that same log back with
+genElapsedTime.py -- and that
+parser read the timing line positionally, so a wrapper that prefixes
+each line (bazel-orfs's own //:log_timestamps.py, under
+--@bazel-orfs//:log_timestamps) silently deleted the per-stage summary
+block, sha1sum column included, exit status 0. Landing this alone would
+hand that regression to every ORFS user who overrides RUN_CMD.
+patches/0065-orfs-genelapsedtime-stamped-log.patch fixes the parser and
+is the prerequisite; the two are one change and go upstream together or
+not at all.
+
+Not upstreamed. Retire at the //:bump onto an ORFS whose flow.sh runs
+the stage through RUN_CMD.
+
 diff --git a/flow/scripts/flow.sh b/flow/scripts/flow.sh
 --- a/flow/scripts/flow.sh
 +++ b/flow/scripts/flow.sh

--- a/patches/0065-orfs-genelapsedtime-stamped-log.patch
+++ b/patches/0065-orfs-genelapsedtime-stamped-log.patch
@@ -1,0 +1,173 @@
+Parse the elapsed-time line wherever it sits on the line.
+
+genElapsedTime.py writes the per-stage summary block -- the only place
+ORFS reports a hash of a stage's result:
+
+  Log                Ext   Elapsed/s  Peak Memory/MB  sha1sum result [0:20)
+
+flow/scripts/flow.sh calls it after every stage, synth.sh does the same,
+and flow/Makefile exposes it as `make elapsed` / `elapsed-all`.
+
+It read the elapsed time positionally: strip the line, delete the
+literal "Elapsed time: " substring, then split on "[h:]", on the first
+".", and on ":". That works only when the timing line starts the log
+line. Give the line any prefix -- "[  123.45] " -- and the prefix
+survives the substring delete, the split on "." cuts at the prefix's own
+decimal point, and the resulting one-element list falls to the
+"Elapsed time not understood" branch. elapsedTime stays None, so the
+bottom of the loop skips the whole row: header, elapsed, peak memory and
+the sha1sum column all vanish. `found` is already True, so the
+"No elapsed time found" warning does not fire either; the complaint goes
+to stderr, not to the log, and the exit status is 0. The one line you
+would read to check whether two builds produced the same result
+disappears without saying so.
+
+Matching a regex anchored on the format instead -- hours optional, as
+run_command.py's _format_elapsed only emits them past an hour -- ignores
+whatever precedes it. An unstamped line parses to exactly the same
+number it did before, including the truncation of the fraction of a
+second, and a genuinely unparseable line still reaches the
+"not understood" branch.
+
+Reaching the broken case needs a prefix on the stage log, and that is
+this repo's doing: patches/0048-orfs-flow-sh-honor-run-cmd.patch makes
+flow.sh run the tool through RUN_CMD, and bazel-orfs points RUN_CMD at
+//:log_timestamps.py under --@bazel-orfs//:log_timestamps. flow.sh both
+writes the log through RUN_CMD and, four lines later, parses it back
+with genElapsedTime.py, so the stamping the flag asks for is fed
+straight into this parser. 0048 without this patch is a regression for
+anyone who overrides RUN_CMD; the two are one change and must be
+upstreamed together or not at all. This one is the prerequisite.
+
+flow/test/test_run_command.py's test_genElapsedTime_parses_output is
+extended in the same patch. It drove genElapsedTime.py from a log
+run_command.py had just written, so it only ever saw an unstamped line
+-- and it asserted only that the stage name appeared, which it does even
+when the row is dropped. It now asserts the elapsed and memory columns
+are there, and two cases are added: a prefixed line, and the hours form.
+
+Not upstreamed. Retire at the //:bump onto an ORFS whose
+genElapsedTime.py parses the timing line independently of what precedes
+it on the log line.
+
+diff --git a/flow/util/genElapsedTime.py b/flow/util/genElapsedTime.py
+--- a/flow/util/genElapsedTime.py
++++ b/flow/util/genElapsedTime.py
+@@ -8,6 +8,7 @@
+ import hashlib
+ import pathlib
+ import os
++import re
+ import sys
+ 
+ # Parse and validate arguments
+@@ -21,6 +22,15 @@
+ RESULT_EXTS = [".v", ".rtlil", ".odb", ".def", ".spef", ".gds", ".sdc"]
+ 
+ 
++# The timing line run_command.py emits, matched wherever it appears in
++# the line rather than from its start.  A RUN_CMD wrapper is free to
++# prefix every log line -- a per-line elapsed stamp, "[  123.45] " --
++# and such a prefix must not change what this reports.  Hours are
++# optional, as _format_elapsed only emits them past an hour, and the
++# fraction of a second is matched so it can be discarded.
++ELAPSED_RE = re.compile(r"Elapsed time: (?:(\d+):)?(\d+):(\d+)(?:\.\d+)?\[h:\]min:sec")
++
++
+ def get_hashes(f):
+     """Return [(ext, sha1), ...] for every result file alongside log
+     `f` whose extension is in RESULT_EXTS.  A yosys stage typically
+@@ -77,24 +87,15 @@
+                 # Elapsed time: 0:04.26[h:]min:sec. CPU time: user 4.08 sys 0.17 (99%). Peak memory: 671508KB.
+                 if "Elapsed time" in line:
+                     found = True
+-                    # Extract the portion that has the time
+-                    timePor = line.strip().replace("Elapsed time: ", "")
+-                    # Remove the units from the time portion
+-                    timePor = timePor.split("[h:]", 1)[0]
+-                    # Remove any fraction of a second
+-                    timePor = timePor.split(".", 1)[0]
+-                    # Calculate elapsed time that has this format 'h:m:s'
+-                    timeList = timePor.split(":")
+-                    if len(timeList) == 2:
+-                        # Only minutes and seconds are present
+-                        elapsedTime = int(timeList[0]) * 60 + int(timeList[1])
+-                    elif len(timeList) == 3:
+-                        # Hours, minutes, and seconds are present
+-                        elapsedTime = (
+-                            int(timeList[0]) * 3600
+-                            + int(timeList[1]) * 60
+-                            + int(timeList[2])
+-                        )
++                    # Match the 'h:m:s' time against the known format,
++                    # so anything the line is prefixed with is ignored.
++                    timeMatch = ELAPSED_RE.search(line)
++                    if timeMatch:
++                        hours, minutes, seconds = timeMatch.groups()
++                        # Any fraction of a second is dropped.
++                        elapsedTime = int(minutes) * 60 + int(seconds)
++                        if hours is not None:
++                            elapsedTime += int(hours) * 3600
+                     else:
+                         print(
+                             "Elapsed time not understood in", str(line), file=sys.stderr
+diff --git a/flow/test/test_run_command.py b/flow/test/test_run_command.py
+--- a/flow/test/test_run_command.py
++++ b/flow/test/test_run_command.py
+@@ -283,6 +283,56 @@
+             genElapsedTime.scan_logs(["--logDir", log_dir, "--noHeader"])
+         output = mock_out.getvalue()
+         self.assertIn("1_test", output)
++        # The elapsed column is the point of the table; a line that
++        # parses to nothing drops the whole row, exit status 0.
++        self.assertRegex(output, r"1_test\s+\S*\s+\d+\s+\d+")
++
++    def test_genElapsedTime_parses_prefixed_output(self):
++        """Verify genElapsedTime.py can parse a timing line behind a log prefix."""
++        sys.path.insert(
++            0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "util")
++        )
++        import genElapsedTime
++        from io import StringIO
++        from unittest.mock import patch
++
++        # A RUN_CMD wrapper may stamp every log line -- an elapsed-seconds
++        # prefix, say -- so the timing line is not at the start of its line.
++        log_dir = self.tmp_dir.name
++        log_file = os.path.join(log_dir, "1_test.log")
++        with open(log_file, "w") as f:
++            f.write("[    0.001] some output\n")
++            f.write(
++                "[  123.456] Elapsed time: 0:04.26[h:]min:sec. "
++                "CPU time: user 4.08 sys 0.17 (99%). Peak memory: 671508KB.\n"
++            )
++        with patch("sys.stdout", new_callable=StringIO) as mock_out:
++            genElapsedTime.scan_logs(["--logDir", log_dir, "--noHeader"])
++        output = mock_out.getvalue()
++        # 0:04.26 is 4 seconds, and 671508KB is 655MB; the prefix is not
++        # part of either.
++        self.assertRegex(output, r"1_test\s+\S*\s+4\s+655")
++
++    def test_genElapsedTime_parses_hours(self):
++        """Verify genElapsedTime.py understands the optional hours field."""
++        sys.path.insert(
++            0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "util")
++        )
++        import genElapsedTime
++        from io import StringIO
++        from unittest.mock import patch
++
++        log_dir = self.tmp_dir.name
++        log_file = os.path.join(log_dir, "1_test.log")
++        with open(log_file, "w") as f:
++            f.write(
++                "Elapsed time: 1:01:01.00[h:]min:sec. "
++                "CPU time: user 4.08 sys 0.17 (99%). Peak memory: 671508KB.\n"
++            )
++        with patch("sys.stdout", new_callable=StringIO) as mock_out:
++            genElapsedTime.scan_logs(["--logDir", log_dir, "--noHeader"])
++        output = mock_out.getvalue()
++        self.assertRegex(output, r"1_test\s+\S*\s+3661\s+655")
+ 
+ 
+ if __name__ == "__main__":


### PR DESCRIPTION
## The bug

Turn on `--@bazel-orfs//:log_timestamps` and every stage log silently loses this block — the only place ORFS reports a hash of the stage result:

```
Log                       Ext     Elapsed/s Peak Memory/MB sha1sum result [0:20)
4_1_cts                   .odb            4            655 f6dd36e821d8c6351712
```

Exit status 0. One line on stderr. Nothing in the log.

The documented debugging flag deletes the one column you would use to check determinism — the column `diagnose-pr-head` reads.

## We did this to ourselves

`flow/scripts/flow.sh` writes the stage log through `$RUN_CMD` and then, four lines later, parses that same log back:

```sh
$RUN_CMD --log "$LOG_DIR/$1.tmp.log" --append --tee -- $OPENROAD_CMD ...   # ~15
...
"$PYTHON_EXE" "$UTILS_DIR/genElapsedTime.py" --match "$1" -d "$LOG_DIR" \   # ~20
  | tee -a "$(realpath "$LOG_DIR/$1.log")"
```

`patches/0048-orfs-flow-sh-honor-run-cmd.patch` (#900) is what routes `RUN_CMD` into that first line. Before it, no stage log was ever stamped and this parser never saw a prefix. **0048 is what made the broken case reachable**, and it shipped in the same PR as the flag that reaches it.

`genElapsedTime.py` read the timing line positionally:

```python
timePor = line.strip().replace("Elapsed time: ", "")  # prefix survives
timePor = timePor.split("[h:]", 1)[0]                 # "[  123.45] 0:04.26"
timePor = timePor.split(".", 1)[0]                    # cuts at the STAMP's decimal -> "[  123"
timeList = timePor.split(":")                         # length 1 -> no branch matches
```

`elapsedTime` stays `None`, so the row is skipped. `found` is already `True`, so the "No elapsed time found" warning never fires. The message goes to stderr, and `flow.sh` does not check the status.

## The fix

Match the format with a regex, so whatever precedes it on the line is ignored:

```python
ELAPSED_RE = re.compile(r"Elapsed time: (?:(\d+):)?(\d+):(\d+)(?:\.\d+)?\[h:\]min:sec")
```

Unstamped output is byte-identical, the hours form still works, and a genuinely unparseable line still reaches the existing diagnostic.

## Verified

Against the pinned ORFS `a71b115b9b` (tarball sha256 matches `MODULE.bazel`'s integrity):

| | unstamped | stamped |
| --- | --- | --- |
| before | table | **gone**, exit 0 |
| after | table, byte-identical | table |

Plus `1:02:03.45` → 3723s, and `Elapsed time: nonsense.` still reports "not understood".

`patch -p1 --dry-run` clean on a fresh extract. ORFS's own `flow/test/test_run_command.py`: **21/21 on the patched tree, and the new case fails on a pristine one.** `//test/bump:bump_test`, `//:fix_lint`, `//:host_tools`, `//:public_surface` all pass. No flow target was built and `@orfs` was never refetched.

## Also: 0048's header was wrong about itself

`2837a5c` closed with *"Upstreamable as-is, and worth upstreaming"*. It is not — landing 0048 alone hands this regression to every ORFS user who overrides `RUN_CMD`. 0048's header now says so and names 0065 as its prerequisite: **the two go upstream together or not at all.** Prose only; its hunks are untouched and still apply.

Worth noting how 0048 was verified at the time: *"with the flag off, a gcd place log comes out with zero stamped lines"* — the path it does **not** change. The path it does change was not covered, which is also why ORFS's own `test_genElapsedTime_parses_output` never caught this: it calls `run_command.run()` directly and only ever sees an unstamped line. This patch extends it.

ORFS stays read-only per the moratorium in CLAUDE.md — carried here, retires on a `//:bump` onto an ORFS that has it.

Found while building the `-threads` idempotency harness for #970. #968 hit the same wall, worked around it by computing the hash itself, and never filed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
