### PR TITLE
fix(deps): locate the stage make script in the deployed tree

### DIFF
--- a/deps_wrapper.sh
+++ b/deps_wrapper.sh
@@ -85,12 +85,36 @@ if [ -d "$RUNFILES_DIR" ]; then
     rmdir "$RUNFILES_DIR"
 fi
 
-# Find the make binary (the stage-specific shell wrapper).
-MAKE_BIN="$(echo "$DST"/make_*)"
-if [ ! -f "$MAKE_BIN" ]; then
+# Find the make script (the stage-specific shell wrapper). It is NOT at
+# the deploy root: it keeps its runfiles path, <repo-dir>/<package>/
+# make_<target>_<variant>_<stage>, and the repo dir depends on which
+# repository the design's package lives in:
+#   _main/test/make_lb_32x128_cts_base_4_cts
+#   +orfs_repositories+orfs/flow/designs/nangate45/gcd/make_gcd_cts_base_4_cts
+# So search the deployed tree, keyed on the target name -- a bare
+# 'make_*' also matches unrelated ORFS payload such as
+# flow/platforms/asap7/openRoad/make_tracks.tcl.
+# mapfile keeps the search out of a pipeline whose failure would, under
+# 'set -euo pipefail', abort before any diagnostic could print.
+MAKE_CANDIDATES=()
+mapfile -t MAKE_CANDIDATES < <(
+    find "$DST" -type f -name "make_${LABEL_NAME}_*" | sort
+)
+
+if [ "${#MAKE_CANDIDATES[@]}" -eq 0 ]; then
     echo "Error: make binary not found in $DST"
+    echo "Searched the deployed tree for a regular file named" \
+        "'make_${LABEL_NAME}_*'."
+    echo "Does the target have a _deps companion (is it an ORFS stage target)?"
     exit 1
 fi
+if [ "${#MAKE_CANDIDATES[@]}" -gt 1 ]; then
+    echo "Error: multiple make binaries found in $DST"
+    printf '  %s\n' "${MAKE_CANDIDATES[@]}"
+    echo "Refusing to guess which one drives the stage."
+    exit 1
+fi
+MAKE_BIN="${MAKE_CANDIDATES[0]}"
 
 # Find the config file (*.short.mk).
 CONFIG="$(echo "$DST"/*.short.mk)"
@@ -100,15 +124,22 @@ if [ -f "$CONFIG" ]; then
     cp "$CONFIG" "$DST/_main/config.mk"
 fi
 
