### PR TITLE
docs(deps): what //:deps accepts and what it builds

### DIFF
--- a/docs/local-flow.md
+++ b/docs/local-flow.md
@@ -42,10 +42,12 @@ The local flow lets you build with a locally compiled [ORFS](https://openroad-fl
 
 > **NOTE:** Files are always placed in `tmp/<package>/<name>_deps/` under the workspace root (e.g. `tmp/sram/sdq_17x64_floorplan_deps/` for `//sram:sdq_17x64_floorplan`, `tmp/MyDesign_floorplan_deps/` for the root package), which is added to `.gitignore` automatically.
 >
-> You can override the installation directory with `--install`:
+> `//:deps` takes no `--install`; it forwards any trailing arguments to
+> `make`. To choose the directory, run the stage's own `_deps` target,
+> which does accept it:
 >
 > ```bash
-> bazel run //:deps -- <target>_<stage> --install /path/to/dir [<make args...>]
+> bazel run <target>_<stage>_deps -- --install /path/to/dir [<make args...>]
 > ```
 >
 > This is useful on systems where `/tmp` is small or when you want to place the build artifacts in a specific location.
@@ -111,8 +113,9 @@ bazel run //:deps -- //coralnpu:CoreMiniAxi_place do-3_4_place_resized
 ```
 
 The `//:deps` wrapper builds all preceding stages (synth, floorplan, place)
-automatically via `--output_groups=deps` before deploying artifacts, so you
-never need to manually build the dependency chain.
+automatically by building the `<target>_<stage>_deps_tar` companion target
+before deploying artifacts, so you never need to manually build the
+dependency chain.
 
 ### Available substeps per stage
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -23,7 +23,7 @@ See [Substep targets](local-flow.md#substep-targets).
 
 ### Dependency deployment
 
-Dependencies are deployed using the `//:deps` wrapper, which uses `--output_groups=deps` to build and deploy stage artifacts:
+Dependencies are deployed using the `//:deps` wrapper, which builds the `<target>_<stage>_deps_tar` companion target and extracts it:
 
 ```bash
 bazel run //:deps -- <target>_<stage>


### PR DESCRIPTION
Two things the docs say about `//:deps` that are not true. Both verified against `deps_wrapper.sh` on main.

## 1. `--install` is documented for a wrapper that has no such flag

`docs/local-flow.md` offered:

```bash
bazel run //:deps -- <target>_<stage> --install /path/to/dir [<make args...>]
```

`deps_wrapper.sh` has no `--install` handling. It computes its destination itself and forwards trailing arguments to `make`, so `--install /path/to/dir` reaches GNU make as two arguments and the directory is silently ignored.

The capability is real, but it belongs to the other deploy path — the `<target>_<stage>_deps` runnable generated from `deploy.tpl`, which parses it (usage at `:6`, help at `:8`, the parse arm at `:53`). The doc now points at the mechanism that implements it.

Deliberately **not** implemented in `deps_wrapper.sh`: adding a flag is a feature decision, not a doc correction.

## 2. `--output_groups=deps` — it never worked that way

- `docs/reference.md:26` — "the `//:deps` wrapper, which uses `--output_groups=deps` to build and deploy stage artifacts"
- `docs/local-flow.md:114` — "automatically via `--output_groups=deps` before deploying artifacts"

It builds a whole target: `{target}_deps` before #971, `{target}_deps_tar` after it. Both corrected to name the target.

This is the doc-side counterpart of #973, which corrected the same falsehood in the `BUILD` comment. That one landed first; these four sites were untouched by it.

## Checked and left alone

- `docs/reference.md:157` (`bazel build --output_groups=deps //test:L1MetadataArray_synth`) — **accurate.** A `deps` output group does exist: `private/rules.bzl:2589` (synth) and `:3050` (make stages), both `deps = depset([deps_tar])`. That line is a user invoking the group directly, which works.
- `docs/local-flow.md:151` (`--output_groups=substep_3_3_place_gp`) — **accurate.** `private/rules.bzl:3057` emits `"substep_" + substep_names[i]`, and `3_3_place_gp` is in `STAGE_SUBSTEPS["place"]`.
- `docs/local-flow.md:52` — "useful on systems where `/tmp` is small" is still slightly wrong: the destination is the workspace's `tmp/`, not `/tmp`. Pre-existing, adjacent to my edit, and outside this concern — flagging rather than folding it in.

Docs only: no change to `deps_wrapper.sh`, `deploy.tpl`, `BUILD` or any test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
