### PR TITLE
docs(deps): say what //:deps builds and what it costs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -190,7 +190,9 @@ py_test(
 )
 
 # Run `bazelisk run //:deps -- //pkg:target` to deploy stage inputs
-# for interactive debugging. Only builds the deps output group (cheap).
+# for interactive debugging. Builds {target}_deps_tar, so it pays for
+# every prior stage of the flow: a cts reproducer builds synth,
+# floorplan and place.
 sh_binary(
     name = "deps",
     srcs = ["deps_wrapper.sh"],


### PR DESCRIPTION
The comment above `sh_binary(name = "deps")` says:

> Only builds the deps output group (cheap).

Both halves are wrong, and were before #971 too.

**It is not an output group.** The script builds a whole target. It always did — `bazelisk build "${TARGET}_deps"` before #971, and `bazelisk build "${TARGET}_deps_tar"` after it.

**It is not cheap.** `{target}_deps` packages the stage's *inputs*, so building it builds every prior stage of the flow. A deployed `cts` reproducer contains `1_synth.args.json`, `2_floorplan.analysis.json` and `3_place.odb` — synth, floorplan and place all ran to produce it. After #971 it builds the `pkg_tar` companion, which also packs the runfiles, so it is strictly more work than the comment ever described.

"Cheap" is the one word in that sentence a reader would act on: it is what tells you it is fine to run on a whim. It is the opposite of true for a design whose earlier stages take minutes.

Comment only. No code, no docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