-# Create the make wrapper script.
-MAKE_REL="$(basename "$MAKE_BIN")"
+# Create the make wrapper script. The wrapper cd's into _main, so the
+# exec target is the make script's path relative to _main -- the same
+# shape deploy.tpl gets from the script's Bazel short_path: <package>/...
+# for a design in this repo, ../<repo>/<package>/... for an external one.
+MAKE_REL="${MAKE_BIN#"$DST"/}"
+case "$MAKE_REL" in
+_main/*) MAKE_EXEC="./${MAKE_REL#_main/}" ;;
+*) MAKE_EXEC="./../$MAKE_REL" ;;
+esac
 cat > "$DST/make" <<WRAPPER
 #!/usr/bin/env bash
 set -exuo pipefail
 cd "\$(dirname "\$0")/_main"
 find . -not -perm -u+w -exec chmod u+w {} + 2>/dev/null || true
 export RUNFILES_DIR="\$(pwd)/.."
-exec ../$MAKE_REL "\$@"
+exec $MAKE_EXEC "\$@"
 WRAPPER
 chmod +x "$DST/make"
 

--- a/test/deps_wrapper_test.sh
+++ b/test/deps_wrapper_test.sh
@@ -2,11 +2,31 @@
 #
 # Regression test for deps_wrapper.sh (//:deps).
 #
-# The tarball is an output of {target}_deps_tar, not of {target}_deps, and
-# 'set -euo pipefail' used to abort the script on the non-matching grep
-# before the "deps tarball not found" diagnostic could print. Both are
-# exercised here with a stub 'bazelisk' placed first on PATH, so no ORFS
-# stage has to be built.
+# Two bugs are pinned here:
+#
+#  1. The tarball is an output of {target}_deps_tar, not of {target}_deps,
+#     and 'set -euo pipefail' used to abort the script on the non-matching
+#     grep before the "deps tarball not found" diagnostic could print.
+#
+#  2. The stage make script is not at the deploy root. It keeps its
+#     runfiles path, <repo-dir>/<package>/make_<target>_<variant>_<stage>,
+#     and the repo dir depends on which repository the design's package
+#     lives in. A root 'make_*' glob matched neither real layout, and the
+#     generated ./make wrapper hardcoded 'exec ../<basename>'.
+#
+# The payloads below mirror a real tarball, as produced by
+# //test:lb_32x128_cts_deps_tar:
+#
+#   4_cts.short.mk
+#   lb_32x128_cts_deps_run.sh
+#   lb_32x128_cts_deps_run.sh.runfiles/_main/test/make_lb_32x128_cts_base_4_cts
+#   lb_32x128_cts_deps_run.sh.runfiles/+orfs_repositories+orfs/...
+#
+# including ORFS's flow/platforms/asap7/openRoad/make_tracks.tcl, which a
+# bare 'make_*' search happily mistakes for the stage make script.
+#
+# Driven with a stub 'bazelisk' first on PATH, so no ORFS stage has to be
+# built.
 
 set -uo pipefail
 
@@ -17,19 +37,57 @@ STUB="${TEST_TMPDIR}/stub"
 mkdir -p "$ROOT" "$STUB"
 echo "tmp/" >"$ROOT/.gitignore"
 echo "tmp" >"$ROOT/.bazelignore"
-
-# A minimal deploy payload: what the wrapper expects to find after untar.
-PAYLOAD="${TEST_TMPDIR}/payload"
-mkdir -p "$PAYLOAD/_main"
-echo '#!/bin/sh' >"$PAYLOAD/make_mock"
-echo "export FOO=bar" >"$PAYLOAD/mock.short.mk"
 mkdir -p "$ROOT/bazel-bin/pkg"
-tar -czf "$ROOT/bazel-bin/pkg/mock_floorplan_deps_tar.tar.gz" -C "$PAYLOAD" .
+
+# make_payload <tarball> <runner> <script-runfiles-path>...
+#
+# Builds a tarball shaped like the real one: a short config and the
+# *_deps_run.sh launcher at the root, everything else under
+# <launcher>.runfiles/<repo-dir>/..., which the wrapper flattens.
+make_payload() {
+    local tarball="$1" runner="$2"
+    shift 2
+    local payload="${TEST_TMPDIR}/payload.$$.$RANDOM"
+    local runfiles="$payload/$runner.runfiles"
+    mkdir -p "$payload" "$runfiles/_main"
+    echo "export DESIGN_NAME=mock" >"$payload/4_cts.short.mk"
+    echo '#!/bin/sh' >"$payload/$runner"
+    # ORFS payload that a bare 'make_*' search would mistake for the
+    # stage make script.
+    local tracks="$runfiles/+orfs_repositories+orfs/flow/platforms/asap7/openRoad"
+    mkdir -p "$tracks"
+    echo "# tracks" >"$tracks/make_tracks.tcl"
+    local script
+    for script in "$@"; do
+        mkdir -p "$runfiles/$(dirname "$script")"
+        printf '#!/bin/sh\necho "ran $0"\n' >"$runfiles/$script"
+        chmod +x "$runfiles/$script"
+    done
+    tar -czf "$tarball" -C "$payload" .
+    rm -rf "$payload"
+}
+
+# (i) A design in this repository: _main/<package>/make_<name>.
+make_payload "$ROOT/bazel-bin/pkg/main_tar.tar.gz" \
+    lb_32x128_cts_deps_run.sh \
+    _main/test/make_lb_32x128_cts_base_4_cts
+
+# (ii) A design in @orfs: +orfs_repositories+orfs/<package>/make_<name>.
+make_payload "$ROOT/bazel-bin/pkg/orfs_tar.tar.gz" \
+    gcd_cts_deps_run.sh \
+    +orfs_repositories+orfs/flow/designs/nangate45/gcd/make_gcd_cts_base_4_cts
+
+# (iii) Two candidates for the same target: the wrapper must refuse
+# rather than pick one.
+make_payload "$ROOT/bazel-bin/pkg/ambiguous_tar.tar.gz" \
+    dup_cts_deps_run.sh \
+    _main/test/make_dup_cts_base_4_cts \
+    +orfs_repositories+orfs/flow/designs/dup/make_dup_cts_base_4_cts
 
 # Stub bazelisk. MODE selects what 'cquery --output=files' reports:
-#   ok      - the _deps_tar target owns the tarball (the real layout)
-#   notar   - no target owns a tarball
-#   nobuild - 'build' fails, as for a non-ORFS target
+#   main/orfs/ambiguous - the _deps_tar target owns that tarball
+#   notar               - no target owns a tarball
+#   nobuild             - 'build' fails, as for a non-ORFS target
 cat >"$STUB/bazelisk" <<'STUBEOF'
 #!/usr/bin/env bash
 case "$1" in
@@ -44,14 +102,15 @@ cquery)
     label="${!#}"
     case "$label" in
     *_deps_tar)
-        if [ "$MODE" = ok ]; then
-            echo "bazel-bin/pkg/mock_floorplan_deps_tar.tar.gz"
-        fi
+        case "$MODE" in
+        notar) ;;
+        *) echo "bazel-bin/pkg/${MODE}_tar.tar.gz" ;;
+        esac
         ;;
     *_deps)
         # The _deps target's own files: never the tarball.
-        echo "bazel-bin/pkg/2_floorplan.short.mk"
-        echo "bazel-bin/pkg/mock_floorplan_deps.sh"
+        echo "bazel-bin/pkg/4_cts.short.mk"
+        echo "bazel-bin/pkg/mock_cts_deps.sh"
         ;;
     esac
     exit 0
@@ -72,24 +131,77 @@ check() {
     fi
 }
 
-# (a) The tarball is located and extracted via the _deps_tar companion.
-export MODE=ok
-out="$("$WRAPPER" //pkg:mock_floorplan 2>&1)"
+# (a) A design in this repository. The make script sits at
+# _main/test/..., so the wrapper -- which cd's into _main -- must exec
+# ./test/..., the shape deploy.tpl derives from the script's short_path.
+export MODE=main
+out="$("$WRAPPER" //test:lb_32x128_cts 2>&1)"
 rc=$?
-echo "--- MODE=ok (rc=$rc) ---"
+echo "--- MODE=main (rc=$rc) ---"
 echo "$out"
+DST="$ROOT/tmp/test/lb_32x128_cts_deps"
 check "wrapper should succeed when the _deps_tar target has a tarball" \
     '[ "$rc" -eq 0 ]'
 check "wrapper should report the deploy directory" \
-    'grep -q "Deployed to: .*/tmp/pkg/mock_floorplan_deps" <<<"$out"'
-check "payload should be extracted" \
-    '[ -f "$ROOT/tmp/pkg/mock_floorplan_deps/make_mock" ]'
-check "make wrapper should be generated" \
-    '[ -x "$ROOT/tmp/pkg/mock_floorplan_deps/make" ]'
+    'grep -q "Deployed to: $DST\$" <<<"$out"'
+check "runfiles should be flattened to the deploy root" \
+    '[ -f "$DST/_main/test/make_lb_32x128_cts_base_4_cts" ]'
+check "config.mk should be written under _main" \
+    '[ -f "$DST/_main/config.mk" ]'
+check "make wrapper should be generated" '[ -x "$DST/make" ]'
+check "make wrapper should be valid bash" 'bash -n "$DST/make"'
+check "make wrapper should exec the _main-relative make script" \
+    'grep -qx "exec ./test/make_lb_32x128_cts_base_4_cts \"\$@\"" "$DST/make"'
+check "make wrapper's exec target should exist" \
+    '[ -x "$DST/_main/test/make_lb_32x128_cts_base_4_cts" ]'
+check "make wrapper should actually run the stage make script" \
+    '"$DST/make" >/dev/null 2>&1'
 
-# (b) No tarball anywhere: the diagnostic must print, and the exit non-zero.
+# (b) A design in @orfs. The make script sits in the @orfs repo dir, one
+# level up from _main, so the wrapper must exec ./../<repo>/... -- the
+# same string deploy.tpl generates for this design.
+export MODE=orfs
+out="$("$WRAPPER" @orfs//flow/designs/nangate45/gcd:gcd_cts 2>&1)"
+rc=$?
+echo "--- MODE=orfs (rc=$rc) ---"
+echo "$out"
+ODST="$(sed -n 's/^Deployed to: //p' <<<"$out")"
+GCD_MAKE="+orfs_repositories+orfs/flow/designs/nangate45/gcd"
+GCD_MAKE="$GCD_MAKE/make_gcd_cts_base_4_cts"
+check "wrapper should succeed for a design in an external repository" \
+    '[ "$rc" -eq 0 ]'
+check "wrapper should report a deploy directory" '[ -n "$ODST" ]'
+check "runfiles should be flattened to the deploy root" \
+    '[ -f "$ODST/$GCD_MAKE" ]'
+check "config.mk should be written under _main" \
+    '[ -f "$ODST/_main/config.mk" ]'
+check "make wrapper should be valid bash" 'bash -n "$ODST/make"'
+check "make wrapper should exec the make script one level above _main" \
+    'grep -qx "exec ./../$GCD_MAKE \"\$@\"" "$ODST/make"'
+check "make wrapper should actually run the stage make script" \
+    '"$ODST/make" >/dev/null 2>&1'
+
+# (c) Two make scripts match: the wrapper must name both and fail rather
+# than silently pick one.
+export MODE=ambiguous
+out="$("$WRAPPER" //pkg:dup_cts 2>&1)"
+rc=$?
+echo "--- MODE=ambiguous (rc=$rc) ---"
+echo "$out"
+check "wrapper should fail when the make script is ambiguous" \
+    '[ "$rc" -ne 0 ]'
+check "wrapper should say the make binaries are ambiguous" \
+    'grep -q "multiple make binaries found" <<<"$out"'
+check "wrapper should list the first candidate" \
+    'grep -q "_main/test/make_dup_cts_base_4_cts" <<<"$out"'
+check "wrapper should list the second candidate" \
+    'grep -q "+orfs_repositories+orfs/flow/designs/dup/make_dup_cts_base_4_cts" <<<"$out"'
+check "wrapper should not generate a make wrapper it cannot aim" \
+    '[ ! -e "$ROOT/tmp/pkg/dup_cts_deps/make" ]'
+
+# (d) No tarball anywhere: the diagnostic must print, and the exit non-zero.
 export MODE=notar
-out="$("$WRAPPER" //pkg:mock_floorplan 2>&1)"
+out="$("$WRAPPER" //test:lb_32x128_cts 2>&1)"
 rc=$?
 echo "--- MODE=notar (rc=$rc) ---"
 echo "$out"
@@ -99,7 +211,7 @@ check "wrapper should print the not-found diagnostic" \
 check "wrapper should name the _deps_tar target" \
     'grep -q "_deps_tar" <<<"$out"'
 
-# (c) Not an ORFS stage target: the build fails, with a helpful message.
+# (e) Not an ORFS stage target: the build fails, with a helpful message.
 export MODE=nobuild
 out="$("$WRAPPER" //pkg:not_a_stage 2>&1)"
 rc=$?


### PR DESCRIPTION
## `//:deps` is still broken after #971

#971 fixed the tarball *lookup*. The next step still failed, on every target:

```
$ bazel run //:deps -- //test:lb_32x128_cts
Error: make binary not found in .../tmp/test/lb_32x128_cts_deps
```

`MAKE_BIN="$(echo "$DST"/make_*)"` globbed the deploy root. The stage make script is not there — it keeps its runfiles path, `<repo-dir>/<package>/make_<target>_<variant>_<stage>`, and **the repo dir depends on which repository the design's package lives in**:

| design | after flattening, the script is at |
| --- | --- |
| `//test:lb_32x128_cts` | `_main/test/make_lb_32x128_cts_base_4_cts` |
| `@orfs//flow/designs/nangate45/gcd:gcd_cts` | `+orfs_repositories+orfs/flow/designs/nangate45/gcd/make_gcd_cts_base_4_cts` |

So a fixed root glob cannot work, and neither can a hardcoded `_main` — that would fix targets in this repo and leave every ORFS design broken.

## The fix

Search the deployed tree, keyed on the target name:

```sh
mapfile -t MAKE_CANDIDATES < <(find "$DST" -type f -name "make_${LABEL_NAME}_*" | sort)
```

Three details that are deliberate:

- **Keyed on the target name, not a bare `make_*`.** ORFS ships `flow/platforms/asap7/openRoad/make_tracks.tcl`, which matches `make_*`. A bare search finds two candidates in a real `lb_32x128` tree. `private/rules.bzl:2951` names the script `make_{name}_{variant}_{stage}`, so the target name is the correct filter.
- **`mapfile`, not a command substitution over a pipeline.** Under `set -euo pipefail` a failing pipeline aborts the script before any diagnostic can print — that is exactly what made the original bug silent in #971, and it must not be reintroduced one line further down.
- **More than one match refuses, listing them.** Silently picking one would be worse than failing.

The generated `./make` now execs the script at its real location relative to `_main`: `./<rest>` for a design in this repo, `./../<repo>/<rest>` for an external one. That reproduces Bazel `short_path` semantics, so this path and the `_deps` runnable (`deploy.tpl`) emit the identical string for the same design. `_main` remains canonical for the scaffolding: `config.mk` is written to `_main/config.mk` and the wrapper `cd`s there.

## Verified end to end

```
$ bash deps_wrapper.sh //test:lb_32x128_cts
Deployed to: .../tmp/test/lb_32x128_cts_deps

$ tail -1 .../tmp/test/lb_32x128_cts_deps/make
exec ./test/make_lb_32x128_cts_base_4_cts "$@"

$ .../tmp/test/lb_32x128_cts_deps/make do-4_1_cts
...
4_1_cts                   .odb            2            195 05dda11985322120172e
```

The stage runs and writes its ODB. `//:deps` works.

## Why #971's test did not catch this

Its stub payload put `make_mock` at the tar **root** — a layout no real tarball has, so the test passed against a fiction. That is the same failure mode the bug itself had: the piece was exercised in isolation, the real composition was not.

The payload now mirrors a real tarball: `*.short.mk` and `<name>_deps_run.sh` at the root, everything else under `<launcher>.runfiles/<repo-dir>/...` so the flattening step is exercised, and every payload carries the `make_tracks.tcl` decoy. Three layout cases — a design under `_main/<pkg>/`, one under `+orfs_repositories+orfs/<pkg>/`, and both at once (must refuse and list) — plus the unchanged tarball-not-found and build-failure cases. Each success case `bash -n`s the generated wrapper, checks the exec target exists, and *runs* it, so a wrong relative path fails instead of passing a string compare.

Against the unfixed script the new test fails with `make binary not found` and 6 failed assertions; with the fix it passes.

`//:fix_lint`, `//:host_tools`, `//:public_surface`, `//test:deps_wrapper_test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
